### PR TITLE
feat(gemini): rate limit exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 /vendor/
 composer.lock
 /build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode
 /vendor/
 composer.lock
 /build/

--- a/src/Providers/Gemini/Concerns/ValidatesResponse.php
+++ b/src/Providers/Gemini/Concerns/ValidatesResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PrismPHP\Prism\Providers\Gemini\Concerns;
+
+use Illuminate\Http\Client\Response;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+
+trait ValidatesResponse
+{
+    protected function validateResponse(Response $response): void
+    {
+        if ($response->getStatusCode() === 429) {
+            throw new PrismRateLimitedException([]);
+        }
+
+        $data = $response->json();
+
+        if (! $data || data_get($data, 'error')) {
+            throw PrismException::providerResponseError(vsprintf(
+                'Gemini Error: [%s] %s',
+                [
+                    data_get($data, 'error.code', 'unknown'),
+                    data_get($data, 'error.message', 'unknown'),
+                ]
+            ));
+        }
+    }
+}

--- a/src/Providers/Gemini/Handlers/Embeddings.php
+++ b/src/Providers/Gemini/Handlers/Embeddings.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace PrismPHP\Prism\Providers\Gemini\Handlers;
 
-use Throwable;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use PrismPHP\Prism\Embeddings\Request;
-use Illuminate\Http\Client\PendingRequest;
-use PrismPHP\Prism\ValueObjects\Embedding;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
 use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use PrismPHP\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
+use Throwable;
 
 class Embeddings
 {

--- a/src/Providers/Gemini/Handlers/Embeddings.php
+++ b/src/Providers/Gemini/Handlers/Embeddings.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace PrismPHP\Prism\Providers\Gemini\Handlers;
 
-use Illuminate\Http\Client\PendingRequest;
+use Throwable;
 use Illuminate\Http\Client\Response;
 use PrismPHP\Prism\Embeddings\Request;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
+use Illuminate\Http\Client\PendingRequest;
 use PrismPHP\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\Exceptions\PrismException;
 use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use Throwable;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
 
 class Embeddings
 {
@@ -27,6 +28,10 @@ class Embeddings
             $response = $this->sendRequest($request);
         } catch (Throwable $e) {
             throw PrismException::providerRequestError($request->model(), $e);
+        }
+
+        if ($response->getStatusCode() === 429) {
+            throw new PrismRateLimitedException([]);
         }
 
         $data = $response->json();

--- a/tests/Providers/Gemini/GeminiExceptionsTest.php
+++ b/tests/Providers/Gemini/GeminiExceptionsTest.php
@@ -16,7 +16,7 @@ arch()->expect([
 ])
     ->toUseTrait(ValidatesResponse::class);
 
-it('throws a PrismRateLimitedException with a 429 response code', function (): void {
+it('throws a PrismRateLimitedException with a 429 response code for text and structured', function (): void {
     Http::fake([
         '*' => Http::response(
             status: 429,
@@ -26,6 +26,20 @@ it('throws a PrismRateLimitedException with a 429 response code', function (): v
     Prism::text()
         ->using(Provider::Gemini, 'fake-model')
         ->withPrompt('Hello world!')
+        ->generate();
+
+})->throws(PrismRateLimitedException::class);
+
+it('throws a PrismRateLimitedException with a 429 response code for emebddings', function (): void {
+    Http::fake([
+        '*' => Http::response(
+            status: 429,
+        ),
+    ])->preventStrayRequests();
+
+    Prism::embeddings()
+        ->using(Provider::Gemini, 'fake-model')
+        ->fromInput('Hello world!')
         ->generate();
 
 })->throws(PrismRateLimitedException::class);

--- a/tests/Providers/Gemini/GeminiExceptionsTest.php
+++ b/tests/Providers/Gemini/GeminiExceptionsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\Gemini;
+
+use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Providers\Gemini\Concerns\ValidatesResponse;
+
+arch()->expect([
+    'Providers\Gemini\Handlers\Text',
+    'Providers\Gemini\Handlers\Structured',
+])
+    ->toUseTrait(ValidatesResponse::class);
+
+it('throws a PrismRateLimitedException with a 429 response code', function (): void {
+    Http::fake([
+        '*' => Http::response(
+            status: 429,
+        ),
+    ])->preventStrayRequests();
+
+    Prism::text()
+        ->using(Provider::Gemini, 'fake-model')
+        ->withPrompt('Hello world!')
+        ->generate();
+
+})->throws(PrismRateLimitedException::class);


### PR DESCRIPTION
## Description

Implements the rate limit exception for Gemini.

Note, Gemini does not seem to return rate limit headers on responses, so its not possible to implement meta.

They also don't document if/how they communicate which rate limits you have hit... So the rate limit exception is bare for now (no rate limit details).

Note: I have not updated the docs page as I am doing a couple of these today and don't want to cause a conflict. Will circle back after PRs are merged to update. Will note the limitations above in the docs when I do.

Note: will conflict with #219. I will rebase and rectify whichever gets merged second.