### PR TITLE
feat: revert required tool calling after n steps

### DIFF
--- a/src/Concerns/ConfiguresTools.php
+++ b/src/Concerns/ConfiguresTools.php
@@ -11,11 +11,15 @@ trait ConfiguresTools
 {
     protected string|ToolChoice|null $toolChoice = null;
 
-    public function withToolChoice(string|ToolChoice|Tool $toolChoice): self
+    protected ?int $toolChoiceAutoAfterSteps = null;
+
+    public function withToolChoice(string|ToolChoice|Tool $toolChoice, ?int $toolChoiceAutoAfterSteps = null): self
     {
         $this->toolChoice = $toolChoice instanceof Tool
             ? $toolChoice->name()
             : $toolChoice;
+
+        $this->toolChoiceAutoAfterSteps = $toolChoiceAutoAfterSteps;
 
         return $this;
     }

--- a/src/Providers/Anthropic/Concerns/HandlesHttpRequests.php
+++ b/src/Providers/Anthropic/Concerns/HandlesHttpRequests.php
@@ -15,13 +15,13 @@ trait HandlesHttpRequests
     /**
      * @return array<string, mixed>
      */
-    abstract public static function buildHttpRequestPayload(PrismRequest $request): array;
+    abstract public static function buildHttpRequestPayload(PrismRequest $request, int $currentStep = 0): array;
 
-    protected function sendRequest(): void
+    protected function sendRequest(int $currentStep = 0): void
     {
         $this->httpResponse = $this->client->post(
             'messages',
-            static::buildHttpRequestPayload($this->request)
+            static::buildHttpRequestPayload($this->request, $currentStep)
         );
 
         $this->handleResponseErrors();

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -81,7 +81,7 @@ class Structured
      * @return array<string, mixed>
      */
     #[\Override]
-    public static function buildHttpRequestPayload(PrismRequest $request): array
+    public static function buildHttpRequestPayload(PrismRequest $request, int $currentStep = 0): array
     {
         if (! $request->is(StructuredRequest::class)) {
             throw new InvalidArgumentException('Request must be an instance of '.StructuredRequest::class);

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -47,7 +47,7 @@ class Text
 
     public function handle(): Response
     {
-        $this->sendRequest();
+        $this->sendRequest($this->responseBuilder->steps->count());
 
         $this->prepareTempResponse();
 
@@ -73,7 +73,7 @@ class Text
      * @return array<string, mixed>
      */
     #[\Override]
-    public static function buildHttpRequestPayload(PrismRequest $request): array
+    public static function buildHttpRequestPayload(PrismRequest $request, int $currentStep = 0): array
     {
         if (! $request->is(TextRequest::class)) {
             throw new \InvalidArgumentException('Request must be an instance of '.TextRequest::class);
@@ -95,7 +95,7 @@ class Text
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
             'tools' => static::buildTools($request) ?: null,
-            'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+            'tool_choice' => ToolChoiceMap::map($request->toolChoice(), $currentStep, $request->toolChoiceAutoAfterSteps()),
         ]);
     }
 

--- a/src/Providers/Anthropic/Maps/ToolChoiceMap.php
+++ b/src/Providers/Anthropic/Maps/ToolChoiceMap.php
@@ -12,13 +12,19 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, ?int $autoAfterSteps = null): string|array|null
     {
         if (is_null($toolChoice)) {
             return null;
         }
 
         if (is_string($toolChoice)) {
+            if (! is_null($autoAfterSteps) && $currentStep >= $autoAfterSteps) {
+                return [
+                    'type' => 'auto',
+                ];
+            }
+
             return [
                 'type' => 'tool',
                 'name' => $toolChoice,
@@ -32,7 +38,7 @@ class ToolChoiceMap
         return [
             'type' => match ($toolChoice) {
                 ToolChoice::Auto => 'auto',
-                ToolChoice::Any => 'any',
+                ToolChoice::Any => ! is_null($autoAfterSteps) && $currentStep >= $autoAfterSteps ? 'auto' : 'any',
                 ToolChoice::None => 'none',
             },
         ];

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -112,7 +112,7 @@ class Text
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
                 'tools' => ToolMap::map($request->tools()) ?: null,
-                'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                'tool_choice' => ToolChoiceMap::map($request->toolChoice(), $this->responseBuilder->steps->count(), $request->toolChoiceAutoAfterSteps()),
             ]))
         );
 

--- a/src/Providers/DeepSeek/Maps/ToolChoiceMap.php
+++ b/src/Providers/DeepSeek/Maps/ToolChoiceMap.php
@@ -12,9 +12,13 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, ?int $autoAfterSteps = null): string|array|null
     {
         if (is_string($toolChoice)) {
+            if (! is_null($autoAfterSteps) && $currentStep >= $autoAfterSteps) {
+                return 'auto';
+            }
+
             return [
                 'type' => 'function',
                 'function' => [

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -113,7 +113,7 @@ class Text
                 'cachedContent' => $providerOptions['cachedContentName'] ?? null,
                 'generationConfig' => $generationConfig !== [] ? $generationConfig : null,
                 'tools' => $tools !== [] ? $tools : null,
-                'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
+                'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice(), $this->responseBuilder->steps->count(), $request->toolChoiceAutoAfterSteps()) : null,
                 'safetySettings' => $providerOptions['safetySettings'] ?? null,
             ])
         );

--- a/src/Providers/Gemini/Maps/ToolChoiceMap.php
+++ b/src/Providers/Gemini/Maps/ToolChoiceMap.php
@@ -11,9 +11,13 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, ?int $autoAfterSteps = null): string|array|null
     {
         if (is_string($toolChoice)) {
+            if (! is_null($autoAfterSteps) && $currentStep >= $autoAfterSteps) {
+                return ['function_calling_config' => ['mode' => 'AUTO']];
+            }
+
             return [
                 'function_calling_config' => [
                     'mode' => 'ANY',
@@ -23,7 +27,7 @@ class ToolChoiceMap
         }
 
         return match ($toolChoice) {
-            ToolChoice::Any => ['function_calling_config' => ['mode' => 'ANY']],
+            ToolChoice::Any => ['function_calling_config' => ['mode' => ! is_null($autoAfterSteps) && $currentStep >= $autoAfterSteps ? 'AUTO' : 'ANY']],
             ToolChoice::Auto => ['function_calling_config' => ['mode' => 'AUTO']],
             ToolChoice::None => ['function_calling_config' => ['mode' => 'NONE']],
             null => $toolChoice,

--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -75,7 +75,7 @@ class Text
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
                 'tools' => ToolMap::map($request->tools()),
-                'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                'tool_choice' => ToolChoiceMap::map($request->toolChoice(), $this->responseBuilder->steps->count(), $request->toolChoiceAutoAfterSteps()),
             ])
         );
     }

--- a/src/Providers/Groq/Maps/ToolChoiceMap.php
+++ b/src/Providers/Groq/Maps/ToolChoiceMap.php
@@ -12,9 +12,13 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, ?int $autoAfterSteps = null): string|array|null
     {
         if (is_string($toolChoice)) {
+            if (! is_null($autoAfterSteps) && $currentStep >= $autoAfterSteps) {
+                return 'auto';
+            }
+
             return [
                 'type' => 'function',
                 'function' => [

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -116,7 +116,7 @@ class Text
                 'top_p' => $request->topP(),
                 'metadata' => $request->providerOptions('metadata'),
                 'tools' => $this->buildTools($request),
-                'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                'tool_choice' => ToolChoiceMap::map($request->toolChoice(), $this->responseBuilder->steps->count(), $request->toolChoiceAutoAfterSteps()),
                 'previous_response_id' => $request->providerOptions('previous_response_id'),
                 'truncation' => $request->providerOptions('truncation'),
             ]))

--- a/src/Providers/OpenAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/OpenAI/Maps/ToolChoiceMap.php
@@ -11,9 +11,13 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, ?int $autoAfterSteps = null): string|array|null
     {
         if (is_string($toolChoice)) {
+            if (! is_null($autoAfterSteps) && $currentStep >= $autoAfterSteps) {
+                return 'auto';
+            }
+
             return [
                 'type' => 'function',
                 'name' => $toolChoice,
@@ -22,7 +26,7 @@ class ToolChoiceMap
 
         return match ($toolChoice) {
             ToolChoice::Auto => 'auto',
-            ToolChoice::Any => 'required',
+            ToolChoice::Any => ! is_null($autoAfterSteps) && $currentStep >= $autoAfterSteps ? 'auto' : 'required',
             ToolChoice::None => 'none',
             null => $toolChoice,
         };

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -117,7 +117,7 @@ class Text
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
             'tools' => ToolMap::map($request->tools()),
-            'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+            'tool_choice' => ToolChoiceMap::map($request->toolChoice(), $this->responseBuilder->steps->count(), $request->toolChoiceAutoAfterSteps()),
         ]));
 
         return $this->client->post('chat/completions', $payload);

