### PR TITLE
fix: misleading tool return type exception

### DIFF
--- a/docs/core-concepts/tools-function-calling.md
+++ b/docs/core-concepts/tools-function-calling.md
@@ -62,6 +62,8 @@ $searchTool = Tool::as('search')
     });
 ```
 
+Tools can take a variety of parameters, but must always return a string.
+
 ## Parameter Definition
 
 Prism offers multiple ways to define tool parameters, from simple primitives to complex objects.

--- a/src/Exceptions/PrismException.php
+++ b/src/Exceptions/PrismException.php
@@ -47,6 +47,14 @@ class PrismException extends Exception
         );
     }
 
+    public static function invalidReturnTypeInTool(string $toolName, Throwable $previous): self
+    {
+        return new self(
+            sprintf('Invalid return type for tool : %s. Tools must return string.', $toolName),
+            previous: $previous
+        );
+    }
+
     public static function providerResponseError(string $message): self
     {
         return new self($message);

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -176,7 +176,13 @@ class Tool
     public function handle(...$args): string
     {
         try {
-            return call_user_func($this->fn, ...$args);
+            $value = call_user_func($this->fn, ...$args);
+
+            if (! is_string($value)) {
+                throw PrismException::invalidReturnTypeInTool($this->name, new TypeError('Return value must be of type string'));
+            }
+
+            return $value;
         } catch (ArgumentCountError|Error|InvalidArgumentException|TypeError $e) {
             if ($e::class === Error::class && ! str_starts_with($e->getMessage(), 'Unknown named parameter')) {
                 throw $e;

--- a/tests/ToolTest.php
+++ b/tests/ToolTest.php
@@ -161,3 +161,20 @@ it('can throw a prism custom exception for unknown named parameters', function (
 
     $searchTool->handle(input: 'What time is the event?');
 });
+
+it('can throw a prism custom exception for invalid return type', function (): void {
+    $searchTool = (new Tool)
+        ->as('search')
+        ->for('useful for searching current data')
+        ->withParameter(new StringSchema('query', 'the search query'))
+        ->using(function (string $query): int {
+            expect($query)->toBe('What time is the event?');
+
+            return 1;
+        });
+
+    $this->expectException(PrismException::class);
+    $this->expectExceptionMessage('Invalid return type for tool : search. Tools must return string.');
+
+    $searchTool->handle('What time is the event?');
+});


### PR DESCRIPTION
## Description

When a tool returns something else than string, currently `Invalid parameters for tool : %s` is thrown. This message misled me for a moment. The only way to find out the correct reason is to check the previous exception.

As per type definition, a string must be returned from the tool, I think a good place to check for that is right after getting the tool's value. Also, this way, the exception throwing is co-located with the reason it is needed.

This PR adds a more user-friendly exception message (`Invalid return type for tool : %s. Tools must return string.`) and a sentence about tool return types in the tool documentation.


## Breaking Changes

Shouldn't be breaking as tools without `string` return type cannot be used anyways. The only way this could be breaking in my head is if a package consumer let's their consumer/user dynamically define the return type & checks for the current error message while catching.