### PR TITLE
feat(xai): rate limit exception

### DIFF
--- a/src/Providers/XAI/Concerns/ValidatesResponses.php
+++ b/src/Providers/XAI/Concerns/ValidatesResponses.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace PrismPHP\Prism\Providers\XAI\Concerns;
 
+use Illuminate\Http\Client\Response;
 use PrismPHP\Prism\Exceptions\PrismException;
+use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
 
 trait ValidatesResponses
 {
-    /**
-     * @param  array<string, mixed>  $data
-     */
-    protected function validateResponse(array $data): void
+    protected function validateResponse(Response $response): void
     {
+        if ($response->getStatusCode() === 429) {
+            throw new PrismRateLimitedException([]);
+        }
+
+        $data = $response->json();
+
         if (! $data || data_get($data, 'error')) {
             throw PrismException::providerResponseError(vsprintf(
                 'XAI Error:  [%s] %s',


### PR DESCRIPTION
## Description
Implements rate limit exception for XAI No rate limit details or meta as XAI do not return headers.

Note: I have not updated the docs page as I am doing a couple of these today and don't want to cause a conflict. Will circle back after PRs are merged to update.