--- a/src/Providers/XAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/XAI/Maps/ToolChoiceMap.php
@@ -12,13 +12,17 @@ class ToolChoiceMap
     /**
      * @return array<string, mixed>|string|null
      */
-    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    public static function map(string|ToolChoice|null $toolChoice, int $currentStep = 0, ?int $autoAfterSteps = null): string|array|null
     {
         if (is_null($toolChoice)) {
             return null;
         }
 
         if (is_string($toolChoice)) {
+            if (! is_null($autoAfterSteps) && $currentStep >= $autoAfterSteps) {
+                return 'auto';
+            }
+
             return [
                 'type' => 'function',
                 'function' => [
@@ -33,7 +37,7 @@ class ToolChoiceMap
 
         return match ($toolChoice) {
             ToolChoice::Auto => 'auto',
-            ToolChoice::Any => 'required',
+            ToolChoice::Any => ! is_null($autoAfterSteps) && $currentStep >= $autoAfterSteps ? 'auto' : 'required',
         };
     }
 }

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -95,6 +95,7 @@ class PendingRequest
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
             toolChoice: $this->toolChoice,
+            toolChoiceAutoAfterSteps: $this->toolChoiceAutoAfterSteps,
             providerOptions: $this->providerOptions,
             providerTools: $this->providerTools,
         );

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -41,8 +41,9 @@ class Request implements PrismRequest
         protected array $clientOptions,
         protected array $clientRetry,
         protected string|ToolChoice|null $toolChoice,
-        array $providerOptions = [],
-        protected array $providerTools = [],
+        array $providerOptions,
+        protected array $providerTools,
+        protected ?int $toolChoiceAutoAfterSteps,
     ) {
         $this->providerOptions = $providerOptions;
     }
@@ -50,6 +51,11 @@ class Request implements PrismRequest
     public function toolChoice(): string|ToolChoice|null
     {
         return $this->toolChoice;
+    }
+
+    public function toolChoiceAutoAfterSteps(): ?int
+    {
+        return $this->toolChoiceAutoAfterSteps;
     }
 
     /**


### PR DESCRIPTION
Opening this PR to replace [this one](https://github.com/echolabsdev/prism/pull/178).

This proposes adding a new option when calling `withToolChoice` to automatically revert the specific choice back to `auto`.

When combined with setting `maxSteps` this lets you require a model use a tool n times and then return a response.

The default value is `null` so should be a non-breaking change.

Can update docs on how and when to use this if accepted.