### PR TITLE
feat(voyageai): rate limit exception

### DIFF
--- a/src/Providers/VoyageAI/Embeddings.php
+++ b/src/Providers/VoyageAI/Embeddings.php
@@ -8,6 +8,7 @@ use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
 use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
 use PrismPHP\Prism\Enums\Provider;
 use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
 use PrismPHP\Prism\ValueObjects\Embedding;
 use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
 
@@ -55,6 +56,10 @@ class Embeddings
 
     protected function validateResponse(): void
     {
+        if ($this->httpResponse->getStatusCode() === 429) {
+            throw new PrismRateLimitedException([]);
+        }
+
         $data = $this->httpResponse->json();
 
         if (! $data || data_get($data, 'detail')) {


### PR DESCRIPTION
## Description

Implements rate limit exception for VoyageAI. No rate limit details or meta as Voyage do not return headers.

Note: I have not updated the docs page as I am doing a couple of these today and don't want to cause a conflict. Will circle back after PRs are merged to update.