### PR TITLE
feat(openai): rate limit exception and meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ task/
 scratch
 phpunit.xml
 *.code-workspace
+.vscode
 ray.php

--- a/src/Providers/OpenAI/Concerns/ValidatesResponse.php
+++ b/src/Providers/OpenAI/Concerns/ValidatesResponse.php
@@ -12,7 +12,7 @@ use PrismPHP\Prism\Exceptions\PrismException;
 use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
 use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 
-trait ValidatesResponses
+trait ValidatesResponse
 {
     protected function validateResponse(Response $response): void
     {

--- a/src/Providers/OpenAI/Concerns/ValidatesResponse.php
+++ b/src/Providers/OpenAI/Concerns/ValidatesResponse.php
@@ -55,13 +55,21 @@ trait ValidatesResponse
         return array_values(Arr::map($rateLimits, function ($fields, $limitName): ProviderRateLimit {
             $resetsAt = data_get($fields, 'reset');
 
-            $resetMinutes = str_contains($resetsAt, 'm')
-                ? Str::of($resetsAt)->before('m')->toString()
-                : 0;
+            if (str_contains($resetsAt, 'ms')) {
+                $resetMilliseconds = Str::of($resetsAt)->before('ms')->toString();
+                $resetMinutes = 0;
+                $resetSeconds = 0;
+            } else {
+                $resetMilliseconds = 0;
 
-            $resetSeconds = str_contains($resetsAt, 'm')
-                ? Str::of($resetsAt)->after('m')->before('s')->toString()
-                : Str::of($resetsAt)->before('s')->toString();
+                $resetMinutes = str_contains($resetsAt, 'm')
+                    ? Str::of($resetsAt)->before('m')->toString()
+                    : 0;
+
+                $resetSeconds = str_contains($resetsAt, 'm')
+                    ? Str::of($resetsAt)->after('m')->before('s')->toString()
+                    : Str::of($resetsAt)->before('s')->toString();
+            }
 
             return new ProviderRateLimit(
                 name: $limitName,
@@ -72,7 +80,7 @@ trait ValidatesResponse
                     ? (int) data_get($fields, 'remaining')
                     : null,
                 resetsAt: data_get($fields, 'reset') !== null
-                    ? Carbon::now()->addMinutes((int) $resetMinutes)->addSeconds((int) $resetSeconds)
+                    ? Carbon::now()->addMinutes((int) $resetMinutes)->addSeconds((int) $resetSeconds)->addMilliseconds((int) $resetMilliseconds)
                     : null
             );
         }));

--- a/src/Providers/OpenAI/Concerns/ValidatesResponses.php
+++ b/src/Providers/OpenAI/Concerns/ValidatesResponses.php
@@ -4,15 +4,27 @@ declare(strict_types=1);
 
 namespace PrismPHP\Prism\Providers\OpenAI\Concerns;
 
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 
 trait ValidatesResponses
 {
-    /**
-     * @param  array<string, mixed>  $data
-     */
-    protected function validateResponse(array $data): void
+    protected function validateResponse(Response $response): void
     {
+        if ($response->getStatusCode() === 429) {
+            throw PrismRateLimitedException::make(
+                rateLimits: $this->processRateLimits($response),
+                retryAfter: null
+            );
+        }
+
+        $data = $response->json();
+
         if (! $data || data_get($data, 'error')) {
             throw PrismException::providerResponseError(vsprintf(
                 'OpenAI Error:  [%s] %s',
@@ -22,5 +34,47 @@ trait ValidatesResponses
                 ]
             ));
         }
+    }
+
+    /**
+     * @return ProviderRateLimit[]
+     */
+    protected function processRateLimits(Response $response): array
+    {
+        $limitHeaders = array_filter($response->getHeaders(), fn ($headerName) => Str::startsWith($headerName, 'x-ratelimit-'), ARRAY_FILTER_USE_KEY);
+
+        $rateLimits = [];
+
+        foreach ($limitHeaders as $headerName => $headerValues) {
+            $limitName = Str::of($headerName)->afterLast('-')->toString();
+            $fieldName = Str::of($headerName)->after('x-ratelimit-')->beforeLast('-')->toString();
+
+            $rateLimits[$limitName][$fieldName] = $headerValues[0];
+        }
+
+        return array_values(Arr::map($rateLimits, function ($fields, $limitName): ProviderRateLimit {
+            $resetsAt = data_get($fields, 'reset');
+
+            $resetMinutes = str_contains($resetsAt, 'm')
+                ? Str::of($resetsAt)->before('m')->toString()
+                : 0;
+
+            $resetSeconds = str_contains($resetsAt, 'm')
+                ? Str::of($resetsAt)->after('m')->before('s')->toString()
+                : Str::of($resetsAt)->before('s')->toString();
+
+            return new ProviderRateLimit(
+                name: $limitName,
+                limit: data_get($fields, 'limit') !== null
+                    ? (int) data_get($fields, 'limit')
+                    : null,
+                remaining: data_get($fields, 'remaining') !== null
+                    ? (int) data_get($fields, 'remaining')
+                    : null,
+                resetsAt: data_get($fields, 'reset') !== null
+                    ? Carbon::now()->addMinutes((int) $resetMinutes)->addSeconds((int) $resetSeconds)
+                    : null
+            );
+        }));
     }
 }

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -8,7 +8,7 @@ use PrismPHP\Prism\Enums\Provider;
 use PrismPHP\Prism\Enums\StructuredMode;
 use PrismPHP\Prism\Exceptions\PrismException;
 use PrismPHP\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponses;
+use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponse;
 use PrismPHP\Prism\Providers\OpenAI\Maps\MessageMap;
 use PrismPHP\Prism\Providers\OpenAI\Support\StructuredModeResolver;
 use PrismPHP\Prism\Structured\Request;
@@ -24,7 +24,7 @@ use Throwable;
 class Structured
 {
     use MapsFinishReason;
-    use ValidatesResponses;
+    use ValidatesResponse;
 
     protected ResponseBuilder $responseBuilder;
 

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -3,6 +3,7 @@
 namespace PrismPHP\Prism\Providers\OpenAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response as ClientResponse;
 use PrismPHP\Prism\Enums\Provider;
 use PrismPHP\Prism\Enums\StructuredMode;
 use PrismPHP\Prism\Exceptions\PrismException;
@@ -34,14 +35,17 @@ class Structured
 
     public function handle(Request $request): StructuredResponse
     {
-        $data = match ($request->mode()) {
+        $response = match ($request->mode()) {
             StructuredMode::Auto => $this->handleAutoMode($request),
             StructuredMode::Structured => $this->handleStructuredMode($request),
             StructuredMode::Json => $this->handleJsonMode($request),
 
         };
 
-        $this->validateResponse($data);
+        $this->validateResponse($response);
+
+        $data = $response->json();
+
         $this->handleRefusal(data_get($data, 'choices.0.message', []));
 
         $responseMessage = new AssistantMessage(
@@ -52,7 +56,7 @@ class Structured
 
         $request->addMessage($responseMessage);
 
-        $this->addStep($data, $request);
+        $this->addStep($data, $request, $response);
 
         return $this->responseBuilder->toResponse();
     }
@@ -60,7 +64,7 @@ class Structured
     /**
      * @param  array<string, mixed>  $data
      */
-    protected function addStep(array $data, Request $request): void
+    protected function addStep(array $data, Request $request, ClientResponse $clientResponse): void
     {
         $this->responseBuilder->addStep(new Step(
             text: data_get($data, 'choices.0.message.content') ?? '',
@@ -72,6 +76,7 @@ class Structured
             meta: new Meta(
                 id: data_get($data, 'id'),
                 model: data_get($data, 'model'),
+                rateLimits: $this->processRateLimits($clientResponse)
             ),
             messages: $request->messages(),
             additionalContent: [],
@@ -81,12 +86,11 @@ class Structured
 
     /**
      * @param  array{type: 'json_schema', json_schema: array<string, mixed>}|array{type: 'json_object'}  $responseFormat
-     * @return array<string, mixed>
      */
-    protected function sendRequest(Request $request, array $responseFormat): array
+    protected function sendRequest(Request $request, array $responseFormat): ClientResponse
     {
         try {
-            $response = $this->client->post(
+            return $this->client->post(
                 'chat/completions',
                 array_merge([
                     'model' => $request->model(),
@@ -98,17 +102,12 @@ class Structured
                     'response_format' => $responseFormat,
                 ]))
             );
-
-            return $response->json();
         } catch (Throwable $e) {
             throw PrismException::providerRequestError($request->model(), $e);
         }
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function handleAutoMode(Request $request): array
+    protected function handleAutoMode(Request $request): ClientResponse
     {
         $mode = StructuredModeResolver::forModel($request->model());
 
@@ -119,10 +118,7 @@ class Structured
         };
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function handleStructuredMode(Request $request): array
+    protected function handleStructuredMode(Request $request): ClientResponse
     {
         $mode = StructuredModeResolver::forModel($request->model());
 
@@ -140,10 +136,7 @@ class Structured
         ]);
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function handleJsonMode(Request $request): array
+    protected function handleJsonMode(Request $request): ClientResponse
     {
         $request = $this->appendMessageForJsonMode($request);
 

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PrismPHP\Prism\Providers\OpenAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response as ClientResponse;
 use PrismPHP\Prism\Concerns\CallsTools;
 use PrismPHP\Prism\Enums\FinishReason;
 use PrismPHP\Prism\Exceptions\PrismException;
@@ -40,9 +41,11 @@ class Text
 
     public function handle(Request $request): Response
     {
-        $data = $this->sendRequest($request);
+        $response = $this->sendRequest($request);
 
-        $this->validateResponse($data);
+        $this->validateResponse($response);
+
+        $data = $response->json();
 
         $responseMessage = new AssistantMessage(
             data_get($data, 'message.content') ?? '',
@@ -54,8 +57,8 @@ class Text
         $request->addMessage($responseMessage);
 
         return match ($this->mapFinishReason($data)) {
-            FinishReason::ToolCalls => $this->handleToolCalls($data, $request),
-            FinishReason::Stop => $this->handleStop($data, $request),
+            FinishReason::ToolCalls => $this->handleToolCalls($data, $request, $response),
+            FinishReason::Stop => $this->handleStop($data, $request, $response),
             default => throw new PrismException('OpenAI: unknown finish reason'),
         };
     }
@@ -63,7 +66,7 @@ class Text
     /**
      * @param  array<string, mixed>  $data
      */
-    protected function handleToolCalls(array $data, Request $request): Response
+    protected function handleToolCalls(array $data, Request $request, ClientResponse $clientResponse): Response
     {
         $toolResults = $this->callTools(
             $request->tools(),
@@ -72,7 +75,7 @@ class Text
 
         $request->addMessage(new ToolResultMessage($toolResults));
 
-        $this->addStep($data, $request, $toolResults);
+        $this->addStep($data, $request, $clientResponse, $toolResults);
 
         if ($this->shouldContinue($request)) {
             return $this->handle($request);
@@ -84,9 +87,9 @@ class Text
     /**
      * @param  array<string, mixed>  $data
      */
-    protected function handleStop(array $data, Request $request): Response
+    protected function handleStop(array $data, Request $request, ClientResponse $clientResponse): Response
     {
-        $this->addStep($data, $request);
+        $this->addStep($data, $request, $clientResponse);
 
         return $this->responseBuilder->toResponse();
     }
@@ -96,13 +99,10 @@ class Text
         return $this->responseBuilder->steps->count() < $request->maxSteps();
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    protected function sendRequest(Request $request): array
+    protected function sendRequest(Request $request): ClientResponse
     {
         try {
-            $response = $this->client->post(
+            return $this->client->post(
                 'chat/completions',
                 array_merge([
                     'model' => $request->model(),
@@ -115,8 +115,6 @@ class Text
                     'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
                 ]))
             );
-
-            return $response->json();
         } catch (Throwable $e) {
             throw PrismException::providerRequestError($request->model(), $e);
         }
@@ -126,7 +124,7 @@ class Text
      * @param  array<string, mixed>  $data
      * @param  ToolResult[]  $toolResults
      */
-    protected function addStep(array $data, Request $request, array $toolResults = []): void
+    protected function addStep(array $data, Request $request, ClientResponse $clientResponse, array $toolResults = []): void
     {
         $this->responseBuilder->addStep(new Step(
             text: data_get($data, 'choices.0.message.content') ?? '',
@@ -140,6 +138,7 @@ class Text
             meta: new Meta(
                 id: data_get($data, 'id'),
                 model: data_get($data, 'model'),
+                rateLimits: $this->processRateLimits($clientResponse)
             ),
             messages: $request->messages(),
             additionalContent: [],

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -10,7 +10,7 @@ use PrismPHP\Prism\Concerns\CallsTools;
 use PrismPHP\Prism\Enums\FinishReason;
 use PrismPHP\Prism\Exceptions\PrismException;
 use PrismPHP\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponses;
+use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponse;
 use PrismPHP\Prism\Providers\OpenAI\Maps\MessageMap;
 use PrismPHP\Prism\Providers\OpenAI\Maps\ToolCallMap;
 use PrismPHP\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
@@ -30,7 +30,7 @@ class Text
 {
     use CallsTools;
     use MapsFinishReason;
-    use ValidatesResponses;
+    use ValidatesResponse;
 
     protected ResponseBuilder $responseBuilder;
 

--- a/tests/Providers/OpenAI/OpenAIExceptionsTest.php
+++ b/tests/Providers/OpenAI/OpenAIExceptionsTest.php
@@ -9,14 +9,14 @@ use Illuminate\Support\Facades\Http;
 use PrismPHP\Prism\Enums\Provider;
 use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
 use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponses;
+use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponse;
 use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 
 arch()->expect([
     'Providers\OpenAI\Handlers\Text',
     'Providers\OpenAI\Handlers\Structured',
 ])
-    ->toUseTrait(ValidatesResponses::class);
+    ->toUseTrait(ValidatesResponse::class);
 
 it('throws a PrismRateLimitedException with a 429 response code', function (): void {
     Http::fake([

--- a/tests/Providers/OpenAI/OpenAIExceptionsTest.php
+++ b/tests/Providers/OpenAI/OpenAIExceptionsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\OpenAI;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponses;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+
+arch()->expect([
+    'Providers\OpenAI\Handlers\Text',
+    'Providers\OpenAI\Handlers\Structured',
+])
+    ->toUseTrait(ValidatesResponses::class);
+
+it('throws a PrismRateLimitedException with a 429 response code', function (): void {
+    Http::fake([
+        '*' => Http::response(
+            status: 429,
+        ),
+    ])->preventStrayRequests();
+
+    Prism::text()
+        ->using(Provider::OpenAI, 'fake-model')
+        ->withPrompt('Hello world!')
+        ->generate();
+
+})->throws(PrismRateLimitedException::class);
+
+it('sets the correct data on the PrismRateLimitedException', function (): void {
+    $this->freezeTime(function (Carbon $time): void {
+        $time = $time->toImmutable();
+        Http::fake([
+            '*' => Http::response(
+                status: 429,
+                headers: [
+                    'x-ratelimit-limit-requests' => 60,
+                    'x-ratelimit-limit-tokens' => 150000,
+                    'x-ratelimit-remaining-requests' => 0,
+                    'x-ratelimit-remaining-tokens' => 149984,
+                    'x-ratelimit-reset-requests' => '1s',
+                    'x-ratelimit-reset-tokens' => '6m30s',
+                ]
+            ),
+        ])->preventStrayRequests();
+
+        try {
+            Prism::text()
+                ->using(Provider::OpenAI, 'fake-model')
+                ->withPrompt('Hello world!')
+                ->generate();
+        } catch (PrismRateLimitedException $e) {
+            expect($e->retryAfter)->toEqual(null);
+            expect($e->rateLimits)->toHaveCount(2);
+            expect($e->rateLimits[0])->toBeInstanceOf(ProviderRateLimit::class);
+            expect($e->rateLimits[0]->name)->toEqual('requests');
+            expect($e->rateLimits[0]->limit)->toEqual(60);
+            expect($e->rateLimits[0]->remaining)->toEqual(0);
+            expect($e->rateLimits[0]->resetsAt->equalTo($time->addSeconds(1)))->toBeTrue();
+
+            expect($e->rateLimits[1]->name)->toEqual('tokens');
+            expect($e->rateLimits[1]->limit)->toEqual(150000);
+            expect($e->rateLimits[1]->remaining)->toEqual(149984);
+            expect($e->rateLimits[1]->resetsAt->equalTo($time->addMinutes(6)->addSeconds(30)))->toBeTrue();
+        }
+    });
+});

--- a/tests/Providers/OpenAI/StructuredTest.php
+++ b/tests/Providers/OpenAI/StructuredTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Providers\OpenAI;
 
 use Illuminate\Http\Client\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use PrismPHP\Prism\Enums\Provider;
 use PrismPHP\Prism\Exceptions\PrismException;
@@ -207,3 +208,45 @@ it('throws an exception for o1 models', function (string $model): void {
     'o1-preview',
     'o1-preview-2024-09-12',
 ]);
+
+it('sets the rate limits on meta', function (): void {
+    $this->freezeTime(function (Carbon $time): void {
+        $time = $time->toImmutable();
+
+        FixtureResponse::fakeResponseSequence('v1/chat/completions', 'openai/structured-structured-mode', [
+            'x-ratelimit-limit-requests' => 60,
+            'x-ratelimit-limit-tokens' => 150000,
+            'x-ratelimit-remaining-requests' => 0,
+            'x-ratelimit-remaining-tokens' => 149984,
+            'x-ratelimit-reset-requests' => '1s',
+            'x-ratelimit-reset-tokens' => '6m30s',
+        ]);
+
+        $schema = new ObjectSchema(
+            'output',
+            'the output object',
+            [
+                new StringSchema('weather', 'The weather forecast'),
+                new StringSchema('game_time', 'The tigers game time'),
+                new BooleanSchema('coat_required', 'whether a coat is required'),
+            ],
+            ['weather', 'game_time', 'coat_required']
+        );
+
+        $response = Prism::structured()
+            ->withSchema($schema)
+            ->using(Provider::OpenAI, 'gpt-4o')
+            ->withPrompt('What time is the tigers game today and should I wear a coat?')
+            ->generate();
+
+        expect($response->meta->rateLimits)->toHaveCount(2);
+        expect($response->meta->rateLimits[0]->name)->toEqual('requests');
+        expect($response->meta->rateLimits[0]->limit)->toEqual(60);
+        expect($response->meta->rateLimits[0]->remaining)->toEqual(0);
+        expect($response->meta->rateLimits[0]->resetsAt->equalTo(now()->addSeconds(1)))->toBeTrue();
+        expect($response->meta->rateLimits[1]->name)->toEqual('tokens');
+        expect($response->meta->rateLimits[1]->limit)->toEqual(150000);
+        expect($response->meta->rateLimits[1]->remaining)->toEqual(149984);
+        expect($response->meta->rateLimits[1]->resetsAt->equalTo(now()->addMinutes(6)->addSeconds(30)))->toBeTrue();
+    });
+});


### PR DESCRIPTION
## Description

Implements the rate limit exception and meta for OpenAI text and structured (cc #221).

Will look into streaming and embeddings separately.

Note: I have not updated the docs page as I am doing a couple of these today and don't want to cause a conflict. Will circle back after PRs are merged to update. 