### PR TITLE
Reorg

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
             carbon: ^2.63
           - laravel: 12.*
             testbench: 10.*
-            carbon: ^2.63
+            carbon: ^3.8.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.3, 8.4]
-        laravel: [11.*]
+        laravel: [11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
+            carbon: ^2.63
+          - laravel: 12.*
+            testbench: 10.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 ![](assets/prism-banner.webp)
 
 <p align="center">
-    <a href="https://packagist.org/packages/echolabsdev/prism">
-        <img src="https://poser.pugx.org/echolabsdev/prism/d/total.svg" alt="Total Downloads">
+    <a href="https://packagist.org/packages/prism-php/prism">
+        <img src="https://poser.pugx.org/prism-php/prism/d/total.svg" alt="Total Downloads">
     </a>
-    <a href="https://packagist.org/packages/echolabsdev/prism">
-        <img src="https://poser.pugx.org/echolabsdev/prism/v/stable.svg" alt="Latest Stable Version">
+    <a href="https://packagist.org/packages/prism-php/prism">
+        <img src="https://poser.pugx.org/prism-php/prism/v/stable.svg" alt="Latest Stable Version">
     </a>
-    <a href="https://packagist.org/packages/echolabsdev/prism">
-        <img src="https://poser.pugx.org/echolabsdev/prism/license.svg" alt="License">
+    <a href="https://packagist.org/packages/prism-php/prism">
+        <img src="https://poser.pugx.org/prism-php/prism/license.svg" alt="License">
     </a>
 </p>
 
@@ -18,7 +18,7 @@ Prism is a powerful Laravel package for integrating Large Language Models (LLMs)
 
 ## Official Documentation
 
-Official documentation can be found on the [Prism website](https://prism.echolabs.dev).
+Official documentation can be found on the [Prism website](https://prismphp.com).
 
 ## Code of Conduct
 
@@ -26,7 +26,7 @@ While we aren't affiliated with Laravel, we follow the Laravel [Code of Conduct]
 
 ## Authors
 
-This library is created by [TJ Miller](https://tjmiller.me) with contributions from the [Open Source Community](https://github.com/echolabsdev/prism/graphs/contributors).
+This library is created by [TJ Miller](https://tjmiller.me) with contributions from the [Open Source Community](https://github.com/prismphp/prism/graphs/contributors).
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-  "name": "echolabsdev/prism",
+  "name": "prism-php/prism",
   "description": "A powerful Laravel package for integrating Large Language Models (LLMs) into your applications.",
   "type": "library",
   "license": "MIT",
   "autoload": {
     "psr-4": {
-      "EchoLabs\\Prism\\": "src/"
+      "PrismPHP\\Prism\\": "src/"
     }
   },
   "authors": [
@@ -86,10 +86,10 @@
   "extra": {
     "laravel": {
       "providers": [
-        "EchoLabs\\Prism\\PrismServiceProvider"
+        "PrismPHP\\Prism\\PrismServiceProvider"
       ],
       "aliases": {
-        "PrismServer": "EchoLabs\\Prism\\Facades\\PrismServer"
+        "PrismServer": "PrismPHP\\Prism\\Facades\\PrismServer"
       }
     }
   }

--- a/docs/advanced/custom-providers.md
+++ b/docs/advanced/custom-providers.md
@@ -4,15 +4,15 @@ Want to add support for a new AI provider in Prism? This guide will walk you thr
 
 ## Provider Interface
 
-All providers must implement the `EchoLabs\Prism\Contracts\Provider` interface:
+All providers must implement the `PrismPHP\Prism\Contracts\Provider` interface:
 
 ```php
-use EchoLabs\Prism\Embeddings\Request as EmbeddingsRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 interface Provider
 {
@@ -65,7 +65,7 @@ return [
 Now you can use your custom provider:
 
 ```php
-use EchoLabs\Prism\Facades\Prism;
+use PrismPHP\Prism\Facades\Prism;
 
 $response = Prism::text()
     ->using('my-custom-provider', 'model-name')

--- a/docs/advanced/rate-limits.md
+++ b/docs/advanced/rate-limits.md
@@ -31,10 +31,10 @@ Prism throws a `PrismRateLimitedException` when you hit a rate limit.
 You can catch that exception, gracefully fail and inspect the `rateLimits` property which contains an array of `ProviderRateLimit`s. 
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Enums\Provider;
-use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
-use EchoLabs\Prism\Exceptions\PrismRateLimitedException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Enums\Provider;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
 
 try {
     Prism::text()
@@ -61,7 +61,7 @@ However most providers implement various rate limits (e.g. request, input tokens
 For simple rate limits like "requests", the `remaining` property on `ProviderRateLimit` will be 0 if you have hit it. These are easy to find:
 
 ```php 
-use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 use Illuminate\Support\Arr;
 
 try {
@@ -77,7 +77,7 @@ For less simple rate limits like input tokens, the `remaining` property may not 
 Here, you may need to implement some logic to approximate how many tokens your request will use before sending it, and then test against that:
 
 ```php 
-use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 use Illuminate\Support\Arr;
 
 try {
@@ -105,9 +105,9 @@ If you aren't sure where to start with that, check out the [What should you do w
 Prism adds the same rate limit information to every successful request:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Enums\Provider;
-use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Enums\Provider;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')

--- a/docs/core-concepts/embeddings.md
+++ b/docs/core-concepts/embeddings.md
@@ -7,8 +7,8 @@ Transform your text into powerful vector representations! Embeddings let you add
 Here's how to generate an embedding with just a few lines of code:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::embeddings()
     ->using(Provider::OpenAI, 'text-embedding-3-large')
@@ -27,8 +27,8 @@ echo $response->usage->tokens;
 You can generate multiple embeddings at once with all providers that support embeddings, other than Gemini:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::embeddings()
     ->using(Provider::OpenAI, 'text-embedding-3-large')
@@ -60,8 +60,8 @@ You've got two convenient ways to feed text into the embeddings generator:
 ### Direct Text Input
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::embeddings()
     ->using(Provider::OpenAI, 'text-embedding-3-large')
@@ -74,8 +74,8 @@ $response = Prism::embeddings()
 Need to analyze a larger document? No problem:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::embeddings()
     ->using(Provider::OpenAI, 'text-embedding-3-large')
@@ -91,8 +91,8 @@ $response = Prism::embeddings()
 Just like with text generation, you can fine-tune your embeddings requests:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::embeddings()
     ->using(Provider::OpenAI, 'text-embedding-3-large')
@@ -107,7 +107,7 @@ $response = Prism::embeddings()
 The embeddings response gives you everything you need:
 
 ```php
-namespace EchoLabs\Prism\ValueObjects\Embedding;
+namespace PrismPHP\Prism\ValueObjects\Embedding;
 
 // Get an array of Embedding value objects
 $embeddings = $response->embeddings;
@@ -130,9 +130,9 @@ $tokenCount = $response->usage->tokens;
 Always handle potential errors gracefully:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
 
 try {
     $response = Prism::embeddings()

--- a/docs/core-concepts/prism-server.md
+++ b/docs/core-concepts/prism-server.md
@@ -25,9 +25,9 @@ First, make sure Prism Server is enabled in your `config/prism.php` file:
 To make your Prism models available through the server, you need to register them. This is typically done in a service provider, such as `AppServiceProvider`:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Facades\PrismServer;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Facades\PrismServer;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider

--- a/docs/core-concepts/schemas.md
+++ b/docs/core-concepts/schemas.md
@@ -7,9 +7,9 @@ Schemas are the blueprints that help you define the shape of your data in Prism.
 Let's dive right in with a practical example:
 
 ```php
-use EchoLabs\Prism\Schema\ArraySchema;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Schema\ArraySchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
 
 $userSchema = new ObjectSchema(
     name: 'user',
@@ -41,7 +41,7 @@ $userSchema = new ObjectSchema(
 For text values of any length. Perfect for names, descriptions, or any textual data.
 
 ```php
-use EchoLabs\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Schema\StringSchema;
 
 $nameSchema = new StringSchema(
     name: 'full_name',
@@ -54,7 +54,7 @@ $nameSchema = new StringSchema(
 Handles both integers and floating-point numbers. Great for ages, quantities, or measurements.
 
 ```php
-use EchoLabs\Prism\Schema\NumberSchema;
+use PrismPHP\Prism\Schema\NumberSchema;
 
 $ageSchema = new NumberSchema(
     name: 'age',
@@ -67,7 +67,7 @@ $ageSchema = new NumberSchema(
 For simple true/false values. Perfect for flags and toggles.
 
 ```php
-use EchoLabs\Prism\Schema\BooleanSchema;
+use PrismPHP\Prism\Schema\BooleanSchema;
 
 $activeSchema = new BooleanSchema(
     name: 'is_active',
@@ -80,8 +80,8 @@ $activeSchema = new BooleanSchema(
 For lists of items, where each item follows a specific schema.
 
 ```php
-use EchoLabs\Prism\Schema\ArraySchema;
-use EchoLabs\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Schema\ArraySchema;
+use PrismPHP\Prism\Schema\StringSchema;
 
 $tagsSchema = new ArraySchema(
     name: 'tags',
@@ -95,7 +95,7 @@ $tagsSchema = new ArraySchema(
 When you need to restrict values to a specific set of options.
 
 ```php
-use EchoLabs\Prism\Schema\EnumSchema;
+use PrismPHP\Prism\Schema\EnumSchema;
 
 $statusSchema = new EnumSchema(
     name: 'status',
@@ -109,9 +109,9 @@ $statusSchema = new EnumSchema(
 For complex, nested data structures. The Swiss Army knife of schemas!
 
 ```php
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
-use EchoLabs\Prism\Schema\NumberSchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Schema\NumberSchema;
 
 $profileSchema = new ObjectSchema(
     name: 'profile',
@@ -130,7 +130,7 @@ $profileSchema = new ObjectSchema(
 Sometimes, not every field is required. You can make any schema nullable by setting the `nullable` parameter to `true`:
 
 ```php
-use EchoLabs\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Schema\StringSchema;
 
 $bioSchema = new StringSchema(
     name: 'bio',

--- a/docs/core-concepts/streaming-output.md
+++ b/docs/core-concepts/streaming-output.md
@@ -7,7 +7,7 @@ Want to show AI responses to your users in real-time? Streaming lets you display
 At its simplest, streaming works like this:
 
 ```php
-use EchoLabs\Prism\Prism;
+use PrismPHP\Prism\Prism;
 
 $response = Prism::stream()
     ->using('openai', 'gpt-4')
@@ -44,8 +44,8 @@ foreach ($response as $chunk) {
 Streaming works seamlessly with tools, allowing real-time interaction:
 
 ```php
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Prism;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Prism;
 
 $weatherTool = Tool::as('weather')
     ->for('Get current weather information')
@@ -95,7 +95,7 @@ Here's how to integrate streaming in a Laravel controller:
 Alternatively, you might consider using Laravel's [Broadcasting feature](https://laravel.com/docs/12.x/broadcasting) to send the chunks to your frontend.
 
 ```php
-use EchoLabs\Prism\Prism;
+use PrismPHP\Prism\Prism;
 use Illuminate\Http\Response;
 
 public function streamResponse()

--- a/docs/core-concepts/structured-output.md
+++ b/docs/core-concepts/structured-output.md
@@ -7,10 +7,10 @@ Want your AI responses as neat and tidy as a Marie Kondo-approved closet? Struct
 Here's how to get structured data from your AI:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
 
 $schema = new ObjectSchema(
     name: 'movie_review',
@@ -54,8 +54,8 @@ Different AI providers handle structured output in two main ways:
 Providers may offer additional options for structured output. For example, OpenAI supports a "strict mode" for even tighter schema validation:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::structured()
     ->withProviderMeta(Provider::OpenAI, [
@@ -74,7 +74,7 @@ $response = Prism::structured()
 When working with structured responses, you have access to both the structured data and metadata about the generation:
 
 ```php
-use EchoLabs\Prism\Prism;
+use PrismPHP\Prism\Prism;
 
 $response = Prism::structured()
     ->withSchema($schema)
@@ -139,9 +139,9 @@ See the [Text Generation](./text-generation.md) documentation for comparison wit
 When working with structured output, it's especially important to handle potential errors:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
 
 try {
     $response = Prism::structured()

--- a/docs/core-concepts/testing.md
+++ b/docs/core-concepts/testing.md
@@ -7,12 +7,12 @@ Want to make sure your Prism integrations work flawlessly? Let's dive into testi
 First, let's look at how to set up basic response faking:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\ValueObjects\Usage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\ValueObjects\Usage;
+use PrismPHP\Prism\ValueObjects\ResponseMeta;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 it('can generate text', function () {
     // Create a fake text response
@@ -48,10 +48,10 @@ it('can generate text', function () {
 When testing conversations or tool usage, you might need to simulate multiple responses:
 
 ```php
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\ValueObjects\Usage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\ValueObjects\Usage;
+use PrismPHP\Prism\ValueObjects\ResponseMeta;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 it('can handle tool calls', function () {
     $responses = [
@@ -96,11 +96,11 @@ it('can handle tool calls', function () {
 If you need to test a richer response object, e.g. with Steps, you may find it easier to use the ResponseBuilder:
 
 ```php
-use EchoLabs\Prism\Text\ResponseBuilder;
-use EchoLabs\Prism\Text\Step;
-use EchoLabs\Prism\ValueObjects\Usage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\Text\ResponseBuilder;
+use PrismPHP\Prism\Text\Step;
+use PrismPHP\Prism\ValueObjects\Usage;
+use PrismPHP\Prism\ValueObjects\ResponseMeta;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 Prism::fake([
     (new ResponseBuilder)
@@ -148,13 +148,13 @@ Prism::fake([
 When testing tools, you'll want to verify both the tool calls and their results. Here's a complete example:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\Tool;
-use EchoLabs\Prism\ValueObjects\Usage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\Tool;
+use PrismPHP\Prism\ValueObjects\Usage;
+use PrismPHP\Prism\ValueObjects\ResponseMeta;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 it('can use weather tool', function () {
     // Define the expected tool call and response sequence
@@ -231,12 +231,12 @@ it('can use weather tool', function () {
 ## Testing Structured Output
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\ValueObjects\Usage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\ValueObjects\Usage;
+use PrismPHP\Prism\ValueObjects\ResponseMeta;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
 
 it('can generate structured response', function () {
     $schema = new ObjectSchema(

--- a/docs/core-concepts/text-generation.md
+++ b/docs/core-concepts/text-generation.md
@@ -7,8 +7,8 @@ Prism provides a powerful interface for generating text using Large Language Mod
 At its simplest, you can generate text with just a few lines of code:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -23,8 +23,8 @@ echo $response->text;
 System prompts help set the behavior and context for the AI. They're particularly useful for maintaining consistent responses or giving the LLM a persona:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -36,8 +36,8 @@ $response = Prism::text()
 You can also use Laravel views for complex system prompts:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -53,10 +53,10 @@ You an also pass a View to the `withPrompt` method.
 For interactive conversations, use message chains to maintain context:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -121,8 +121,8 @@ This allows for complete or partial override of the providers configuration. Thi
 The response object provides rich access to the generation results:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -170,9 +170,9 @@ FinishReason::Unknown;
 Remember to handle potential errors in your generations:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
 use Throwable;
 
 try {

--- a/docs/core-concepts/tools-function-calling.md
+++ b/docs/core-concepts/tools-function-calling.md
@@ -7,9 +7,9 @@ Need your AI assistant to check the weather, search a database, or call your API
 Think of tools as special functions that your AI assistant can use when it needs to perform specific tasks. Just like how Laravel's facades provide a clean interface to complex functionality, Prism tools give your AI a clean way to interact with external services and data sources.
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Facades\Tool;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Facades\Tool;
 
 $weatherTool = Tool::as('weather')
     ->for('Get current weather conditions')
@@ -32,8 +32,8 @@ $response = Prism::text()
 Prism defaults to allowing a single step. To use Tools, you'll need to increase this using `withMaxSteps`:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
@@ -51,7 +51,7 @@ You should use a higher number of max steps if you expect your initial prompt to
 Creating tools in Prism is straightforward and fluent. Here's how you can create a simple tool:
 
 ```php
-use EchoLabs\Prism\Facades\Tool;
+use PrismPHP\Prism\Facades\Tool;
 
 $searchTool = Tool::as('search')
     ->for('Search for current information')
@@ -71,7 +71,7 @@ Prism offers multiple ways to define tool parameters, from simple primitives to 
 Perfect for text inputs:
 
 ```php
-use EchoLabs\Prism\Facades\Tool;
+use PrismPHP\Prism\Facades\Tool;
 
 $tool = Tool::as('search')
     ->for('Search for information')
@@ -86,7 +86,7 @@ $tool = Tool::as('search')
 For integer or floating-point values:
 
 ```php
-use EchoLabs\Prism\Facades\Tool;
+use PrismPHP\Prism\Facades\Tool;
 
 $tool = Tool::as('calculate')
     ->for('Perform calculations')
@@ -101,7 +101,7 @@ $tool = Tool::as('calculate')
 For true/false flags:
 
 ```php
-use EchoLabs\Prism\Facades\Tool;
+use PrismPHP\Prism\Facades\Tool;
 
 $tool = Tool::as('feature_toggle')
     ->for('Toggle a feature')
@@ -116,7 +116,7 @@ $tool = Tool::as('feature_toggle')
 For handling lists of items:
 
 ```php
-use EchoLabs\Prism\Facades\Tool;
+use PrismPHP\Prism\Facades\Tool;
 
 $tool = Tool::as('process_tags')
     ->for('Process a list of tags')
@@ -135,7 +135,7 @@ $tool = Tool::as('process_tags')
 When you need to restrict values to a specific set:
 
 ```php
-use EchoLabs\Prism\Facades\Tool;
+use PrismPHP\Prism\Facades\Tool;
 
 $tool = Tool::as('set_status')
     ->for('Set the status')
@@ -154,9 +154,9 @@ $tool = Tool::as('set_status')
 For complex objects without needing to create separate schema instances:
 
 ```php
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Schema\StringSchema;
-use EchoLabs\Prism\Schema\NumberSchema;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Schema\NumberSchema;
 
 $tool = Tool::as('update_user')
     ->for('Update a user profile')
@@ -180,10 +180,10 @@ $tool = Tool::as('update_user')
 For complex, nested data structures, you can use Prism's schema system:
 
 ```php
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
-use EchoLabs\Prism\Schema\NumberSchema;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Schema\NumberSchema;
 
 $tool = Tool::as('create_user')
     ->for('Create a new user profile')
@@ -212,7 +212,7 @@ For more sophisticated tools, you can create dedicated classes:
 ```php
 namespace App\Tools;
 
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Tool;
 use Illuminate\Support\Facades\Http;
 
 class SearchTool extends Tool
@@ -258,9 +258,9 @@ class SearchTool extends Tool
 
 You can control how the AI uses tools with the `withToolChoice` method:
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Enums\ToolChoice;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\ToolChoice;
 
 $prism = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
@@ -283,8 +283,8 @@ $prism = Prism::text()
 When your AI uses tools, you can inspect the results and see how it arrived at its answer:
 
 ```php
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,13 +12,13 @@ Before we dive in, make sure your project meets these requirements:
 ## Step 1: Composer Installation
 
 ::: tip
-Prism is actively evolving. To prevent unexpected issues from breaking changes, we strongly recommend pinning your installation to a specific version. Example: "echolabsdev/prism": "^0.3.0".
+Prism is actively evolving. To prevent unexpected issues from breaking changes, we strongly recommend pinning your installation to a specific version. Example: "prism-php/prism": "^0.3.0".
 :::
 
 First, let's add Prism to your project using Composer. Open your terminal, navigate to your project directory, and run:
 
 ```bash
-composer require echolabsdev/prism
+composer require prism-php/prism
 ```
 
 This command will download Prism and its dependencies into your project.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -12,8 +12,8 @@ Here's a quick example of how you can generate text using Prism:
 
 ::: code-group
 ```php [Anthropic]
-use EchoLabs\Prism\Prism;
-use EchoLabs\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-sonnet')
@@ -25,8 +25,8 @@ echo $response->text;
 ```
 
 ```php [Mistral]
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Mistral, 'mistral-medium')
@@ -38,8 +38,8 @@ echo $response->text;
 ```
 
 ```php [Ollama]
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Ollama, 'llama2')
@@ -51,8 +51,8 @@ echo $response->text;
 ```
 
 ```php [OpenAI]
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::OpenAI, 'gpt-4')

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ hero:
       link: /project-info/roadmap
     - theme: alt
       text: Github
-      link: https://github.com/echolabsdev/prism
+      link: https://github.com/prism-php/prism
 
 features:
   - title: Elegant Provider Integrations

--- a/docs/input-modalities/documents.md
+++ b/docs/input-modalities/documents.md
@@ -30,10 +30,10 @@ All of these formats should work with Prism.
 To add an image to your message, add a `Document` value object to the `additionalContent` property:
 
 ```php
-use EchoLabs\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
 
 Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')

--- a/docs/input-modalities/images.md
+++ b/docs/input-modalities/images.md
@@ -11,8 +11,8 @@ Note however that not all models with a supported provider support vision. If yo
 To add an image to your message, add an `Image` value object to the `additionalContent` property:
 
 ```php
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
 
 // From a local file
 $message = new UserMessage(

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -24,11 +24,11 @@ We support Anthropic prompt caching on:
 The API for enabling prompt caching is the same for all, enabled via the `withProviderMeta()` method. Where a UserMessage contains both text and an image or document, both will be cached.
 
 ```php
-use EchoLabs\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Tool;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Tool;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
 
 Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -49,10 +49,10 @@ Prism::text()
 If you prefer, you can use the `AnthropicCacheType` Enum like so:
 
 ```php
-use EchoLabs\Enums\Provider;
-use EchoLabs\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Enums\Provider;
+use PrismPHP\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
 
 (new UserMessage('I am a long re-usable user message.'))->withProviderMeta(Provider::Anthropic, ['cacheType' => AnthropicCacheType::ephemeral])
 ```
@@ -68,8 +68,8 @@ Claude Sonnet 3.7 supports an optional extended thinking mode, where it will rea
 Prism supports thinking mode for text and structured with the same API:
 
 ```php
-use EchoLabs\Enums\Provider;
-use EchoLabs\Prism\Prism;
+use PrismPHP\Enums\Provider;
+use PrismPHP\Prism\Prism;
 
 Prism::text()
     ->using('anthropic', 'claude-3-7-sonnet-latest')
@@ -83,8 +83,8 @@ By default Prism will set the thinking budget to the value set in config, or whe
 You can overide the config (or its default) using `withProviderMeta`:
 
 ```php
-use EchoLabs\Enums\Provider;
-use EchoLabs\Prism\Prism;
+use PrismPHP\Enums\Provider;
+use PrismPHP\Prism\Prism;
 
 Prism::text()
     ->using('anthropic', 'claude-3-7-sonnet-latest')
@@ -110,8 +110,8 @@ You can access it via the additionalContent property on either the Response or t
 On the Response (easiest if not using tools):
 
 ```php
-use EchoLabs\Enums\Provider;
-use EchoLabs\Prism\Prism;
+use PrismPHP\Enums\Provider;
+use PrismPHP\Prism\Prism;
 
 Prism::text()
     ->using('anthropic', 'claude-3-7-sonnet-latest')
@@ -157,10 +157,10 @@ Anthropic also supports "custom content documents", separately documented below,
 Custom content documents are primarily for use with citations (see below), if you need citations to reference your own chunking strategy.
 
 ```php
-use EchoLabs\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
 
 Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -186,10 +186,10 @@ Please note however that due to Anthropic not supporting "native" structured out
 Anthropic require citations to be enabled on all documents in a request. To enable them, using the `withProviderMeta()` method when building your request:
 
 ```php
-use EchoLabs\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -216,8 +216,8 @@ You can access the chunked output with its citations via the additionalContent p
 As a rough worked example, let's assume you want to implement footnotes. You'll need to loop through those chunks and (1) re-construct the message with links to the footnotes; and (2) build an array of footnotes to loop through in your frontend.
 
 ```php
-use EchoLabs\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
-use EchoLabs\Prism\Providers\Anthropic\ValueObjects\Citation;
+use PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
+use PrismPHP\Prism\Providers\Anthropic\ValueObjects\Citation;
 
 $messageChunks = $response->additionalContent['messagePartsWithCitations'];
 

--- a/docs/providers/voyageai.md
+++ b/docs/providers/voyageai.md
@@ -20,8 +20,8 @@ However, they taylor your vectors for the task they are intended for - for searc
 For search / querying:
 
 ```php
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
 
 Prism::embeddings()
     ->using(Provider::VoyageAI, 'voyage-3-lite')
@@ -33,8 +33,8 @@ Prism::embeddings()
 For document retrieval:
 
 ```php
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
 
 Prism::embeddings()
     ->using(Provider::VoyageAI, 'voyage-3-lite')
@@ -50,8 +50,8 @@ By default, Voyage AI truncates inputs that are over the context length.
 You can force it to throw an error instead by setting truncation to false.
 
 ```php
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
 
 Prism::embeddings()
     ->using(Provider::VoyageAI, 'voyage-3-lite')

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Rectors\ReorderMethodsRector;
+use PrismPHP\Prism\Rectors\ReorderMethodsRector;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;

--- a/src/Concerns/CallsTools.php
+++ b/src/Concerns/CallsTools.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Tool;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Tool;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 use Throwable;
 
 trait CallsTools

--- a/src/Concerns/ChecksSelf.php
+++ b/src/Concerns/ChecksSelf.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
 trait ChecksSelf
 {

--- a/src/Concerns/ConfiguresClient.php
+++ b/src/Concerns/ConfiguresClient.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
 use Closure;
 

--- a/src/Concerns/ConfiguresGeneration.php
+++ b/src/Concerns/ConfiguresGeneration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
 trait ConfiguresGeneration
 {

--- a/src/Concerns/ConfiguresModels.php
+++ b/src/Concerns/ConfiguresModels.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
 trait ConfiguresModels
 {

--- a/src/Concerns/ConfiguresProviders.php
+++ b/src/Concerns/ConfiguresProviders.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Enums\Provider as ProviderEnum;
-use EchoLabs\Prism\PrismManager;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Enums\Provider as ProviderEnum;
+use PrismPHP\Prism\PrismManager;
 
 trait ConfiguresProviders
 {

--- a/src/Concerns/ConfiguresStructuredOutput.php
+++ b/src/Concerns/ConfiguresStructuredOutput.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
-use EchoLabs\Prism\Enums\StructuredMode;
+use PrismPHP\Prism\Enums\StructuredMode;
 
 trait ConfiguresStructuredOutput
 {

--- a/src/Concerns/ConfiguresTools.php
+++ b/src/Concerns/ConfiguresTools.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
-use EchoLabs\Prism\Enums\ToolChoice;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Enums\ToolChoice;
+use PrismPHP\Prism\Tool;
 
 trait ConfiguresTools
 {

--- a/src/Concerns/HasMessages.php
+++ b/src/Concerns/HasMessages.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
-use EchoLabs\Prism\Contracts\Message;
+use PrismPHP\Prism\Contracts\Message;
 
 trait HasMessages
 {

--- a/src/Concerns/HasPrompts.php
+++ b/src/Concerns/HasPrompts.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use Illuminate\Contracts\View\View;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
 
 trait HasPrompts
 {

--- a/src/Concerns/HasProviderMeta.php
+++ b/src/Concerns/HasProviderMeta.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\Provider;
 
 trait HasProviderMeta
 {

--- a/src/Concerns/HasSchema.php
+++ b/src/Concerns/HasSchema.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
-use EchoLabs\Prism\Contracts\Schema;
+use PrismPHP\Prism\Contracts\Schema;
 
 trait HasSchema
 {

--- a/src/Concerns/HasTools.php
+++ b/src/Concerns/HasTools.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Tool;
 
 trait HasTools
 {

--- a/src/Concerns/NullableSchema.php
+++ b/src/Concerns/NullableSchema.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EchoLabs\Prism\Concerns;
+namespace PrismPHP\Prism\Concerns;
 
 trait NullableSchema
 {

--- a/src/Contracts/Message.php
+++ b/src/Contracts/Message.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Contracts;
+namespace PrismPHP\Prism\Contracts;
 
 interface Message {}

--- a/src/Contracts/PrismRequest.php
+++ b/src/Contracts/PrismRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Contracts;
+namespace PrismPHP\Prism\Contracts;
 
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\Provider;
 
 interface PrismRequest
 {

--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Contracts;
+namespace PrismPHP\Prism\Contracts;
 
-use EchoLabs\Prism\Embeddings\Request as EmbeddingsRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Stream\Chunk;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
 use Generator;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Stream\Chunk;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 interface Provider
 {

--- a/src/Contracts/Schema.php
+++ b/src/Contracts/Schema.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Contracts;
+namespace PrismPHP\Prism\Contracts;
 
 interface Schema
 {

--- a/src/Embeddings/Generator.php
+++ b/src/Embeddings/Generator.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Embeddings;
+namespace PrismPHP\Prism\Embeddings;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
 
 class Generator
 {

--- a/src/Embeddings/PendingRequest.php
+++ b/src/Embeddings/PendingRequest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Embeddings;
+namespace PrismPHP\Prism\Embeddings;
 
-use EchoLabs\Prism\Concerns\ConfiguresClient;
-use EchoLabs\Prism\Concerns\ConfiguresProviders;
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Concerns\ConfiguresClient;
+use PrismPHP\Prism\Concerns\ConfiguresProviders;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Exceptions\PrismException;
 
 class PendingRequest
 {
@@ -52,7 +52,7 @@ class PendingRequest
         return $this;
     }
 
-    public function generate(): \EchoLabs\Prism\Embeddings\Response
+    public function generate(): \PrismPHP\Prism\Embeddings\Response
     {
         return (new Generator($this->provider))->generate($this->toRequest());
     }

--- a/src/Embeddings/Request.php
+++ b/src/Embeddings/Request.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Embeddings;
+namespace PrismPHP\Prism\Embeddings;
 
 use Closure;
-use EchoLabs\Prism\Concerns\ChecksSelf;
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Contracts\PrismRequest;
+use PrismPHP\Prism\Concerns\ChecksSelf;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Contracts\PrismRequest;
 
 class Request implements PrismRequest
 {

--- a/src/Embeddings/Response.php
+++ b/src/Embeddings/Response.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Embeddings;
+namespace PrismPHP\Prism\Embeddings;
 
-use EchoLabs\Prism\ValueObjects\Embedding;
-use EchoLabs\Prism\ValueObjects\EmbeddingsUsage;
+use PrismPHP\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
 
 readonly class Response
 {

--- a/src/Enums/FinishReason.php
+++ b/src/Enums/FinishReason.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Enums;
+namespace PrismPHP\Prism\Enums;
 
 enum FinishReason
 {

--- a/src/Enums/Provider.php
+++ b/src/Enums/Provider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Enums;
+namespace PrismPHP\Prism\Enums;
 
 enum Provider: string
 {

--- a/src/Enums/StructuredMode.php
+++ b/src/Enums/StructuredMode.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Enums;
+namespace PrismPHP\Prism\Enums;
 
 enum StructuredMode
 {

--- a/src/Enums/ToolChoice.php
+++ b/src/Enums/ToolChoice.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Enums;
+namespace PrismPHP\Prism\Enums;
 
 enum ToolChoice
 {

--- a/src/Exceptions/PrismChunkDecodeException.php
+++ b/src/Exceptions/PrismChunkDecodeException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Exceptions;
+namespace PrismPHP\Prism\Exceptions;
 
 use Throwable;
 

--- a/src/Exceptions/PrismException.php
+++ b/src/Exceptions/PrismException.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Exceptions;
+namespace PrismPHP\Prism\Exceptions;
 
-use EchoLabs\Prism\ValueObjects\ToolCall;
 use Exception;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 use Throwable;
 
 class PrismException extends Exception

--- a/src/Exceptions/PrismProviderOverloadedException.php
+++ b/src/Exceptions/PrismProviderOverloadedException.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Exceptions;
+namespace PrismPHP\Prism\Exceptions;
 
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\Provider;
 
 class PrismProviderOverloadedException extends PrismException
 {

--- a/src/Exceptions/PrismRateLimitedException.php
+++ b/src/Exceptions/PrismRateLimitedException.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Exceptions;
+namespace PrismPHP\Prism\Exceptions;
 
-use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 
 class PrismRateLimitedException extends PrismException
 {

--- a/src/Exceptions/PrismRequestTooLargeException.php
+++ b/src/Exceptions/PrismRequestTooLargeException.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Exceptions;
+namespace PrismPHP\Prism\Exceptions;
 
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\Provider;
 
 class PrismRequestTooLargeException extends PrismException
 {

--- a/src/Exceptions/PrismServerException.php
+++ b/src/Exceptions/PrismServerException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Exceptions;
+namespace PrismPHP\Prism\Exceptions;
 
 use Exception;
 use Throwable;

--- a/src/Exceptions/PrismStructuredDecodingException.php
+++ b/src/Exceptions/PrismStructuredDecodingException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Exceptions;
+namespace PrismPHP\Prism\Exceptions;
 
 class PrismStructuredDecodingException extends PrismException
 {

--- a/src/Facades/PrismServer.php
+++ b/src/Facades/PrismServer.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Facades;
+namespace PrismPHP\Prism\Facades;
 
 use Closure;
-use EchoLabs\Prism\Text\PendingRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
+use PrismPHP\Prism\Text\PendingRequest;
 
 /**
  * @method static self register(string $name, Closure():PendingRequest|callable():PendingRequest $prism)

--- a/src/Facades/Tool.php
+++ b/src/Facades/Tool.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Facades;
+namespace PrismPHP\Prism\Facades;
 
 use Closure;
-use EchoLabs\Prism\Contracts\Schema;
-use EchoLabs\Prism\Tool as BaseTool;
+use PrismPHP\Prism\Contracts\Schema;
+use PrismPHP\Prism\Tool as BaseTool;
 
 /**
  * @method static BaseTool as(string $name)

--- a/src/Http/Controllers/PrismChatController.php
+++ b/src/Http/Controllers/PrismChatController.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace EchoLabs\Prism\Http\Controllers;
+namespace PrismPHP\Prism\Http\Controllers;
 
-use EchoLabs\Prism\Exceptions\PrismServerException;
-use EchoLabs\Prism\Facades\PrismServer;
-use EchoLabs\Prism\Text\PendingRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Illuminate\Support\ItemNotFoundException;
+use PrismPHP\Prism\Exceptions\PrismServerException;
+use PrismPHP\Prism\Facades\PrismServer;
+use PrismPHP\Prism\Text\PendingRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 

--- a/src/Http/Controllers/PrismModelController.php
+++ b/src/Http/Controllers/PrismModelController.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Http\Controllers;
+namespace PrismPHP\Prism\Http\Controllers;
 
-use EchoLabs\Prism\Facades\PrismServer;
 use Illuminate\Http\JsonResponse;
+use PrismPHP\Prism\Facades\PrismServer;
 
 class PrismModelController
 {

--- a/src/Prism.php
+++ b/src/Prism.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism;
+namespace PrismPHP\Prism;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\PendingRequest as PendingEmbeddingRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
-use EchoLabs\Prism\Enums\Provider as ProviderEnum;
-use EchoLabs\Prism\Stream\PendingRequest as PendingStreamRequest;
-use EchoLabs\Prism\Structured\PendingRequest as PendingStructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Testing\PrismFake;
-use EchoLabs\Prism\Text\PendingRequest as PendingTextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\PendingRequest as PendingEmbeddingRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
+use PrismPHP\Prism\Enums\Provider as ProviderEnum;
+use PrismPHP\Prism\Stream\PendingRequest as PendingStreamRequest;
+use PrismPHP\Prism\Structured\PendingRequest as PendingStructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Testing\PrismFake;
+use PrismPHP\Prism\Text\PendingRequest as PendingTextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 class Prism
 {

--- a/src/PrismManager.php
+++ b/src/PrismManager.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism;
+namespace PrismPHP\Prism;
 
 use Closure;
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Enums\Provider as ProviderEnum;
-use EchoLabs\Prism\Providers\Anthropic\Anthropic;
-use EchoLabs\Prism\Providers\DeepSeek\DeepSeek;
-use EchoLabs\Prism\Providers\Gemini\Gemini;
-use EchoLabs\Prism\Providers\Groq\Groq;
-use EchoLabs\Prism\Providers\Mistral\Mistral;
-use EchoLabs\Prism\Providers\Ollama\Ollama;
-use EchoLabs\Prism\Providers\OpenAI\OpenAI;
-use EchoLabs\Prism\Providers\VoyageAI\VoyageAI;
-use EchoLabs\Prism\Providers\XAI\XAI;
 use Illuminate\Contracts\Foundation\Application;
 use InvalidArgumentException;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Enums\Provider as ProviderEnum;
+use PrismPHP\Prism\Providers\Anthropic\Anthropic;
+use PrismPHP\Prism\Providers\DeepSeek\DeepSeek;
+use PrismPHP\Prism\Providers\Gemini\Gemini;
+use PrismPHP\Prism\Providers\Groq\Groq;
+use PrismPHP\Prism\Providers\Mistral\Mistral;
+use PrismPHP\Prism\Providers\Ollama\Ollama;
+use PrismPHP\Prism\Providers\OpenAI\OpenAI;
+use PrismPHP\Prism\Providers\VoyageAI\VoyageAI;
+use PrismPHP\Prism\Providers\XAI\XAI;
 use RuntimeException;
 
 class PrismManager

--- a/src/PrismServer.php
+++ b/src/PrismServer.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism;
+namespace PrismPHP\Prism;
 
 use Closure;
-use EchoLabs\Prism\Text\PendingRequest;
 use Illuminate\Support\Collection;
+use PrismPHP\Prism\Text\PendingRequest;
 
 readonly class PrismServer
 {

--- a/src/PrismServiceProvider.php
+++ b/src/PrismServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EchoLabs\Prism;
+namespace PrismPHP\Prism;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Anthropic;
+namespace PrismPHP\Prism\Providers\Anthropic;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Anthropic\Handlers\Structured;
-use EchoLabs\Prism\Providers\Anthropic\Handlers\Text;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Anthropic\Handlers\Structured;
+use PrismPHP\Prism\Providers\Anthropic\Handlers\Text;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response;
 
 readonly class Anthropic implements Provider
 {

--- a/src/Providers/Anthropic/Enums/AnthropicCacheType.php
+++ b/src/Providers/Anthropic/Enums/AnthropicCacheType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EchoLabs\Prism\Providers\Anthropic\Enums;
+namespace PrismPHP\Prism\Providers\Anthropic\Enums;
 
 enum AnthropicCacheType: string
 {

--- a/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
+++ b/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Anthropic\Handlers;
+namespace PrismPHP\Prism\Providers\Anthropic\Handlers;
 
-use EchoLabs\Prism\Contracts\PrismRequest;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Exceptions\PrismProviderOverloadedException;
-use EchoLabs\Prism\Exceptions\PrismRateLimitedException;
-use EchoLabs\Prism\Exceptions\PrismRequestTooLargeException;
-use EchoLabs\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
-use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use PrismPHP\Prism\Contracts\PrismRequest;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismProviderOverloadedException;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use PrismPHP\Prism\Exceptions\PrismRequestTooLargeException;
+use PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 use Throwable;
 
 abstract class AnthropicHandlerAbstract
@@ -68,7 +68,7 @@ abstract class AnthropicHandlerAbstract
             return null;
         }
 
-        return Arr::map(data_get($data, 'content', []), fn ($contentBlock): \EchoLabs\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations => MessagePartWithCitations::fromContentBlock($contentBlock));
+        return Arr::map(data_get($data, 'content', []), fn ($contentBlock): \PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations => MessagePartWithCitations::fromContentBlock($contentBlock));
     }
 
     protected function handleResponseErrors(): void

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Anthropic\Handlers;
+namespace PrismPHP\Prism\Providers\Anthropic\Handlers;
 
-use EchoLabs\Prism\Contracts\PrismRequest;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Providers\Anthropic\Maps\FinishReasonMap;
-use EchoLabs\Prism\Providers\Anthropic\Maps\MessageMap;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response;
-use EchoLabs\Prism\Structured\ResponseBuilder;
-use EchoLabs\Prism\Structured\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Support\Collection;
+use PrismPHP\Prism\Contracts\PrismRequest;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Providers\Anthropic\Maps\FinishReasonMap;
+use PrismPHP\Prism\Providers\Anthropic\Maps\MessageMap;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response;
+use PrismPHP\Prism\Structured\ResponseBuilder;
+use PrismPHP\Prism\Structured\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 class Structured extends AnthropicHandlerAbstract
 {

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -2,28 +2,28 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Anthropic\Handlers;
+namespace PrismPHP\Prism\Providers\Anthropic\Handlers;
 
-use EchoLabs\Prism\Concerns\CallsTools;
-use EchoLabs\Prism\Contracts\PrismRequest;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Anthropic\Maps\FinishReasonMap;
-use EchoLabs\Prism\Providers\Anthropic\Maps\MessageMap;
-use EchoLabs\Prism\Providers\Anthropic\Maps\ToolChoiceMap;
-use EchoLabs\Prism\Providers\Anthropic\Maps\ToolMap;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response;
-use EchoLabs\Prism\Text\ResponseBuilder;
-use EchoLabs\Prism\Text\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Support\Collection;
+use PrismPHP\Prism\Concerns\CallsTools;
+use PrismPHP\Prism\Contracts\PrismRequest;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Anthropic\Maps\FinishReasonMap;
+use PrismPHP\Prism\Providers\Anthropic\Maps\MessageMap;
+use PrismPHP\Prism\Providers\Anthropic\Maps\ToolChoiceMap;
+use PrismPHP\Prism\Providers\Anthropic\Maps\ToolMap;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response;
+use PrismPHP\Prism\Text\ResponseBuilder;
+use PrismPHP\Prism\Text\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 /**
  * @template TRequest of TextRequest

--- a/src/Providers/Anthropic/Maps/FinishReasonMap.php
+++ b/src/Providers/Anthropic/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Anthropic\Maps;
+namespace PrismPHP\Prism\Providers\Anthropic\Maps;
 
-use EchoLabs\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/Anthropic/Maps/MessageMap.php
+++ b/src/Providers/Anthropic/Maps/MessageMap.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Anthropic\Maps;
+namespace PrismPHP\Prism\Providers\Anthropic\Maps;
 
 use BackedEnum;
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
 use Exception;
 use InvalidArgumentException;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 class MessageMap
 {

--- a/src/Providers/Anthropic/Maps/ToolChoiceMap.php
+++ b/src/Providers/Anthropic/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Anthropic\Maps;
+namespace PrismPHP\Prism\Providers\Anthropic\Maps;
 
-use EchoLabs\Prism\Enums\ToolChoice;
 use InvalidArgumentException;
+use PrismPHP\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/Anthropic/Maps/ToolMap.php
+++ b/src/Providers/Anthropic/Maps/ToolMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Anthropic\Maps;
+namespace PrismPHP\Prism\Providers\Anthropic\Maps;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Tool as PrismTool;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Tool as PrismTool;
 use UnitEnum;
 
 class ToolMap

--- a/src/Providers/Anthropic/ValueObjects/Citation.php
+++ b/src/Providers/Anthropic/ValueObjects/Citation.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Anthropic\ValueObjects;
+namespace PrismPHP\Prism\Providers\Anthropic\ValueObjects;
 
 class Citation
 {

--- a/src/Providers/Anthropic/ValueObjects/MessagePartWithCitations.php
+++ b/src/Providers/Anthropic/ValueObjects/MessagePartWithCitations.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Anthropic\ValueObjects;
+namespace PrismPHP\Prism\Providers\Anthropic\ValueObjects;
 
 class MessagePartWithCitations
 {
@@ -21,7 +21,7 @@ class MessagePartWithCitations
     {
         return new self(
             $data['text'],
-            array_map(function (array $citation): \EchoLabs\Prism\Providers\Anthropic\ValueObjects\Citation {
+            array_map(function (array $citation): \PrismPHP\Prism\Providers\Anthropic\ValueObjects\Citation {
                 $indexPropertyCommonPart = match ($citation['type']) {
                     'page_location' => 'page_number',
                     'char_location' => 'char_index',

--- a/src/Providers/DeepSeek/Concerns/MapsFinishReason.php
+++ b/src/Providers/DeepSeek/Concerns/MapsFinishReason.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\DeepSeek\Concerns;
+namespace PrismPHP\Prism\Providers\DeepSeek\Concerns;
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Providers\DeepSeek\Maps\FinishReasonMap;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Providers\DeepSeek\Maps\FinishReasonMap;
 
 trait MapsFinishReason
 {

--- a/src/Providers/DeepSeek/Concerns/ValidatesResponses.php
+++ b/src/Providers/DeepSeek/Concerns/ValidatesResponses.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\DeepSeek\Concerns;
+namespace PrismPHP\Prism\Providers\DeepSeek\Concerns;
 
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismException;
 
 trait ValidatesResponses
 {

--- a/src/Providers/DeepSeek/DeepSeek.php
+++ b/src/Providers/DeepSeek/DeepSeek.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\DeepSeek;
+namespace PrismPHP\Prism\Providers\DeepSeek;
 
 use Closure;
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingsRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\DeepSeek\Handlers\Structured;
-use EchoLabs\Prism\Providers\DeepSeek\Handlers\Text;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\DeepSeek\Handlers\Structured;
+use PrismPHP\Prism\Providers\DeepSeek\Handlers\Text;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 readonly class DeepSeek implements Provider
 {

--- a/src/Providers/DeepSeek/Handlers/Structured.php
+++ b/src/Providers/DeepSeek/Handlers/Structured.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace EchoLabs\Prism\Providers\DeepSeek\Handlers;
+namespace PrismPHP\Prism\Providers\DeepSeek\Handlers;
 
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\DeepSeek\Concerns\MapsFinishReason;
-use EchoLabs\Prism\Providers\DeepSeek\Concerns\ValidatesResponses;
-use EchoLabs\Prism\Providers\DeepSeek\Maps\FinishReasonMap;
-use EchoLabs\Prism\Providers\DeepSeek\Maps\MessageMap;
-use EchoLabs\Prism\Structured\Request;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Structured\ResponseBuilder;
-use EchoLabs\Prism\Structured\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\DeepSeek\Concerns\MapsFinishReason;
+use PrismPHP\Prism\Providers\DeepSeek\Concerns\ValidatesResponses;
+use PrismPHP\Prism\Providers\DeepSeek\Maps\FinishReasonMap;
+use PrismPHP\Prism\Providers\DeepSeek\Maps\MessageMap;
+use PrismPHP\Prism\Structured\Request;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Structured\ResponseBuilder;
+use PrismPHP\Prism\Structured\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Structured

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -2,27 +2,27 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\DeepSeek\Handlers;
+namespace PrismPHP\Prism\Providers\DeepSeek\Handlers;
 
-use EchoLabs\Prism\Concerns\CallsTools;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\DeepSeek\Concerns\MapsFinishReason;
-use EchoLabs\Prism\Providers\DeepSeek\Concerns\ValidatesResponses;
-use EchoLabs\Prism\Providers\DeepSeek\Maps\MessageMap;
-use EchoLabs\Prism\Providers\DeepSeek\Maps\ToolCallMap;
-use EchoLabs\Prism\Providers\DeepSeek\Maps\ToolChoiceMap;
-use EchoLabs\Prism\Providers\DeepSeek\Maps\ToolMap;
-use EchoLabs\Prism\Text\Request;
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\Text\ResponseBuilder;
-use EchoLabs\Prism\Text\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolResult;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
+use PrismPHP\Prism\Concerns\CallsTools;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\DeepSeek\Concerns\MapsFinishReason;
+use PrismPHP\Prism\Providers\DeepSeek\Concerns\ValidatesResponses;
+use PrismPHP\Prism\Providers\DeepSeek\Maps\MessageMap;
+use PrismPHP\Prism\Providers\DeepSeek\Maps\ToolCallMap;
+use PrismPHP\Prism\Providers\DeepSeek\Maps\ToolChoiceMap;
+use PrismPHP\Prism\Providers\DeepSeek\Maps\ToolMap;
+use PrismPHP\Prism\Text\Request;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\Text\ResponseBuilder;
+use PrismPHP\Prism\Text\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/DeepSeek/Maps/FinishReasonMap.php
+++ b/src/Providers/DeepSeek/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\DeepSeek\Maps;
+namespace PrismPHP\Prism\Providers\DeepSeek\Maps;
 
-use EchoLabs\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/DeepSeek/Maps/MessageMap.php
+++ b/src/Providers/DeepSeek/Maps/MessageMap.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\DeepSeek\Maps;
+namespace PrismPHP\Prism\Providers\DeepSeek\Maps;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
 use Exception;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 class MessageMap
 {

--- a/src/Providers/DeepSeek/Maps/ToolCallMap.php
+++ b/src/Providers/DeepSeek/Maps/ToolCallMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\DeepSeek\Maps;
+namespace PrismPHP\Prism\Providers\DeepSeek\Maps;
 
-use EchoLabs\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 class ToolCallMap
 {

--- a/src/Providers/DeepSeek/Maps/ToolChoiceMap.php
+++ b/src/Providers/DeepSeek/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\DeepSeek\Maps;
+namespace PrismPHP\Prism\Providers\DeepSeek\Maps;
 
-use EchoLabs\Prism\Enums\ToolChoice;
 use InvalidArgumentException;
+use PrismPHP\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/DeepSeek/Maps/ToolMap.php
+++ b/src/Providers/DeepSeek/Maps/ToolMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\DeepSeek\Maps;
+namespace PrismPHP\Prism\Providers\DeepSeek\Maps;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/Gemini/Gemini.php
+++ b/src/Providers/Gemini/Gemini.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Gemini;
+namespace PrismPHP\Prism\Providers\Gemini;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Gemini\Handlers\Embeddings;
-use EchoLabs\Prism\Providers\Gemini\Handlers\Structured;
-use EchoLabs\Prism\Providers\Gemini\Handlers\Text;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Gemini\Handlers\Embeddings;
+use PrismPHP\Prism\Providers\Gemini\Handlers\Structured;
+use PrismPHP\Prism\Providers\Gemini\Handlers\Text;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 readonly class Gemini implements Provider
 {

--- a/src/Providers/Gemini/Handlers/Embeddings.php
+++ b/src/Providers/Gemini/Handlers/Embeddings.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Gemini\Handlers;
+namespace PrismPHP\Prism\Providers\Gemini\Handlers;
 
-use EchoLabs\Prism\Embeddings\Request;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Embedding;
-use EchoLabs\Prism\ValueObjects\EmbeddingsUsage;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use PrismPHP\Prism\Embeddings\Request;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
 use Throwable;
 
 class Embeddings

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace EchoLabs\Prism\Providers\Gemini\Handlers;
+namespace PrismPHP\Prism\Providers\Gemini\Handlers;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Gemini\Maps\FinishReasonMap;
-use EchoLabs\Prism\Providers\Gemini\Maps\MessageMap;
-use EchoLabs\Prism\Providers\Gemini\Maps\SchemaMap;
-use EchoLabs\Prism\Structured\Request;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Structured\ResponseBuilder;
-use EchoLabs\Prism\Structured\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Gemini\Maps\FinishReasonMap;
+use PrismPHP\Prism\Providers\Gemini\Maps\MessageMap;
+use PrismPHP\Prism\Providers\Gemini\Maps\SchemaMap;
+use PrismPHP\Prism\Structured\Request;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Structured\ResponseBuilder;
+use PrismPHP\Prism\Structured\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Structured

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -2,27 +2,27 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Gemini\Handlers;
+namespace PrismPHP\Prism\Providers\Gemini\Handlers;
 
-use EchoLabs\Prism\Concerns\CallsTools;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Gemini\Maps\FinishReasonMap;
-use EchoLabs\Prism\Providers\Gemini\Maps\MessageMap;
-use EchoLabs\Prism\Providers\Gemini\Maps\ToolCallMap;
-use EchoLabs\Prism\Providers\Gemini\Maps\ToolChoiceMap;
-use EchoLabs\Prism\Providers\Gemini\Maps\ToolMap;
-use EchoLabs\Prism\Text\Request;
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\Text\ResponseBuilder;
-use EchoLabs\Prism\Text\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolResult;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
+use PrismPHP\Prism\Concerns\CallsTools;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Gemini\Maps\FinishReasonMap;
+use PrismPHP\Prism\Providers\Gemini\Maps\MessageMap;
+use PrismPHP\Prism\Providers\Gemini\Maps\ToolCallMap;
+use PrismPHP\Prism\Providers\Gemini\Maps\ToolChoiceMap;
+use PrismPHP\Prism\Providers\Gemini\Maps\ToolMap;
+use PrismPHP\Prism\Text\Request;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\Text\ResponseBuilder;
+use PrismPHP\Prism\Text\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/Gemini/Maps/FinishReasonMap.php
+++ b/src/Providers/Gemini/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Gemini\Maps;
+namespace PrismPHP\Prism\Providers\Gemini\Maps;
 
-use EchoLabs\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/Gemini/Maps/MessageMap.php
+++ b/src/Providers/Gemini/Maps/MessageMap.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Gemini\Maps;
+namespace PrismPHP\Prism\Providers\Gemini\Maps;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Exception;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 
 class MessageMap
 {

--- a/src/Providers/Gemini/Maps/SchemaMap.php
+++ b/src/Providers/Gemini/Maps/SchemaMap.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace EchoLabs\Prism\Providers\Gemini\Maps;
+namespace PrismPHP\Prism\Providers\Gemini\Maps;
 
-use EchoLabs\Prism\Contracts\Schema;
-use EchoLabs\Prism\Schema\ArraySchema;
-use EchoLabs\Prism\Schema\BooleanSchema;
-use EchoLabs\Prism\Schema\NumberSchema;
-use EchoLabs\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Contracts\Schema;
+use PrismPHP\Prism\Schema\ArraySchema;
+use PrismPHP\Prism\Schema\BooleanSchema;
+use PrismPHP\Prism\Schema\NumberSchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
 
 class SchemaMap
 {

--- a/src/Providers/Gemini/Maps/ToolCallMap.php
+++ b/src/Providers/Gemini/Maps/ToolCallMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Gemini\Maps;
+namespace PrismPHP\Prism\Providers\Gemini\Maps;
 
-use EchoLabs\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 class ToolCallMap
 {
@@ -18,7 +18,7 @@ class ToolCallMap
             return [];
         }
 
-        return array_map(fn (array $toolCall): \EchoLabs\Prism\ValueObjects\ToolCall => new ToolCall(
+        return array_map(fn (array $toolCall): \PrismPHP\Prism\ValueObjects\ToolCall => new ToolCall(
             id: data_get($toolCall, 'functionCall.name'),
             name: data_get($toolCall, 'functionCall.name'),
             arguments: data_get($toolCall, 'functionCall.args'),

--- a/src/Providers/Gemini/Maps/ToolChoiceMap.php
+++ b/src/Providers/Gemini/Maps/ToolChoiceMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Gemini\Maps;
+namespace PrismPHP\Prism\Providers\Gemini\Maps;
 
-use EchoLabs\Prism\Enums\ToolChoice;
+use PrismPHP\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/Gemini/Maps/ToolMap.php
+++ b/src/Providers/Gemini/Maps/ToolMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Gemini\Maps;
+namespace PrismPHP\Prism\Providers\Gemini\Maps;
 
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/Groq/Groq.php
+++ b/src/Providers/Groq/Groq.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Groq;
+namespace PrismPHP\Prism\Providers\Groq;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Groq\Handlers\Text;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request;
-use EchoLabs\Prism\Text\Response as TextResponse;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Groq\Handlers\Text;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 readonly class Groq implements Provider
 {

--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -2,26 +2,26 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Groq\Handlers;
+namespace PrismPHP\Prism\Providers\Groq\Handlers;
 
-use EchoLabs\Prism\Concerns\CallsTools;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Groq\Maps\FinishReasonMap;
-use EchoLabs\Prism\Providers\Groq\Maps\MessageMap;
-use EchoLabs\Prism\Providers\Groq\Maps\ToolChoiceMap;
-use EchoLabs\Prism\Providers\Groq\Maps\ToolMap;
-use EchoLabs\Prism\Text\Request;
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\Text\ResponseBuilder;
-use EchoLabs\Prism\Text\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
+use PrismPHP\Prism\Concerns\CallsTools;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Groq\Maps\FinishReasonMap;
+use PrismPHP\Prism\Providers\Groq\Maps\MessageMap;
+use PrismPHP\Prism\Providers\Groq\Maps\ToolChoiceMap;
+use PrismPHP\Prism\Providers\Groq\Maps\ToolMap;
+use PrismPHP\Prism\Text\Request;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\Text\ResponseBuilder;
+use PrismPHP\Prism\Text\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/Groq/Maps/FinishReasonMap.php
+++ b/src/Providers/Groq/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Groq\Maps;
+namespace PrismPHP\Prism\Providers\Groq\Maps;
 
-use EchoLabs\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/Groq/Maps/MessageMap.php
+++ b/src/Providers/Groq/Maps/MessageMap.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Groq\Maps;
+namespace PrismPHP\Prism\Providers\Groq\Maps;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
 use Exception;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 class MessageMap
 {

--- a/src/Providers/Groq/Maps/ToolChoiceMap.php
+++ b/src/Providers/Groq/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Groq\Maps;
+namespace PrismPHP\Prism\Providers\Groq\Maps;
 
-use EchoLabs\Prism\Enums\ToolChoice;
 use InvalidArgumentException;
+use PrismPHP\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/Groq/Maps/ToolMap.php
+++ b/src/Providers/Groq/Maps/ToolMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Groq\Maps;
+namespace PrismPHP\Prism\Providers\Groq\Maps;
 
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/Mistral/Concerns/MapsFinishReason.php
+++ b/src/Providers/Mistral/Concerns/MapsFinishReason.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Mistral\Concerns;
+namespace PrismPHP\Prism\Providers\Mistral\Concerns;
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Providers\Mistral\Maps\FinishReasonMap;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Providers\Mistral\Maps\FinishReasonMap;
 
 trait MapsFinishReason
 {

--- a/src/Providers/Mistral/Concerns/ValidatesResponses.php
+++ b/src/Providers/Mistral/Concerns/ValidatesResponses.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Mistral\Concerns;
+namespace PrismPHP\Prism\Providers\Mistral\Concerns;
 
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismException;
 
 trait ValidatesResponses
 {

--- a/src/Providers/Mistral/Handlers/Embeddings.php
+++ b/src/Providers/Mistral/Handlers/Embeddings.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Mistral\Handlers;
+namespace PrismPHP\Prism\Providers\Mistral\Handlers;
 
-use EchoLabs\Prism\Embeddings\Request;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Embedding;
-use EchoLabs\Prism\ValueObjects\EmbeddingsUsage;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use PrismPHP\Prism\Embeddings\Request;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
 use Throwable;
 
 class Embeddings
@@ -38,7 +38,7 @@ class Embeddings
         }
 
         return new EmbeddingsResponse(
-            embeddings: array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($data, 'data', [])),
+            embeddings: array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($data, 'data', [])),
             usage: new EmbeddingsUsage(data_get($data, 'usage.total_tokens', null)),
         );
     }

--- a/src/Providers/Mistral/Handlers/Text.php
+++ b/src/Providers/Mistral/Handlers/Text.php
@@ -2,26 +2,26 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Mistral\Handlers;
+namespace PrismPHP\Prism\Providers\Mistral\Handlers;
 
-use EchoLabs\Prism\Concerns\CallsTools;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Mistral\Concerns\MapsFinishReason;
-use EchoLabs\Prism\Providers\Mistral\Concerns\ValidatesResponses;
-use EchoLabs\Prism\Providers\Mistral\Maps\MessageMap;
-use EchoLabs\Prism\Providers\Mistral\Maps\ToolMap;
-use EchoLabs\Prism\Text\Request;
-use EchoLabs\Prism\Text\Response;
-use EchoLabs\Prism\Text\ResponseBuilder;
-use EchoLabs\Prism\Text\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
+use PrismPHP\Prism\Concerns\CallsTools;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Mistral\Concerns\MapsFinishReason;
+use PrismPHP\Prism\Providers\Mistral\Concerns\ValidatesResponses;
+use PrismPHP\Prism\Providers\Mistral\Maps\MessageMap;
+use PrismPHP\Prism\Providers\Mistral\Maps\ToolMap;
+use PrismPHP\Prism\Text\Request;
+use PrismPHP\Prism\Text\Response;
+use PrismPHP\Prism\Text\ResponseBuilder;
+use PrismPHP\Prism\Text\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text
@@ -154,7 +154,7 @@ class Text
             return [];
         }
 
-        return array_map(fn ($toolCall): \EchoLabs\Prism\ValueObjects\ToolCall => new ToolCall(
+        return array_map(fn ($toolCall): \PrismPHP\Prism\ValueObjects\ToolCall => new ToolCall(
             id: data_get($toolCall, 'id'),
             name: data_get($toolCall, 'function.name'),
             arguments: data_get($toolCall, 'function.arguments'),

--- a/src/Providers/Mistral/Maps/FinishReasonMap.php
+++ b/src/Providers/Mistral/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Mistral\Maps;
+namespace PrismPHP\Prism\Providers\Mistral\Maps;
 
-use EchoLabs\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/Mistral/Maps/MessageMap.php
+++ b/src/Providers/Mistral/Maps/MessageMap.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Mistral\Maps;
+namespace PrismPHP\Prism\Providers\Mistral\Maps;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
 use Exception;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 class MessageMap
 {

--- a/src/Providers/Mistral/Maps/ToolChoiceMap.php
+++ b/src/Providers/Mistral/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Mistral\Maps;
+namespace PrismPHP\Prism\Providers\Mistral\Maps;
 
-use EchoLabs\Prism\Enums\ToolChoice;
 use InvalidArgumentException;
+use PrismPHP\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/Mistral/Maps/ToolMap.php
+++ b/src/Providers/Mistral/Maps/ToolMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Mistral\Maps;
+namespace PrismPHP\Prism\Providers\Mistral\Maps;
 
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Mistral;
+namespace PrismPHP\Prism\Providers\Mistral;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Mistral\Handlers\Embeddings;
-use EchoLabs\Prism\Providers\Mistral\Handlers\Text;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Mistral\Handlers\Embeddings;
+use PrismPHP\Prism\Providers\Mistral\Handlers\Text;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 readonly class Mistral implements Provider
 {

--- a/src/Providers/Ollama/Concerns/MapsFinishReason.php
+++ b/src/Providers/Ollama/Concerns/MapsFinishReason.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Ollama\Concerns;
+namespace PrismPHP\Prism\Providers\Ollama\Concerns;
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Providers\Ollama\Maps\FinishReasonMap;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Providers\Ollama\Maps\FinishReasonMap;
 
 trait MapsFinishReason
 {

--- a/src/Providers/Ollama/Concerns/MapsToolCalls.php
+++ b/src/Providers/Ollama/Concerns/MapsToolCalls.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Ollama\Concerns;
+namespace PrismPHP\Prism\Providers\Ollama\Concerns;
 
-use EchoLabs\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 trait MapsToolCalls
 {

--- a/src/Providers/Ollama/Concerns/ValidatesResponse.php
+++ b/src/Providers/Ollama/Concerns/ValidatesResponse.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Ollama\Concerns;
+namespace PrismPHP\Prism\Providers\Ollama\Concerns;
 
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismException;
 
 trait ValidatesResponse
 {

--- a/src/Providers/Ollama/Handlers/Embeddings.php
+++ b/src/Providers/Ollama/Handlers/Embeddings.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Ollama\Handlers;
+namespace PrismPHP\Prism\Providers\Ollama\Handlers;
 
-use EchoLabs\Prism\Embeddings\Request;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Embedding;
-use EchoLabs\Prism\ValueObjects\EmbeddingsUsage;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use PrismPHP\Prism\Embeddings\Request;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
 use Throwable;
 
 class Embeddings
@@ -34,7 +34,7 @@ class Embeddings
         }
 
         return new EmbeddingsResponse(
-            embeddings: array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($data, 'embeddings', [])),
+            embeddings: array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($data, 'embeddings', [])),
             usage: new EmbeddingsUsage(data_get($data, 'prompt_eval_count', null)),
         );
     }

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -2,20 +2,20 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Ollama\Handlers;
+namespace PrismPHP\Prism\Providers\Ollama\Handlers;
 
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Ollama\Concerns\MapsFinishReason;
-use EchoLabs\Prism\Providers\Ollama\Concerns\ValidatesResponse;
-use EchoLabs\Prism\Providers\Ollama\Maps\MessageMap;
-use EchoLabs\Prism\Structured\Request;
-use EchoLabs\Prism\Structured\Response;
-use EchoLabs\Prism\Structured\ResponseBuilder;
-use EchoLabs\Prism\Structured\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Ollama\Concerns\MapsFinishReason;
+use PrismPHP\Prism\Providers\Ollama\Concerns\ValidatesResponse;
+use PrismPHP\Prism\Providers\Ollama\Maps\MessageMap;
+use PrismPHP\Prism\Structured\Request;
+use PrismPHP\Prism\Structured\Response;
+use PrismPHP\Prism\Structured\ResponseBuilder;
+use PrismPHP\Prism\Structured\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Structured

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -2,26 +2,26 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Ollama\Handlers;
+namespace PrismPHP\Prism\Providers\Ollama\Handlers;
 
-use EchoLabs\Prism\Concerns\CallsTools;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Ollama\Concerns\MapsFinishReason;
-use EchoLabs\Prism\Providers\Ollama\Concerns\MapsToolCalls;
-use EchoLabs\Prism\Providers\Ollama\Concerns\ValidatesResponse;
-use EchoLabs\Prism\Providers\Ollama\Maps\MessageMap;
-use EchoLabs\Prism\Providers\Ollama\Maps\ToolMap;
-use EchoLabs\Prism\Text\Request;
-use EchoLabs\Prism\Text\Response;
-use EchoLabs\Prism\Text\ResponseBuilder;
-use EchoLabs\Prism\Text\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolResult;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
+use PrismPHP\Prism\Concerns\CallsTools;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Ollama\Concerns\MapsFinishReason;
+use PrismPHP\Prism\Providers\Ollama\Concerns\MapsToolCalls;
+use PrismPHP\Prism\Providers\Ollama\Concerns\ValidatesResponse;
+use PrismPHP\Prism\Providers\Ollama\Maps\MessageMap;
+use PrismPHP\Prism\Providers\Ollama\Maps\ToolMap;
+use PrismPHP\Prism\Text\Request;
+use PrismPHP\Prism\Text\Response;
+use PrismPHP\Prism\Text\ResponseBuilder;
+use PrismPHP\Prism\Text\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/Ollama/Maps/FinishReasonMap.php
+++ b/src/Providers/Ollama/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Ollama\Maps;
+namespace PrismPHP\Prism\Providers\Ollama\Maps;
 
-use EchoLabs\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/Ollama/Maps/MessageMap.php
+++ b/src/Providers/Ollama/Maps/MessageMap.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Ollama\Maps;
+namespace PrismPHP\Prism\Providers\Ollama\Maps;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Exception;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 
 class MessageMap
 {

--- a/src/Providers/Ollama/Maps/ToolMap.php
+++ b/src/Providers/Ollama/Maps/ToolMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Ollama\Maps;
+namespace PrismPHP\Prism\Providers\Ollama\Maps;
 
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/Ollama/Ollama.php
+++ b/src/Providers/Ollama/Ollama.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\Ollama;
+namespace PrismPHP\Prism\Providers\Ollama;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingsRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Ollama\Handlers\Embeddings;
-use EchoLabs\Prism\Providers\Ollama\Handlers\Structured;
-use EchoLabs\Prism\Providers\Ollama\Handlers\Text;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Ollama\Handlers\Embeddings;
+use PrismPHP\Prism\Providers\Ollama\Handlers\Structured;
+use PrismPHP\Prism\Providers\Ollama\Handlers\Text;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 readonly class Ollama implements Provider
 {

--- a/src/Providers/OpenAI/Concerns/MapsFinishReason.php
+++ b/src/Providers/OpenAI/Concerns/MapsFinishReason.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Concerns;
+namespace PrismPHP\Prism\Providers\OpenAI\Concerns;
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Providers\OpenAI\Maps\FinishReasonMap;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Providers\OpenAI\Maps\FinishReasonMap;
 
 trait MapsFinishReason
 {

--- a/src/Providers/OpenAI/Concerns/ValidatesResponses.php
+++ b/src/Providers/OpenAI/Concerns/ValidatesResponses.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Concerns;
+namespace PrismPHP\Prism\Providers\OpenAI\Concerns;
 
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismException;
 
 trait ValidatesResponses
 {

--- a/src/Providers/OpenAI/Handlers/Embeddings.php
+++ b/src/Providers/OpenAI/Handlers/Embeddings.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Handlers;
+namespace PrismPHP\Prism\Providers\OpenAI\Handlers;
 
-use EchoLabs\Prism\Embeddings\Request;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Embedding;
-use EchoLabs\Prism\ValueObjects\EmbeddingsUsage;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use PrismPHP\Prism\Embeddings\Request;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
 use Throwable;
 
 class Embeddings
@@ -38,7 +38,7 @@ class Embeddings
         }
 
         return new EmbeddingsResponse(
-            embeddings: array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($data, 'data', [])),
+            embeddings: array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($data, 'data', [])),
             usage: new EmbeddingsUsage(data_get($data, 'usage.total_tokens', null)),
         );
     }

--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Handlers;
+namespace PrismPHP\Prism\Providers\OpenAI\Handlers;
 
-use EchoLabs\Prism\Concerns\CallsTools;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismChunkDecodeException;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\OpenAI\Maps\FinishReasonMap;
-use EchoLabs\Prism\Providers\OpenAI\Maps\MessageMap;
-use EchoLabs\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
-use EchoLabs\Prism\Providers\OpenAI\Maps\ToolMap;
-use EchoLabs\Prism\Stream\Chunk;
-use EchoLabs\Prism\Text\Request;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Str;
+use PrismPHP\Prism\Concerns\CallsTools;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismChunkDecodeException;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\OpenAI\Maps\FinishReasonMap;
+use PrismPHP\Prism\Providers\OpenAI\Maps\MessageMap;
+use PrismPHP\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
+use PrismPHP\Prism\Providers\OpenAI\Maps\ToolMap;
+use PrismPHP\Prism\Stream\Chunk;
+use PrismPHP\Prism\Text\Request;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 use Psr\Http\Message\StreamInterface;
 use Throwable;
 

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -1,23 +1,23 @@
 <?php
 
-namespace EchoLabs\Prism\Providers\OpenAI\Handlers;
+namespace PrismPHP\Prism\Providers\OpenAI\Handlers;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Enums\StructuredMode;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
-use EchoLabs\Prism\Providers\OpenAI\Concerns\ValidatesResponses;
-use EchoLabs\Prism\Providers\OpenAI\Maps\MessageMap;
-use EchoLabs\Prism\Providers\OpenAI\Support\StructuredModeResolver;
-use EchoLabs\Prism\Structured\Request;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Structured\ResponseBuilder;
-use EchoLabs\Prism\Structured\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\StructuredMode;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
+use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponses;
+use PrismPHP\Prism\Providers\OpenAI\Maps\MessageMap;
+use PrismPHP\Prism\Providers\OpenAI\Support\StructuredModeResolver;
+use PrismPHP\Prism\Structured\Request;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Structured\ResponseBuilder;
+use PrismPHP\Prism\Structured\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Structured

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -2,27 +2,27 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Handlers;
+namespace PrismPHP\Prism\Providers\OpenAI\Handlers;
 
-use EchoLabs\Prism\Concerns\CallsTools;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
-use EchoLabs\Prism\Providers\OpenAI\Concerns\ValidatesResponses;
-use EchoLabs\Prism\Providers\OpenAI\Maps\MessageMap;
-use EchoLabs\Prism\Providers\OpenAI\Maps\ToolCallMap;
-use EchoLabs\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
-use EchoLabs\Prism\Providers\OpenAI\Maps\ToolMap;
-use EchoLabs\Prism\Text\Request;
-use EchoLabs\Prism\Text\Response;
-use EchoLabs\Prism\Text\ResponseBuilder;
-use EchoLabs\Prism\Text\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolResult;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
+use PrismPHP\Prism\Concerns\CallsTools;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
+use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponses;
+use PrismPHP\Prism\Providers\OpenAI\Maps\MessageMap;
+use PrismPHP\Prism\Providers\OpenAI\Maps\ToolCallMap;
+use PrismPHP\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
+use PrismPHP\Prism\Providers\OpenAI\Maps\ToolMap;
+use PrismPHP\Prism\Text\Request;
+use PrismPHP\Prism\Text\Response;
+use PrismPHP\Prism\Text\ResponseBuilder;
+use PrismPHP\Prism\Text\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/OpenAI/Maps/FinishReasonMap.php
+++ b/src/Providers/OpenAI/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Maps;
+namespace PrismPHP\Prism\Providers\OpenAI\Maps;
 
-use EchoLabs\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/OpenAI/Maps/MessageMap.php
+++ b/src/Providers/OpenAI/Maps/MessageMap.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Maps;
+namespace PrismPHP\Prism\Providers\OpenAI\Maps;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
 use Exception;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 class MessageMap
 {

--- a/src/Providers/OpenAI/Maps/ToolCallMap.php
+++ b/src/Providers/OpenAI/Maps/ToolCallMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Maps;
+namespace PrismPHP\Prism\Providers\OpenAI\Maps;
 
-use EchoLabs\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 class ToolCallMap
 {

--- a/src/Providers/OpenAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/OpenAI/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Maps;
+namespace PrismPHP\Prism\Providers\OpenAI\Maps;
 
-use EchoLabs\Prism\Enums\ToolChoice;
 use InvalidArgumentException;
+use PrismPHP\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/OpenAI/Maps/ToolMap.php
+++ b/src/Providers/OpenAI/Maps/ToolMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Maps;
+namespace PrismPHP\Prism\Providers\OpenAI\Maps;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI;
+namespace PrismPHP\Prism\Providers\OpenAI;
 
 use Closure;
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingsRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Providers\OpenAI\Handlers\Embeddings;
-use EchoLabs\Prism\Providers\OpenAI\Handlers\Stream;
-use EchoLabs\Prism\Providers\OpenAI\Handlers\Structured;
-use EchoLabs\Prism\Providers\OpenAI\Handlers\Text;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Providers\OpenAI\Handlers\Embeddings;
+use PrismPHP\Prism\Providers\OpenAI\Handlers\Stream;
+use PrismPHP\Prism\Providers\OpenAI\Handlers\Structured;
+use PrismPHP\Prism\Providers\OpenAI\Handlers\Text;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 readonly class OpenAI implements Provider
 {

--- a/src/Providers/OpenAI/Support/StructuredModeResolver.php
+++ b/src/Providers/OpenAI/Support/StructuredModeResolver.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\OpenAI\Support;
+namespace PrismPHP\Prism\Providers\OpenAI\Support;
 
-use EchoLabs\Prism\Enums\StructuredMode;
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Enums\StructuredMode;
+use PrismPHP\Prism\Exceptions\PrismException;
 
 class StructuredModeResolver
 {

--- a/src/Providers/VoyageAI/Embeddings.php
+++ b/src/Providers/VoyageAI/Embeddings.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace EchoLabs\Prism\Providers\VoyageAI;
+namespace PrismPHP\Prism\Providers\VoyageAI;
 
-use EchoLabs\Prism\Embeddings\Request as EmbeddingsRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Embedding;
-use EchoLabs\Prism\ValueObjects\EmbeddingsUsage;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
 
 class Embeddings
 {

--- a/src/Providers/VoyageAI/VoyageAI.php
+++ b/src/Providers/VoyageAI/VoyageAI.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace EchoLabs\Prism\Providers\VoyageAI;
+namespace PrismPHP\Prism\Providers\VoyageAI;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingsResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 class VoyageAI implements Provider
 {

--- a/src/Providers/XAI/Concerns/MapsFinishReason.php
+++ b/src/Providers/XAI/Concerns/MapsFinishReason.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\XAI\Concerns;
+namespace PrismPHP\Prism\Providers\XAI\Concerns;
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Providers\XAI\Maps\FinishReasonMap;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Providers\XAI\Maps\FinishReasonMap;
 
 trait MapsFinishReason
 {

--- a/src/Providers/XAI/Concerns/ValidatesResponses.php
+++ b/src/Providers/XAI/Concerns/ValidatesResponses.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\XAI\Concerns;
+namespace PrismPHP\Prism\Providers\XAI\Concerns;
 
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismException;
 
 trait ValidatesResponses
 {

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -2,27 +2,27 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\XAI\Handlers;
+namespace PrismPHP\Prism\Providers\XAI\Handlers;
 
-use EchoLabs\Prism\Concerns\CallsTools;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\XAI\Concerns\MapsFinishReason;
-use EchoLabs\Prism\Providers\XAI\Concerns\ValidatesResponses;
-use EchoLabs\Prism\Providers\XAI\Maps\MessageMap;
-use EchoLabs\Prism\Providers\XAI\Maps\ToolChoiceMap;
-use EchoLabs\Prism\Providers\XAI\Maps\ToolMap;
-use EchoLabs\Prism\Text\Request;
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\Text\ResponseBuilder;
-use EchoLabs\Prism\Text\Step;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Http\Client\PendingRequest;
+use PrismPHP\Prism\Concerns\CallsTools;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\XAI\Concerns\MapsFinishReason;
+use PrismPHP\Prism\Providers\XAI\Concerns\ValidatesResponses;
+use PrismPHP\Prism\Providers\XAI\Maps\MessageMap;
+use PrismPHP\Prism\Providers\XAI\Maps\ToolChoiceMap;
+use PrismPHP\Prism\Providers\XAI\Maps\ToolMap;
+use PrismPHP\Prism\Text\Request;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\Text\ResponseBuilder;
+use PrismPHP\Prism\Text\Step;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/XAI/Maps/FinishReasonMap.php
+++ b/src/Providers/XAI/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\XAI\Maps;
+namespace PrismPHP\Prism\Providers\XAI\Maps;
 
-use EchoLabs\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/XAI/Maps/MessageMap.php
+++ b/src/Providers/XAI/Maps/MessageMap.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\XAI\Maps;
+namespace PrismPHP\Prism\Providers\XAI\Maps;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
 use Exception;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 class MessageMap
 {

--- a/src/Providers/XAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/XAI/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\XAI\Maps;
+namespace PrismPHP\Prism\Providers\XAI\Maps;
 
-use EchoLabs\Prism\Enums\ToolChoice;
 use InvalidArgumentException;
+use PrismPHP\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/XAI/Maps/ToolMap.php
+++ b/src/Providers/XAI/Maps/ToolMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\XAI\Maps;
+namespace PrismPHP\Prism\Providers\XAI\Maps;
 
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/XAI/XAI.php
+++ b/src/Providers/XAI/XAI.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Providers\XAI;
+namespace PrismPHP\Prism\Providers\XAI;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\XAI\Handlers\Text;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\XAI\Handlers\Text;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 readonly class XAI implements Provider
 {

--- a/src/Rectors/ReorderMethodsRector.php
+++ b/src/Rectors/ReorderMethodsRector.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EchoLabs\Prism\Rectors;
+namespace PrismPHP\Prism\Rectors;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;

--- a/src/Routes/PrismServer.php
+++ b/src/Routes/PrismServer.php
@@ -1,8 +1,8 @@
 <?php
 
-use EchoLabs\Prism\Http\Controllers\PrismChatController;
-use EchoLabs\Prism\Http\Controllers\PrismModelController;
 use Illuminate\Support\Facades\Route;
+use PrismPHP\Prism\Http\Controllers\PrismChatController;
+use PrismPHP\Prism\Http\Controllers\PrismModelController;
 
 Route::prefix('/prism/openai/v1')
     ->group(function (): void {

--- a/src/Schema/ArraySchema.php
+++ b/src/Schema/ArraySchema.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Schema;
+namespace PrismPHP\Prism\Schema;
 
-use EchoLabs\Prism\Concerns\NullableSchema;
-use EchoLabs\Prism\Contracts\Schema;
+use PrismPHP\Prism\Concerns\NullableSchema;
+use PrismPHP\Prism\Contracts\Schema;
 
 class ArraySchema implements Schema
 {

--- a/src/Schema/BooleanSchema.php
+++ b/src/Schema/BooleanSchema.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Schema;
+namespace PrismPHP\Prism\Schema;
 
-use EchoLabs\Prism\Concerns\NullableSchema;
-use EchoLabs\Prism\Contracts\Schema;
+use PrismPHP\Prism\Concerns\NullableSchema;
+use PrismPHP\Prism\Contracts\Schema;
 
 class BooleanSchema implements Schema
 {

--- a/src/Schema/EnumSchema.php
+++ b/src/Schema/EnumSchema.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Schema;
+namespace PrismPHP\Prism\Schema;
 
-use EchoLabs\Prism\Contracts\Schema;
+use PrismPHP\Prism\Contracts\Schema;
 
 readonly class EnumSchema implements Schema
 {

--- a/src/Schema/NumberSchema.php
+++ b/src/Schema/NumberSchema.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Schema;
+namespace PrismPHP\Prism\Schema;
 
-use EchoLabs\Prism\Concerns\NullableSchema;
-use EchoLabs\Prism\Contracts\Schema;
+use PrismPHP\Prism\Concerns\NullableSchema;
+use PrismPHP\Prism\Contracts\Schema;
 
 class NumberSchema implements Schema
 {

--- a/src/Schema/ObjectSchema.php
+++ b/src/Schema/ObjectSchema.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Schema;
+namespace PrismPHP\Prism\Schema;
 
-use EchoLabs\Prism\Concerns\NullableSchema;
-use EchoLabs\Prism\Contracts\Schema;
+use PrismPHP\Prism\Concerns\NullableSchema;
+use PrismPHP\Prism\Contracts\Schema;
 
 class ObjectSchema implements Schema
 {

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Schema;
+namespace PrismPHP\Prism\Schema;
 
-use EchoLabs\Prism\Concerns\NullableSchema;
-use EchoLabs\Prism\Contracts\Schema;
+use PrismPHP\Prism\Concerns\NullableSchema;
+use PrismPHP\Prism\Contracts\Schema;
 
 class StringSchema implements Schema
 {

--- a/src/Stream/Chunk.php
+++ b/src/Stream/Chunk.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Stream;
+namespace PrismPHP\Prism\Stream;
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 readonly class Chunk
 {

--- a/src/Stream/PendingRequest.php
+++ b/src/Stream/PendingRequest.php
@@ -2,20 +2,20 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Stream;
+namespace PrismPHP\Prism\Stream;
 
-use EchoLabs\Prism\Concerns\ConfiguresClient;
-use EchoLabs\Prism\Concerns\ConfiguresGeneration;
-use EchoLabs\Prism\Concerns\ConfiguresModels;
-use EchoLabs\Prism\Concerns\ConfiguresProviders;
-use EchoLabs\Prism\Concerns\ConfiguresTools;
-use EchoLabs\Prism\Concerns\HasMessages;
-use EchoLabs\Prism\Concerns\HasPrompts;
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Concerns\HasTools;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Generator;
+use PrismPHP\Prism\Concerns\ConfiguresClient;
+use PrismPHP\Prism\Concerns\ConfiguresGeneration;
+use PrismPHP\Prism\Concerns\ConfiguresModels;
+use PrismPHP\Prism\Concerns\ConfiguresProviders;
+use PrismPHP\Prism\Concerns\ConfiguresTools;
+use PrismPHP\Prism\Concerns\HasMessages;
+use PrismPHP\Prism\Concerns\HasPrompts;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Concerns\HasTools;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 
 class PendingRequest
 {

--- a/src/Stream/Request.php
+++ b/src/Stream/Request.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Stream;
+namespace PrismPHP\Prism\Stream;
 
-use EchoLabs\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Request as TextRequest;
 
 class Request extends TextRequest
 {

--- a/src/Stream/Response.php
+++ b/src/Stream/Response.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Stream;
+namespace PrismPHP\Prism\Stream;
 
-use EchoLabs\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\Text\Response as TextResponse;
 
 readonly class Response extends TextResponse
 {

--- a/src/Stream/ResponseBuilder.php
+++ b/src/Stream/ResponseBuilder.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Stream;
+namespace PrismPHP\Prism\Stream;
 
-use EchoLabs\Prism\Text\ResponseBuilder as TextResponseBuilder;
+use PrismPHP\Prism\Text\ResponseBuilder as TextResponseBuilder;
 
 readonly class ResponseBuilder extends TextResponseBuilder
 {

--- a/src/Stream/Step.php
+++ b/src/Stream/Step.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Stream;
+namespace PrismPHP\Prism\Stream;
 
-use EchoLabs\Prism\Text\Step as TextStep;
+use PrismPHP\Prism\Text\Step as TextStep;
 
 readonly class Step extends TextStep
 {

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Structured;
+namespace PrismPHP\Prism\Structured;
 
-use EchoLabs\Prism\Concerns\ConfiguresClient;
-use EchoLabs\Prism\Concerns\ConfiguresModels;
-use EchoLabs\Prism\Concerns\ConfiguresProviders;
-use EchoLabs\Prism\Concerns\ConfiguresStructuredOutput;
-use EchoLabs\Prism\Concerns\HasMessages;
-use EchoLabs\Prism\Concerns\HasPrompts;
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Concerns\HasSchema;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\Concerns\ConfiguresClient;
+use PrismPHP\Prism\Concerns\ConfiguresModels;
+use PrismPHP\Prism\Concerns\ConfiguresProviders;
+use PrismPHP\Prism\Concerns\ConfiguresStructuredOutput;
+use PrismPHP\Prism\Concerns\HasMessages;
+use PrismPHP\Prism\Concerns\HasPrompts;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Concerns\HasSchema;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 
 class PendingRequest
 {
@@ -43,7 +43,7 @@ class PendingRequest
             $messages[] = new UserMessage($this->prompt);
         }
 
-        if (! $this->schema instanceof \EchoLabs\Prism\Contracts\Schema) {
+        if (! $this->schema instanceof \PrismPHP\Prism\Contracts\Schema) {
             throw new PrismException('A schema is required for structured output');
         }
 

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Structured;
+namespace PrismPHP\Prism\Structured;
 
 use Closure;
-use EchoLabs\Prism\Concerns\ChecksSelf;
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\Contracts\PrismRequest;
-use EchoLabs\Prism\Contracts\Schema;
-use EchoLabs\Prism\Enums\StructuredMode;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\Concerns\ChecksSelf;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\Contracts\PrismRequest;
+use PrismPHP\Prism\Contracts\Schema;
+use PrismPHP\Prism\Enums\StructuredMode;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
 
 class Request implements PrismRequest
 {

--- a/src/Structured/Response.php
+++ b/src/Structured/Response.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Structured;
+namespace PrismPHP\Prism\Structured;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Support\Collection;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 readonly class Response
 {

--- a/src/Structured/ResponseBuilder.php
+++ b/src/Structured/ResponseBuilder.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Structured;
+namespace PrismPHP\Prism\Structured;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismStructuredDecodingException;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Support\Collection;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismStructuredDecodingException;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 readonly class ResponseBuilder
 {

--- a/src/Structured/Step.php
+++ b/src/Structured/Step.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Structured;
+namespace PrismPHP\Prism\Structured;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 readonly class Step
 {

--- a/src/Testing/PrismFake.php
+++ b/src/Testing/PrismFake.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Testing;
+namespace PrismPHP\Prism\Testing;
 
 use Closure;
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\ValueObjects\EmbeddingsUsage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Exception;
 use Generator;
 use PHPUnit\Framework\Assert as PHPUnit;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 class PrismFake implements Provider
 {

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Text;
+namespace PrismPHP\Prism\Text;
 
-use EchoLabs\Prism\Concerns\ConfiguresClient;
-use EchoLabs\Prism\Concerns\ConfiguresGeneration;
-use EchoLabs\Prism\Concerns\ConfiguresModels;
-use EchoLabs\Prism\Concerns\ConfiguresProviders;
-use EchoLabs\Prism\Concerns\ConfiguresTools;
-use EchoLabs\Prism\Concerns\HasMessages;
-use EchoLabs\Prism\Concerns\HasPrompts;
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Concerns\HasTools;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\Concerns\ConfiguresClient;
+use PrismPHP\Prism\Concerns\ConfiguresGeneration;
+use PrismPHP\Prism\Concerns\ConfiguresModels;
+use PrismPHP\Prism\Concerns\ConfiguresProviders;
+use PrismPHP\Prism\Concerns\ConfiguresTools;
+use PrismPHP\Prism\Concerns\HasMessages;
+use PrismPHP\Prism\Concerns\HasPrompts;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Concerns\HasTools;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 
 class PendingRequest
 {

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Text;
+namespace PrismPHP\Prism\Text;
 
 use Closure;
-use EchoLabs\Prism\Concerns\ChecksSelf;
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\Contracts\PrismRequest;
-use EchoLabs\Prism\Enums\ToolChoice;
-use EchoLabs\Prism\Tool;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\Concerns\ChecksSelf;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\Contracts\PrismRequest;
+use PrismPHP\Prism\Enums\ToolChoice;
+use PrismPHP\Prism\Tool;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
 
 class Request implements PrismRequest
 {

--- a/src/Text/Response.php
+++ b/src/Text/Response.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Text;
+namespace PrismPHP\Prism\Text;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Support\Collection;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 readonly class Response
 {

--- a/src/Text/ResponseBuilder.php
+++ b/src/Text/ResponseBuilder.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Text;
+namespace PrismPHP\Prism\Text;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Support\Collection;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 readonly class ResponseBuilder
 {

--- a/src/Text/Step.php
+++ b/src/Text/Step.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\Text;
+namespace PrismPHP\Prism\Text;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
-use EchoLabs\Prism\ValueObjects\Usage;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 readonly class Step
 {

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism;
+namespace PrismPHP\Prism;
 
 use ArgumentCountError;
 use Closure;
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Contracts\Schema;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Schema\ArraySchema;
-use EchoLabs\Prism\Schema\BooleanSchema;
-use EchoLabs\Prism\Schema\EnumSchema;
-use EchoLabs\Prism\Schema\NumberSchema;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
 use Error;
 use InvalidArgumentException;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Contracts\Schema;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Schema\ArraySchema;
+use PrismPHP\Prism\Schema\BooleanSchema;
+use PrismPHP\Prism\Schema\EnumSchema;
+use PrismPHP\Prism\Schema\NumberSchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
 use Throwable;
 use TypeError;
 

--- a/src/ValueObjects/Embedding.php
+++ b/src/ValueObjects/Embedding.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects;
+namespace PrismPHP\Prism\ValueObjects;
 
 class Embedding
 {

--- a/src/ValueObjects/EmbeddingsUsage.php
+++ b/src/ValueObjects/EmbeddingsUsage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects;
+namespace PrismPHP\Prism\ValueObjects;
 
 readonly class EmbeddingsUsage
 {

--- a/src/ValueObjects/Messages/AssistantMessage.php
+++ b/src/ValueObjects/Messages/AssistantMessage.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects\Messages;
+namespace PrismPHP\Prism\ValueObjects\Messages;
 
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\ValueObjects\ToolCall;
 
 class AssistantMessage implements Message
 {

--- a/src/ValueObjects/Messages/Support/Document.php
+++ b/src/ValueObjects/Messages/Support/Document.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects\Messages\Support;
+namespace PrismPHP\Prism\ValueObjects\Messages\Support;
 
-use EchoLabs\Prism\Concerns\HasProviderMeta;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
 
 /**
  * Note: Prism currently only supports Documents with Anthropic.

--- a/src/ValueObjects/Messages/Support/Image.php
+++ b/src/ValueObjects/Messages/Support/Image.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects\Messages\Support;
+namespace PrismPHP\Prism\ValueObjects\Messages\Support;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;

--- a/src/ValueObjects/Messages/Support/Text.php
+++ b/src/ValueObjects/Messages/Support/Text.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects\Messages\Support;
+namespace PrismPHP\Prism\ValueObjects\Messages\Support;
 
 readonly class Text
 {

--- a/src/ValueObjects/Messages/SystemMessage.php
+++ b/src/ValueObjects/Messages/SystemMessage.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects\Messages;
+namespace PrismPHP\Prism\ValueObjects\Messages;
 
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Contracts\Message;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Contracts\Message;
 
 class SystemMessage implements Message
 {

--- a/src/ValueObjects/Messages/ToolResultMessage.php
+++ b/src/ValueObjects/Messages/ToolResultMessage.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects\Messages;
+namespace PrismPHP\Prism\ValueObjects\Messages;
 
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 readonly class ToolResultMessage implements Message
 {

--- a/src/ValueObjects/Messages/UserMessage.php
+++ b/src/ValueObjects/Messages/UserMessage.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects\Messages;
+namespace PrismPHP\Prism\ValueObjects\Messages;
 
-use EchoLabs\Prism\Concerns\HasProviderMeta;
-use EchoLabs\Prism\Contracts\Message;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Text;
+use PrismPHP\Prism\Concerns\HasProviderMeta;
+use PrismPHP\Prism\Contracts\Message;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Text;
 
 class UserMessage implements Message
 {

--- a/src/ValueObjects/Meta.php
+++ b/src/ValueObjects/Meta.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects;
+namespace PrismPHP\Prism\ValueObjects;
 
 readonly class Meta
 {

--- a/src/ValueObjects/ProviderRateLimit.php
+++ b/src/ValueObjects/ProviderRateLimit.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EchoLabs\Prism\ValueObjects;
+namespace PrismPHP\Prism\ValueObjects;
 
 use Carbon\Carbon;
 

--- a/src/ValueObjects/ToolCall.php
+++ b/src/ValueObjects/ToolCall.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects;
+namespace PrismPHP\Prism\ValueObjects;
 
 class ToolCall
 {

--- a/src/ValueObjects/ToolResult.php
+++ b/src/ValueObjects/ToolResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects;
+namespace PrismPHP\Prism\ValueObjects;
 
 readonly class ToolResult
 {

--- a/src/ValueObjects/Usage.php
+++ b/src/ValueObjects/Usage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EchoLabs\Prism\ValueObjects;
+namespace PrismPHP\Prism\ValueObjects;
 
 readonly class Usage
 {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Prism;
 use Illuminate\Support\Facades\App;
+use PrismPHP\Prism\Prism;
 
 if (! function_exists('prism')) {
 

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,5 +1,5 @@
 providers:
-  - EchoLabs\Prism\PrismServiceProvider
+  - PrismPHP\Prism\PrismServiceProvider
   - Workbench\App\Providers\WorkbenchServiceProvider
 
 migrations:

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -8,13 +8,13 @@ describe('Arch presets', function (): void {
 
 describe('Custom relaxed preset', function (): void {
     arch('No final classes')
-        ->expect('EchoLabs\Prism')
+        ->expect('PrismPHP\Prism')
         ->classes()
         ->not
         ->toBeFinal();
 
     arch('No private methods')
-        ->expect('EchoLabs\Prism')
+        ->expect('PrismPHP\Prism')
         ->classes()
         ->not
         ->toHavePrivateMethods();

--- a/tests/Concerns/HasProviderMetaTest.php
+++ b/tests/Concerns/HasProviderMetaTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Http;
 
-use EchoLabs\Prism\Text\PendingRequest;
+use PrismPHP\Prism\Text\PendingRequest;
 
 test('providerMeta returns an array with all providerMeta if no valuePath is provided.', function (): void {
     $class = new PendingRequest;

--- a/tests/Fixtures/test-embedding-file.md
+++ b/tests/Fixtures/test-embedding-file.md
@@ -7,8 +7,8 @@ Prism provides a powerful interface for generating text using Large Language Mod
 At its simplest, you can generate text with just a few lines of code:
 
 ```php
-use EchoLabs\Prism\Facades\Prism;
-use EchoLabs\Prism\Enums\Provider;
+use PrismPHP\Prism\Facades\Prism;
+use PrismPHP\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-sonnet')
@@ -47,8 +47,8 @@ You an also pass a View to the `withPrompt` method.
 For interactive conversations, use message chains to maintain context:
 
 ```php
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-sonnet')
@@ -75,7 +75,7 @@ $response = Prism::text()
 Prism supports including images in your messages for visual analysis:
 
 ```php
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
 
 // From a local file
 $message = new UserMessage(
@@ -188,7 +188,7 @@ case Unknown;
 Remember to handle potential errors in your generations:
 
 ```php
-use EchoLabs\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismException;
 use Throwable;
 
 try {

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Prism;
+use PrismPHP\Prism\Prism;
 
 it('can resolve prism from the container with helper function', function (): void {
     expect(prism())->toBeInstanceOf(Prism::class);

--- a/tests/Http/PrismChatControllerTest.php
+++ b/tests/Http/PrismChatControllerTest.php
@@ -2,18 +2,18 @@
 
 namespace Tests\Http;
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Facades\PrismServer;
-use EchoLabs\Prism\Text\PendingRequest;
-use EchoLabs\Prism\Text\Response;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 use Mockery;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Facades\PrismServer;
+use PrismPHP\Prism\Text\PendingRequest;
+use PrismPHP\Prism\Text\Response;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 beforeEach(function (): void {
     config()->set('prism.prism_server.enabled', true);

--- a/tests/Http/PrismModelControllerTest.php
+++ b/tests/Http/PrismModelControllerTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Http;
 
-use EchoLabs\Prism\Facades\PrismServer;
-use EchoLabs\Prism\Text\Generator;
 use Illuminate\Testing\TestResponse;
+use PrismPHP\Prism\Facades\PrismServer;
+use PrismPHP\Prism\Text\Generator;
 
 it('it returns prisms', function (): void {
-    PrismServer::register('nyx', fn (): \EchoLabs\Prism\Text\Generator => new Generator);
-    PrismServer::register('omni', fn (): \EchoLabs\Prism\Text\Generator => new Generator);
+    PrismServer::register('nyx', fn (): \PrismPHP\Prism\Text\Generator => new Generator);
+    PrismServer::register('omni', fn (): \PrismPHP\Prism\Text\Generator => new Generator);
 
     /** @var TestResponse */
     $response = $this->getJson('/prism/openai/v1/models');

--- a/tests/PrismManagerTest.php
+++ b/tests/PrismManagerTest.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use EchoLabs\Prism\Contracts\Provider as ContractsProvider;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\PrismManager;
-use EchoLabs\Prism\Providers\Anthropic\Anthropic;
-use EchoLabs\Prism\Providers\DeepSeek\DeepSeek;
-use EchoLabs\Prism\Providers\Gemini\Gemini;
-use EchoLabs\Prism\Providers\Mistral\Mistral;
-use EchoLabs\Prism\Providers\Ollama\Ollama;
-use EchoLabs\Prism\Providers\OpenAI\OpenAI;
-use EchoLabs\Prism\Providers\XAI\XAI;
 use Illuminate\Contracts\Foundation\Application;
 use Mockery;
+use PrismPHP\Prism\Contracts\Provider as ContractsProvider;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\PrismManager;
+use PrismPHP\Prism\Providers\Anthropic\Anthropic;
+use PrismPHP\Prism\Providers\DeepSeek\DeepSeek;
+use PrismPHP\Prism\Providers\Gemini\Gemini;
+use PrismPHP\Prism\Providers\Mistral\Mistral;
+use PrismPHP\Prism\Providers\Ollama\Ollama;
+use PrismPHP\Prism\Providers\OpenAI\OpenAI;
+use PrismPHP\Prism\Providers\XAI\XAI;
 
 it('can resolve Anthropic', function (): void {
     $manager = new PrismManager($this->app);

--- a/tests/Providers/Anthropic/AnthropicExceptionsTest.php
+++ b/tests/Providers/Anthropic/AnthropicExceptionsTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use EchoLabs\Prism\Exceptions\PrismProviderOverloadedException;
-use EchoLabs\Prism\Exceptions\PrismRateLimitedException;
-use EchoLabs\Prism\Exceptions\PrismRequestTooLargeException;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Exceptions\PrismProviderOverloadedException;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use PrismPHP\Prism\Exceptions\PrismRequestTooLargeException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 
 it('throws a RateLimitException if the Anthropic responds with a 429', function (): void {
     Http::fake([

--- a/tests/Providers/Anthropic/AnthropicTextTest.php
+++ b/tests/Providers/Anthropic/AnthropicTextTest.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Anthropic;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Providers\Anthropic\Handlers\Text;
-use EchoLabs\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Providers\Anthropic\Handlers\Text;
+use PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/Anthropic/MessageMapTest.php
+++ b/tests/Providers/Anthropic/MessageMapTest.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Anthropic;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
-use EchoLabs\Prism\Providers\Anthropic\Maps\MessageMap;
-use EchoLabs\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
 use InvalidArgumentException;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
+use PrismPHP\Prism\Providers\Anthropic\Maps\MessageMap;
+use PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 describe('Anthropic user message mapping', function (): void {
 

--- a/tests/Providers/Anthropic/StructuredTest.php
+++ b/tests/Providers/Anthropic/StructuredTest.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Anthropic;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Providers\Anthropic\Handlers\Structured;
-use EchoLabs\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
-use EchoLabs\Prism\Schema\BooleanSchema;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ProviderRateLimit;
 use Illuminate\Support\Carbon;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Providers\Anthropic\Handlers\Structured;
+use PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
+use PrismPHP\Prism\Schema\BooleanSchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/Anthropic/ToolMapTest.php
+++ b/tests/Providers/Anthropic/ToolMapTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Anthropic;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
-use EchoLabs\Prism\Providers\Anthropic\Maps\ToolMap;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
+use PrismPHP\Prism\Providers\Anthropic\Maps\ToolMap;
+use PrismPHP\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/DeepSeek/EmbeddingsTest.php
+++ b/tests/Providers/DeepSeek/EmbeddingsTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Prism;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Prism;
 
 beforeEach(function (): void {
     config()->set('prism.providers.deepseek.api_key', env('DEEPSEEK_API_KEY'));

--- a/tests/Providers/DeepSeek/MessageMapTest.php
+++ b/tests/Providers/DeepSeek/MessageMapTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Providers\DeepSeek\Maps\MessageMap;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\Providers\DeepSeek\Maps\MessageMap;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/DeepSeek/StructuredTest.php
+++ b/tests/Providers/DeepSeek/StructuredTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Schema\BooleanSchema;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Schema\BooleanSchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/DeepSeek/TextTest.php
+++ b/tests/Providers/DeepSeek/TextTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Text\Response as TextResponse;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/DeepSeek/ToolTest.php
+++ b/tests/Providers/DeepSeek/ToolTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Providers\DeepSeek\Maps\ToolMap;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Providers\DeepSeek\Maps\ToolMap;
+use PrismPHP\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/Gemini/EmbeddingsTest.php
+++ b/tests/Providers/Gemini/EmbeddingsTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Gemini;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Embedding;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Embedding;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/Gemini/GeminiStructuredTest.php
+++ b/tests/Providers/Gemini/GeminiStructuredTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Schema\ArraySchema;
-use EchoLabs\Prism\Schema\BooleanSchema;
-use EchoLabs\Prism\Schema\EnumSchema;
-use EchoLabs\Prism\Schema\NumberSchema;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Schema\ArraySchema;
+use PrismPHP\Prism\Schema\BooleanSchema;
+use PrismPHP\Prism\Schema\EnumSchema;
+use PrismPHP\Prism\Schema\NumberSchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/Gemini/GeminiTextTest.php
+++ b/tests/Providers/Gemini/GeminiTextTest.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Gemini;
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Tool;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Tool;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/Gemini/MessageMapTest.php
+++ b/tests/Providers/Gemini/MessageMapTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Gemini;
 
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Providers\Gemini\Maps\MessageMap;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Providers\Gemini\Maps\MessageMap;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/Gemini/SchemaMapTest.php
+++ b/tests/Providers/Gemini/SchemaMapTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Providers\Gemini\Maps\SchemaMap;
-use EchoLabs\Prism\Schema\ArraySchema;
-use EchoLabs\Prism\Schema\BooleanSchema;
-use EchoLabs\Prism\Schema\EnumSchema;
-use EchoLabs\Prism\Schema\NumberSchema;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Providers\Gemini\Maps\SchemaMap;
+use PrismPHP\Prism\Schema\ArraySchema;
+use PrismPHP\Prism\Schema\BooleanSchema;
+use PrismPHP\Prism\Schema\EnumSchema;
+use PrismPHP\Prism\Schema\NumberSchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
 
 it('maps array schema correctly', function (): void {
     $map = (new SchemaMap(new ArraySchema(

--- a/tests/Providers/Gemini/ToolChoiceMapTest.php
+++ b/tests/Providers/Gemini/ToolChoiceMapTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Gemini;
 
-use EchoLabs\Prism\Enums\ToolChoice;
-use EchoLabs\Prism\Providers\Gemini\Maps\ToolChoiceMap;
+use PrismPHP\Prism\Enums\ToolChoice;
+use PrismPHP\Prism\Providers\Gemini\Maps\ToolChoiceMap;
 
 it('maps string tool choice to ANY mode with allowed function', function (): void {
     expect(ToolChoiceMap::map('weather'))->toBe([

--- a/tests/Providers/Gemini/ToolTest.php
+++ b/tests/Providers/Gemini/ToolTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Gemini;
 
-use EchoLabs\Prism\Providers\Gemini\Maps\ToolMap;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Providers\Gemini\Maps\ToolMap;
+use PrismPHP\Prism\Tool;
 
 it('maps tools to gemini format', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/Groq/GroqTextTest.php
+++ b/tests/Providers/Groq/GroqTextTest.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Groq;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Enums\ToolChoice;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\ToolChoice;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/Groq/MessageMapTest.php
+++ b/tests/Providers/Groq/MessageMapTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Groq;
 
-use EchoLabs\Prism\Providers\Groq\Maps\MessageMap;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\Providers\Groq\Maps\MessageMap;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/Groq/ToolTest.php
+++ b/tests/Providers/Groq/ToolTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Groq;
 
-use EchoLabs\Prism\Providers\Groq\Maps\ToolMap;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Providers\Groq\Maps\ToolMap;
+use PrismPHP\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/Mistral/EmbeddingsTest.php
+++ b/tests/Providers/Mistral/EmbeddingsTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Embedding;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {
@@ -21,7 +21,7 @@ it('returns embeddings from input', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/mistral/embeddings-input-1.json'), true);
-    $embeddings = array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
+    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);
@@ -37,7 +37,7 @@ it('returns embeddings from file', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/mistral/embeddings-file-1.json'), true);
-    $embeddings = array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
+    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);
@@ -56,7 +56,7 @@ it('works with multiple embeddings', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/mistral/embeddings-multiple-inputs-1.json'), true);
-    $embeddings = array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
+    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);

--- a/tests/Providers/Mistral/MessageMapTest.php
+++ b/tests/Providers/Mistral/MessageMapTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Mistral;
 
-use EchoLabs\Prism\Providers\Mistral\Maps\MessageMap;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\Providers\Mistral\Maps\MessageMap;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/Mistral/MistralTextTest.php
+++ b/tests/Providers/Mistral/MistralTextTest.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Mistral;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Enums\ToolChoice;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\ToolChoice;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/Mistral/ToolTest.php
+++ b/tests/Providers/Mistral/ToolTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Mistral;
 
-use EchoLabs\Prism\Providers\Mistral\Maps\ToolMap;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Providers\Mistral\Maps\ToolMap;
+use PrismPHP\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/Ollama/EmbeddingsTest.php
+++ b/tests/Providers/Ollama/EmbeddingsTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Ollama;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Embedding;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns embeddings from input', function (): void {
@@ -18,7 +18,7 @@ it('returns embeddings from input', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/ollama/embeddings-input-1.json'), true);
-    $embeddings = array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
+    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);
@@ -34,7 +34,7 @@ it('returns embeddings from file', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/ollama/embeddings-file-1.json'), true);
-    $embeddings = array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
+    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);
@@ -53,7 +53,7 @@ it('works with multiple embeddings', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/ollama/embeddings-multiple-inputs-1.json'), true);
-    $embeddings = array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
+    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);

--- a/tests/Providers/Ollama/MessageMapTest.php
+++ b/tests/Providers/Ollama/MessageMapTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Providers\Ollama\Maps\MessageMap;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\Providers\Ollama\Maps\MessageMap;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 it('maps system messages correctly', function (): void {
     $systemMessage = new SystemMessage('System instruction');
@@ -135,7 +135,7 @@ it('maps multiple messages in sequence correctly', function (): void {
 });
 
 it('throws exception for unknown message type', function (): void {
-    $invalidMessage = new class implements \EchoLabs\Prism\Contracts\Message {};
+    $invalidMessage = new class implements \PrismPHP\Prism\Contracts\Message {};
     $messageMap = new MessageMap([$invalidMessage]);
 
     expect(fn (): array => $messageMap->map())

--- a/tests/Providers/Ollama/StructuredTest.php
+++ b/tests/Providers/Ollama/StructuredTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Ollama;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Schema\ArraySchema;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Schema\ArraySchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/Ollama/TextTest.php
+++ b/tests/Providers/Ollama/TextTest.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Ollama;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 use Tests\Fixtures\FixtureResponse;
 
 describe('Text generation', function (): void {

--- a/tests/Providers/Ollama/ToolTest.php
+++ b/tests/Providers/Ollama/ToolTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use EchoLabs\Prism\Providers\Ollama\Maps\ToolMap;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Providers\Ollama\Maps\ToolMap;
+use PrismPHP\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/OpenAI/EmbeddingsTest.php
+++ b/tests/Providers/OpenAI/EmbeddingsTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Embedding;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {
@@ -22,7 +22,7 @@ it('returns embeddings from input', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/openai/embeddings-input-1.json'), true);
-    $embeddings = array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
+    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);
@@ -38,7 +38,7 @@ it('returns embeddings from file', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/openai/embeddings-file-1.json'), true);
-    $embeddings = array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
+    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);
@@ -57,7 +57,7 @@ it('works with multiple embeddings', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/openai/embeddings-multiple-inputs-1.json'), true);
-    $embeddings = array_map(fn (array $item): \EchoLabs\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
+    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);

--- a/tests/Providers/OpenAI/MessageMapTest.php
+++ b/tests/Providers/OpenAI/MessageMapTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use EchoLabs\Prism\Providers\OpenAI\Maps\MessageMap;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\Providers\OpenAI\Maps\MessageMap;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/OpenAI/StreamTest.php
+++ b/tests/Providers/OpenAI/StreamTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Prism;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Prism;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/OpenAI/StructuredTest.php
+++ b/tests/Providers/OpenAI/StructuredTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Schema\BooleanSchema;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Schema\BooleanSchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/OpenAI/TextTest.php
+++ b/tests/Providers/OpenAI/TextTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use EchoLabs\Prism\Enums\ToolChoice;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Prism;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\ToolChoice;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Prism;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/OpenAI/ToolTest.php
+++ b/tests/Providers/OpenAI/ToolTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Providers\OpenAI\Maps\ToolMap;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Providers\OpenAI\Maps\ToolMap;
+use PrismPHP\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/VoyageAI/EmbeddingsTest.php
+++ b/tests/Providers/VoyageAI/EmbeddingsTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\ValueObjects\Embedding;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\ValueObjects\Embedding;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns embeddings from input', function (): void {

--- a/tests/Providers/VoyageAI/VoyageAITest.php
+++ b/tests/Providers/VoyageAI/VoyageAITest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Schema\ObjectSchema;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Schema\ObjectSchema;
 
 it('throws an exception for text', function (): void {
     Http::fake()->preventStrayRequests();
@@ -15,7 +15,7 @@ it('throws an exception for text', function (): void {
         ->using(Provider::VoyageAI, 'test-model')
         ->withPrompt('Hello world.')
         ->generate();
-})->throws(PrismException::class, 'EchoLabs\Prism\Providers\VoyageAI\VoyageAI::text is not supported by VoyageAI');
+})->throws(PrismException::class, 'PrismPHP\Prism\Providers\VoyageAI\VoyageAI::text is not supported by VoyageAI');
 
 it('throws an exception for structured', function (): void {
     Http::fake()->preventStrayRequests();
@@ -25,4 +25,4 @@ it('throws an exception for structured', function (): void {
         ->withSchema(new ObjectSchema('', '', []))
         ->withPrompt('Hello world.')
         ->generate();
-})->throws(PrismException::class, 'EchoLabs\Prism\Providers\VoyageAI\VoyageAI::structured is not supported by VoyageAI');
+})->throws(PrismException::class, 'PrismPHP\Prism\Providers\VoyageAI\VoyageAI::structured is not supported by VoyageAI');

--- a/tests/Providers/XAI/MessageMapTest.php
+++ b/tests/Providers/XAI/MessageMapTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\XAI;
 
-use EchoLabs\Prism\Providers\XAI\Maps\MessageMap;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\ToolResultMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
-use EchoLabs\Prism\ValueObjects\ToolCall;
-use EchoLabs\Prism\ValueObjects\ToolResult;
+use PrismPHP\Prism\Providers\XAI\Maps\MessageMap;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\ValueObjects\ToolCall;
+use PrismPHP\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/XAI/ToolTest.php
+++ b/tests/Providers/XAI/ToolTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\XAI;
 
-use EchoLabs\Prism\Providers\XAI\Maps\ToolMap;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Providers\XAI\Maps\ToolMap;
+use PrismPHP\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/XAI/XAITextTest.php
+++ b/tests/Providers/XAI/XAITextTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Tests\Providers\XAI;
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Enums\ToolChoice;
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\ToolChoice;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use EchoLabs\Prism\Schema\ArraySchema;
-use EchoLabs\Prism\Schema\BooleanSchema;
-use EchoLabs\Prism\Schema\EnumSchema;
-use EchoLabs\Prism\Schema\NumberSchema;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Schema\ArraySchema;
+use PrismPHP\Prism\Schema\BooleanSchema;
+use PrismPHP\Prism\Schema\EnumSchema;
+use PrismPHP\Prism\Schema\NumberSchema;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
 
 it('they can have nested properties', function (): void {
     $schema = new ObjectSchema(

--- a/tests/Structured/PendingRequestTest.php
+++ b/tests/Structured/PendingRequestTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Enums\StructuredMode;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Schema\StringSchema;
-use EchoLabs\Prism\Structured\PendingRequest;
-use EchoLabs\Prism\Structured\Request;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\StructuredMode;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Structured\PendingRequest;
+use PrismPHP\Prism\Structured\Request;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 
 beforeEach(function (): void {
     $this->pendingRequest = new PendingRequest;

--- a/tests/Structured/ResponseBuilderTest.php
+++ b/tests/Structured/ResponseBuilderTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismStructuredDecodingException;
-use EchoLabs\Prism\Structured\ResponseBuilder;
-use EchoLabs\Prism\Structured\Step;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismStructuredDecodingException;
+use PrismPHP\Prism\Structured\ResponseBuilder;
+use PrismPHP\Prism\Structured\Step;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 test('throws a PrismStructuredDecodingException if the response is not valid json', function (): void {
     $builder = new ResponseBuilder;

--- a/tests/TestDoubles/TestProvider.php
+++ b/tests/TestDoubles/TestProvider.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace Tests\TestDoubles;
 
-use EchoLabs\Prism\Contracts\Provider;
-use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Stream\Request as StreamRequest;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\ValueObjects\EmbeddingsUsage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\ProviderResponse;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Generator;
+use PrismPHP\Prism\Contracts\Provider;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Stream\Request as StreamRequest;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\ProviderResponse;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 class TestProvider implements Provider
 {

--- a/tests/Testing/PrismFakeTest.php
+++ b/tests/Testing/PrismFakeTest.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace Tests\Testing;
 
-use EchoLabs\Prism\Embeddings\Request as EmbeddingRequest;
-use EchoLabs\Prism\Embeddings\Response as EmbeddingResponse;
-use EchoLabs\Prism\Enums\FinishReason;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Prism;
-use EchoLabs\Prism\Schema\ObjectSchema;
-use EchoLabs\Prism\Schema\StringSchema;
-use EchoLabs\Prism\Structured\Request as StructuredRequest;
-use EchoLabs\Prism\Structured\Response as StructuredResponse;
-use EchoLabs\Prism\Text\Request as TextRequest;
-use EchoLabs\Prism\Text\Response as TextResponse;
-use EchoLabs\Prism\ValueObjects\EmbeddingsUsage;
-use EchoLabs\Prism\ValueObjects\Meta;
-use EchoLabs\Prism\ValueObjects\Usage;
 use Exception;
+use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
+use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
+use PrismPHP\Prism\Enums\FinishReason;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Prism;
+use PrismPHP\Prism\Schema\ObjectSchema;
+use PrismPHP\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Structured\Request as StructuredRequest;
+use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use PrismPHP\Prism\Text\Request as TextRequest;
+use PrismPHP\Prism\Text\Response as TextResponse;
+use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
+use PrismPHP\Prism\ValueObjects\Meta;
+use PrismPHP\Prism\ValueObjects\Usage;
 
 it('fake responses using the prism fake for text', function (): void {
     $fake = Prism::fake([

--- a/tests/Text/PendingRequestTest.php
+++ b/tests/Text/PendingRequestTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-use EchoLabs\Prism\Contracts\Provider as ProviderContract;
-use EchoLabs\Prism\Enums\Provider;
-use EchoLabs\Prism\Enums\ToolChoice;
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Facades\Tool;
-use EchoLabs\Prism\Text\PendingRequest;
-use EchoLabs\Prism\ValueObjects\Messages\AssistantMessage;
-use EchoLabs\Prism\ValueObjects\Messages\SystemMessage;
-use EchoLabs\Prism\ValueObjects\Messages\UserMessage;
 use Illuminate\Contracts\View\View;
+use PrismPHP\Prism\Contracts\Provider as ProviderContract;
+use PrismPHP\Prism\Enums\Provider;
+use PrismPHP\Prism\Enums\ToolChoice;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Facades\Tool;
+use PrismPHP\Prism\Text\PendingRequest;
+use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
 use Tests\TestDoubles\TestProvider;
 
 beforeEach(function (): void {

--- a/tests/ToolTest.php
+++ b/tests/ToolTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use EchoLabs\Prism\Exceptions\PrismException;
-use EchoLabs\Prism\Facades\Tool as ToolFacade;
-use EchoLabs\Prism\Schema\BooleanSchema;
-use EchoLabs\Prism\Schema\StringSchema;
-use EchoLabs\Prism\Tool;
+use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Facades\Tool as ToolFacade;
+use PrismPHP\Prism\Schema\BooleanSchema;
+use PrismPHP\Prism\Schema\StringSchema;
+use PrismPHP\Prism\Tool;
 
 it('can return tool details', function (): void {
     $searchTool = (new Tool)

--- a/tests/ValueObjects/Messages/Support/DocumentTest.php
+++ b/tests/ValueObjects/Messages/Support/DocumentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use EchoLabs\Prism\ValueObjects\Messages\Support\Document;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
 
 it('can create a document from chunks', function (): void {
     $document = Document::fromChunks(['chunk1', 'chunk2'], 'title', 'context');

--- a/tests/ValueObjects/Messages/Support/ImageTest.php
+++ b/tests/ValueObjects/Messages/Support/ImageTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\ValueOpjects\Messages\Support;
 
-use EchoLabs\Prism\ValueObjects\Messages\Support\Image;
+use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
 
 it('can create an image from a file', function (): void {
     $image = Image::fromPath('tests/Fixtures/test-image.png');


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Related to #197 

Updates the codebase related to re-org from `echolabsdev/prism` to `prism-php/prism`.

## Breaking Changes

- Namespace changes from `EchoLabs\Prism` to `PrismPHP\Prism`
- Domain changes from `https://prism.echolabs.dev` to `https://prismphp.com`
- Package namespace changes from `echolabsdev/prism` to `prism-php/prism`
