### PR TITLE
bug(openai + groq): fix null rate limit reset

### DIFF
--- a/src/Providers/Groq/Concerns/ValidateResponse.php
+++ b/src/Providers/Groq/Concerns/ValidateResponse.php
@@ -53,7 +53,7 @@ trait ValidateResponse
         }
 
         return array_values(Arr::map($rateLimits, function ($fields, $limitName): ProviderRateLimit {
-            $resetsAt = data_get($fields, 'reset');
+            $resetsAt = data_get($fields, 'reset', '');
 
             if (str_contains($resetsAt, 'ms')) {
                 $resetMilliseconds = Str::of($resetsAt)->before('ms')->toString();

--- a/src/Providers/OpenAI/Concerns/ProcessesRateLimits.php
+++ b/src/Providers/OpenAI/Concerns/ProcessesRateLimits.php
@@ -27,7 +27,7 @@ trait ProcessesRateLimits
         }
 
         return array_values(Arr::map($rateLimits, function ($fields, $limitName): ProviderRateLimit {
-            $resetsAt = data_get($fields, 'reset');
+            $resetsAt = data_get($fields, 'reset', '');
 
             if (str_contains($resetsAt, 'ms')) {
                 $resetMilliseconds = Str::of($resetsAt)->before('ms')->toString();


### PR DESCRIPTION
## Description

Avoids an exception for openai and groq rate limits where the resets header is null.