### PR TITLE
refactor: Namespace update to Prism

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "autoload": {
     "psr-4": {
-      "PrismPHP\\Prism\\": "src/"
+      "Prism\\Prism\\": "src/"
     }
   },
   "authors": [
@@ -86,10 +86,10 @@
   "extra": {
     "laravel": {
       "providers": [
-        "PrismPHP\\Prism\\PrismServiceProvider"
+        "Prism\\Prism\\PrismServiceProvider"
       ],
       "aliases": {
-        "PrismServer": "PrismPHP\\Prism\\Facades\\PrismServer"
+        "PrismServer": "Prism\\Prism\\Facades\\PrismServer"
       }
     }
   }

--- a/docs/advanced/custom-providers.md
+++ b/docs/advanced/custom-providers.md
@@ -4,15 +4,15 @@ Want to add support for a new AI provider in Prism? This guide will walk you thr
 
 ## Provider Interface
 
-All providers must implement the `PrismPHP\Prism\Contracts\Provider` interface:
+All providers must implement the `Prism\Prism\Contracts\Provider` interface:
 
 ```php
-use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 interface Provider
 {
@@ -65,7 +65,7 @@ return [
 Now you can use your custom provider:
 
 ```php
-use PrismPHP\Prism\Facades\Prism;
+use Prism\Prism\Facades\Prism;
 
 $response = Prism::text()
     ->using('my-custom-provider', 'model-name')

--- a/docs/advanced/rate-limits.md
+++ b/docs/advanced/rate-limits.md
@@ -29,10 +29,10 @@ Prism throws a `PrismRateLimitedException` when you hit a rate limit.
 You can catch that exception, gracefully fail and inspect the `rateLimits` property which contains an array of `ProviderRateLimit`s. 
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Enums\Provider;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Prism;
+use Prism\Enums\Provider;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
 
 try {
     Prism::text()
@@ -59,7 +59,7 @@ However most providers implement various rate limits (e.g. request, input tokens
 For simple rate limits like "requests", the `remaining` property on `ProviderRateLimit` will be 0 if you have hit it. These are easy to find:
 
 ```php 
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 use Illuminate\Support\Arr;
 
 try {
@@ -75,7 +75,7 @@ For less simple rate limits like input tokens, the `remaining` property may not 
 Here, you may need to implement some logic to approximate how many tokens your request will use before sending it, and then test against that:
 
 ```php 
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 use Illuminate\Support\Arr;
 
 try {
@@ -103,9 +103,9 @@ If you aren't sure where to start with that, check out the [What should you do w
 Prism adds the same rate limit information to every successful request:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Enums\Provider;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Prism;
+use Prism\Enums\Provider;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')

--- a/docs/core-concepts/embeddings.md
+++ b/docs/core-concepts/embeddings.md
@@ -7,8 +7,8 @@ Transform your text into powerful vector representations! Embeddings let you add
 Here's how to generate an embedding with just a few lines of code:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::embeddings()
     ->using(Provider::OpenAI, 'text-embedding-3-large')
@@ -27,8 +27,8 @@ echo $response->usage->tokens;
 You can generate multiple embeddings at once with all providers that support embeddings, other than Gemini:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::embeddings()
     ->using(Provider::OpenAI, 'text-embedding-3-large')
@@ -60,8 +60,8 @@ You've got two convenient ways to feed text into the embeddings generator:
 ### Direct Text Input
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::embeddings()
     ->using(Provider::OpenAI, 'text-embedding-3-large')
@@ -74,8 +74,8 @@ $response = Prism::embeddings()
 Need to analyze a larger document? No problem:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::embeddings()
     ->using(Provider::OpenAI, 'text-embedding-3-large')
@@ -91,8 +91,8 @@ $response = Prism::embeddings()
 Just like with text generation, you can fine-tune your embeddings requests:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::embeddings()
     ->using(Provider::OpenAI, 'text-embedding-3-large')
@@ -107,7 +107,7 @@ $response = Prism::embeddings()
 The embeddings response gives you everything you need:
 
 ```php
-namespace PrismPHP\Prism\ValueObjects\Embedding;
+namespace Prism\Prism\ValueObjects\Embedding;
 
 // Get an array of Embedding value objects
 $embeddings = $response->embeddings;
@@ -130,9 +130,9 @@ $tokenCount = $response->usage->tokens;
 Always handle potential errors gracefully:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
 
 try {
     $response = Prism::embeddings()

--- a/docs/core-concepts/prism-server.md
+++ b/docs/core-concepts/prism-server.md
@@ -25,9 +25,9 @@ First, make sure Prism Server is enabled in your `config/prism.php` file:
 To make your Prism models available through the server, you need to register them. This is typically done in a service provider, such as `AppServiceProvider`:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Facades\PrismServer;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Facades\PrismServer;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider

--- a/docs/core-concepts/schemas.md
+++ b/docs/core-concepts/schemas.md
@@ -7,9 +7,9 @@ Schemas are the blueprints that help you define the shape of your data in Prism.
 Let's dive right in with a practical example:
 
 ```php
-use PrismPHP\Prism\Schema\ArraySchema;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Schema\ArraySchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
 
 $userSchema = new ObjectSchema(
     name: 'user',
@@ -41,7 +41,7 @@ $userSchema = new ObjectSchema(
 For text values of any length. Perfect for names, descriptions, or any textual data.
 
 ```php
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Schema\StringSchema;
 
 $nameSchema = new StringSchema(
     name: 'full_name',
@@ -54,7 +54,7 @@ $nameSchema = new StringSchema(
 Handles both integers and floating-point numbers. Great for ages, quantities, or measurements.
 
 ```php
-use PrismPHP\Prism\Schema\NumberSchema;
+use Prism\Prism\Schema\NumberSchema;
 
 $ageSchema = new NumberSchema(
     name: 'age',
@@ -67,7 +67,7 @@ $ageSchema = new NumberSchema(
 For simple true/false values. Perfect for flags and toggles.
 
 ```php
-use PrismPHP\Prism\Schema\BooleanSchema;
+use Prism\Prism\Schema\BooleanSchema;
 
 $activeSchema = new BooleanSchema(
     name: 'is_active',
@@ -80,8 +80,8 @@ $activeSchema = new BooleanSchema(
 For lists of items, where each item follows a specific schema.
 
 ```php
-use PrismPHP\Prism\Schema\ArraySchema;
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Schema\ArraySchema;
+use Prism\Prism\Schema\StringSchema;
 
 $tagsSchema = new ArraySchema(
     name: 'tags',
@@ -95,7 +95,7 @@ $tagsSchema = new ArraySchema(
 When you need to restrict values to a specific set of options.
 
 ```php
-use PrismPHP\Prism\Schema\EnumSchema;
+use Prism\Prism\Schema\EnumSchema;
 
 $statusSchema = new EnumSchema(
     name: 'status',
@@ -109,9 +109,9 @@ $statusSchema = new EnumSchema(
 For complex, nested data structures. The Swiss Army knife of schemas!
 
 ```php
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
-use PrismPHP\Prism\Schema\NumberSchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Schema\NumberSchema;
 
 $profileSchema = new ObjectSchema(
     name: 'profile',
@@ -130,7 +130,7 @@ $profileSchema = new ObjectSchema(
 Sometimes, not every field is required. You can make any schema nullable by setting the `nullable` parameter to `true`:
 
 ```php
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Schema\StringSchema;
 
 $bioSchema = new StringSchema(
     name: 'bio',

--- a/docs/core-concepts/streaming-output.md
+++ b/docs/core-concepts/streaming-output.md
@@ -7,7 +7,7 @@ Want to show AI responses to your users in real-time? Streaming lets you display
 At its simplest, streaming works like this:
 
 ```php
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Prism;
 
 $response = Prism::stream()
     ->using('openai', 'gpt-4')
@@ -44,8 +44,8 @@ foreach ($response as $chunk) {
 Streaming works seamlessly with tools, allowing real-time interaction:
 
 ```php
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Prism;
 
 $weatherTool = Tool::as('weather')
     ->for('Get current weather information')
@@ -95,7 +95,7 @@ Here's how to integrate streaming in a Laravel controller:
 Alternatively, you might consider using Laravel's [Broadcasting feature](https://laravel.com/docs/12.x/broadcasting) to send the chunks to your frontend.
 
 ```php
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Prism;
 use Illuminate\Http\Response;
 
 public function streamResponse()

--- a/docs/core-concepts/structured-output.md
+++ b/docs/core-concepts/structured-output.md
@@ -7,10 +7,10 @@ Want your AI responses as neat and tidy as a Marie Kondo-approved closet? Struct
 Here's how to get structured data from your AI:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
 
 $schema = new ObjectSchema(
     name: 'movie_review',
@@ -54,8 +54,8 @@ Different AI providers handle structured output in two main ways:
 Providers may offer additional options for structured output. For example, OpenAI supports a "strict mode" for even tighter schema validation:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::structured()
     ->withProviderMeta(Provider::OpenAI, [
@@ -74,7 +74,7 @@ $response = Prism::structured()
 When working with structured responses, you have access to both the structured data and metadata about the generation:
 
 ```php
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Prism;
 
 $response = Prism::structured()
     ->withSchema($schema)
@@ -139,9 +139,9 @@ See the [Text Generation](./text-generation.md) documentation for comparison wit
 When working with structured output, it's especially important to handle potential errors:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
 
 try {
     $response = Prism::structured()

--- a/docs/core-concepts/testing.md
+++ b/docs/core-concepts/testing.md
@@ -7,12 +7,12 @@ Want to make sure your Prism integrations work flawlessly? Let's dive into testi
 First, let's look at how to set up basic response faking:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\ValueObjects\Usage;
-use PrismPHP\Prism\ValueObjects\ResponseMeta;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\ValueObjects\Usage;
+use Prism\Prism\ValueObjects\ResponseMeta;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Text\Response as TextResponse;
 
 it('can generate text', function () {
     // Create a fake text response
@@ -48,10 +48,10 @@ it('can generate text', function () {
 When testing conversations or tool usage, you might need to simulate multiple responses:
 
 ```php
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\ValueObjects\Usage;
-use PrismPHP\Prism\ValueObjects\ResponseMeta;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\Usage;
+use Prism\Prism\ValueObjects\ResponseMeta;
+use Prism\Prism\ValueObjects\ToolCall;
 
 it('can handle tool calls', function () {
     $responses = [
@@ -96,11 +96,11 @@ it('can handle tool calls', function () {
 If you need to test a richer response object, e.g. with Steps, you may find it easier to use the ResponseBuilder:
 
 ```php
-use PrismPHP\Prism\Text\ResponseBuilder;
-use PrismPHP\Prism\Text\Step;
-use PrismPHP\Prism\ValueObjects\Usage;
-use PrismPHP\Prism\ValueObjects\ResponseMeta;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\Text\ResponseBuilder;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Usage;
+use Prism\Prism\ValueObjects\ResponseMeta;
+use Prism\Prism\ValueObjects\ToolCall;
 
 Prism::fake([
     (new ResponseBuilder)
@@ -148,13 +148,13 @@ Prism::fake([
 When testing tools, you'll want to verify both the tool calls and their results. Here's a complete example:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\Tool;
-use PrismPHP\Prism\ValueObjects\Usage;
-use PrismPHP\Prism\ValueObjects\ResponseMeta;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\Usage;
+use Prism\Prism\ValueObjects\ResponseMeta;
+use Prism\Prism\ValueObjects\ToolCall;
 
 it('can use weather tool', function () {
     // Define the expected tool call and response sequence
@@ -231,12 +231,12 @@ it('can use weather tool', function () {
 ## Testing Structured Output
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\ValueObjects\Usage;
-use PrismPHP\Prism\ValueObjects\ResponseMeta;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Prism;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\ValueObjects\Usage;
+use Prism\Prism\ValueObjects\ResponseMeta;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
 
 it('can generate structured response', function () {
     $schema = new ObjectSchema(

--- a/docs/core-concepts/text-generation.md
+++ b/docs/core-concepts/text-generation.md
@@ -7,8 +7,8 @@ Prism provides a powerful interface for generating text using Large Language Mod
 At its simplest, you can generate text with just a few lines of code:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -23,8 +23,8 @@ echo $response->text;
 System prompts help set the behavior and context for the AI. They're particularly useful for maintaining consistent responses or giving the LLM a persona:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -36,8 +36,8 @@ $response = Prism::text()
 You can also use Laravel views for complex system prompts:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -53,10 +53,10 @@ You an also pass a View to the `withPrompt` method.
 For interactive conversations, use message chains to maintain context:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -121,8 +121,8 @@ This allows for complete or partial override of the providers configuration. Thi
 The response object provides rich access to the generation results:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -170,9 +170,9 @@ FinishReason::Unknown;
 Remember to handle potential errors in your generations:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
 use Throwable;
 
 try {

--- a/docs/core-concepts/tools-function-calling.md
+++ b/docs/core-concepts/tools-function-calling.md
@@ -7,9 +7,9 @@ Need your AI assistant to check the weather, search a database, or call your API
 Think of tools as special functions that your AI assistant can use when it needs to perform specific tasks. Just like how Laravel's facades provide a clean interface to complex functionality, Prism tools give your AI a clean way to interact with external services and data sources.
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Facades\Tool;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Facades\Tool;
 
 $weatherTool = Tool::as('weather')
     ->for('Get current weather conditions')
@@ -32,8 +32,8 @@ $response = Prism::text()
 Prism defaults to allowing a single step. To use Tools, you'll need to increase this using `withMaxSteps`:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
@@ -51,7 +51,7 @@ You should use a higher number of max steps if you expect your initial prompt to
 Creating tools in Prism is straightforward and fluent. Here's how you can create a simple tool:
 
 ```php
-use PrismPHP\Prism\Facades\Tool;
+use Prism\Prism\Facades\Tool;
 
 $searchTool = Tool::as('search')
     ->for('Search for current information')
@@ -73,7 +73,7 @@ Prism offers multiple ways to define tool parameters, from simple primitives to 
 Perfect for text inputs:
 
 ```php
-use PrismPHP\Prism\Facades\Tool;
+use Prism\Prism\Facades\Tool;
 
 $tool = Tool::as('search')
     ->for('Search for information')
@@ -88,7 +88,7 @@ $tool = Tool::as('search')
 For integer or floating-point values:
 
 ```php
-use PrismPHP\Prism\Facades\Tool;
+use Prism\Prism\Facades\Tool;
 
 $tool = Tool::as('calculate')
     ->for('Perform calculations')
@@ -103,7 +103,7 @@ $tool = Tool::as('calculate')
 For true/false flags:
 
 ```php
-use PrismPHP\Prism\Facades\Tool;
+use Prism\Prism\Facades\Tool;
 
 $tool = Tool::as('feature_toggle')
     ->for('Toggle a feature')
@@ -118,7 +118,7 @@ $tool = Tool::as('feature_toggle')
 For handling lists of items:
 
 ```php
-use PrismPHP\Prism\Facades\Tool;
+use Prism\Prism\Facades\Tool;
 
 $tool = Tool::as('process_tags')
     ->for('Process a list of tags')
@@ -137,7 +137,7 @@ $tool = Tool::as('process_tags')
 When you need to restrict values to a specific set:
 
 ```php
-use PrismPHP\Prism\Facades\Tool;
+use Prism\Prism\Facades\Tool;
 
 $tool = Tool::as('set_status')
     ->for('Set the status')
@@ -156,9 +156,9 @@ $tool = Tool::as('set_status')
 For complex objects without needing to create separate schema instances:
 
 ```php
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Schema\StringSchema;
-use PrismPHP\Prism\Schema\NumberSchema;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Schema\NumberSchema;
 
 $tool = Tool::as('update_user')
     ->for('Update a user profile')
@@ -182,10 +182,10 @@ $tool = Tool::as('update_user')
 For complex, nested data structures, you can use Prism's schema system:
 
 ```php
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
-use PrismPHP\Prism\Schema\NumberSchema;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Schema\NumberSchema;
 
 $tool = Tool::as('create_user')
     ->for('Create a new user profile')
@@ -214,7 +214,7 @@ For more sophisticated tools, you can create dedicated classes:
 ```php
 namespace App\Tools;
 
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Tool;
 use Illuminate\Support\Facades\Http;
 
 class SearchTool extends Tool
@@ -260,9 +260,9 @@ class SearchTool extends Tool
 
 You can control how the AI uses tools with the `withToolChoice` method:
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Enums\ToolChoice;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Enums\ToolChoice;
 
 $prism = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
@@ -285,8 +285,8 @@ $prism = Prism::text()
 When your AI uses tools, you can inspect the results and see how it arrived at its answer:
 
 ```php
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -12,8 +12,8 @@ Here's a quick example of how you can generate text using Prism:
 
 ::: code-group
 ```php [Anthropic]
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-sonnet')
@@ -25,8 +25,8 @@ echo $response->text;
 ```
 
 ```php [Mistral]
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Mistral, 'mistral-medium')
@@ -38,8 +38,8 @@ echo $response->text;
 ```
 
 ```php [Ollama]
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Ollama, 'llama2')
@@ -51,8 +51,8 @@ echo $response->text;
 ```
 
 ```php [OpenAI]
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::OpenAI, 'gpt-4')

--- a/docs/input-modalities/documents.md
+++ b/docs/input-modalities/documents.md
@@ -30,10 +30,10 @@ All of these formats should work with Prism.
 To add an image to your message, add a `Document` value object to the `additionalContent` property:
 
 ```php
-use PrismPHP\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
 
 Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')

--- a/docs/input-modalities/images.md
+++ b/docs/input-modalities/images.md
@@ -11,8 +11,8 @@ Note however that not all models with a supported provider support vision. If yo
 To add an image to your message, add an `Image` value object to the `additionalContent` property:
 
 ```php
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
 
 // From a local file
 $message = new UserMessage(

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -24,11 +24,11 @@ We support Anthropic prompt caching on:
 The API for enabling prompt caching is the same for all, enabled via the `withProviderMeta()` method. Where a UserMessage contains both text and an image or document, both will be cached.
 
 ```php
-use PrismPHP\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Tool;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -49,10 +49,10 @@ Prism::text()
 If you prefer, you can use the `AnthropicCacheType` Enum like so:
 
 ```php
-use PrismPHP\Enums\Provider;
-use PrismPHP\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Enums\Provider;
+use Prism\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
 
 (new UserMessage('I am a long re-usable user message.'))->withProviderMeta(Provider::Anthropic, ['cacheType' => AnthropicCacheType::ephemeral])
 ```
@@ -68,8 +68,8 @@ Claude Sonnet 3.7 supports an optional extended thinking mode, where it will rea
 Prism supports thinking mode for text and structured with the same API:
 
 ```php
-use PrismPHP\Enums\Provider;
-use PrismPHP\Prism\Prism;
+use Prism\Enums\Provider;
+use Prism\Prism\Prism;
 
 Prism::text()
     ->using('anthropic', 'claude-3-7-sonnet-latest')
@@ -83,8 +83,8 @@ By default Prism will set the thinking budget to the value set in config, or whe
 You can overide the config (or its default) using `withProviderMeta`:
 
 ```php
-use PrismPHP\Enums\Provider;
-use PrismPHP\Prism\Prism;
+use Prism\Enums\Provider;
+use Prism\Prism\Prism;
 
 Prism::text()
     ->using('anthropic', 'claude-3-7-sonnet-latest')
@@ -110,8 +110,8 @@ You can access it via the additionalContent property on either the Response or t
 On the Response (easiest if not using tools):
 
 ```php
-use PrismPHP\Enums\Provider;
-use PrismPHP\Prism\Prism;
+use Prism\Enums\Provider;
+use Prism\Prism\Prism;
 
 Prism::text()
     ->using('anthropic', 'claude-3-7-sonnet-latest')
@@ -157,10 +157,10 @@ Anthropic also supports "custom content documents", separately documented below,
 Custom content documents are primarily for use with citations (see below), if you need citations to reference your own chunking strategy.
 
 ```php
-use PrismPHP\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
 
 Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -186,10 +186,10 @@ Please note however that due to Anthropic not supporting "native" structured out
 Anthropic require citations to be enabled on all documents in a request. To enable them, using the `withProviderMeta()` method when building your request:
 
 ```php
-use PrismPHP\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
@@ -216,8 +216,8 @@ You can access the chunked output with its citations via the additionalContent p
 As a rough worked example, let's assume you want to implement footnotes. You'll need to loop through those chunks and (1) re-construct the message with links to the footnotes; and (2) build an array of footnotes to loop through in your frontend.
 
 ```php
-use PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
-use PrismPHP\Prism\Providers\Anthropic\ValueObjects\Citation;
+use Prism\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
+use Prism\Prism\Providers\Anthropic\ValueObjects\Citation;
 
 $messageChunks = $response->additionalContent['messagePartsWithCitations'];
 

--- a/docs/providers/voyageai.md
+++ b/docs/providers/voyageai.md
@@ -21,8 +21,8 @@ However, they taylor your vectors for the task they are intended for - for searc
 For search / querying:
 
 ```php
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
 
 Prism::embeddings()
     ->using(Provider::VoyageAI, 'voyage-3-lite')
@@ -34,8 +34,8 @@ Prism::embeddings()
 For document retrieval:
 
 ```php
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
 
 Prism::embeddings()
     ->using(Provider::VoyageAI, 'voyage-3-lite')
@@ -51,8 +51,8 @@ By default, Voyage AI truncates inputs that are over the context length.
 You can force it to throw an error instead by setting truncation to false.
 
 ```php
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
 
 Prism::embeddings()
     ->using(Provider::VoyageAI, 'voyage-3-lite')

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Rectors\ReorderMethodsRector;
+use Prism\Prism\Rectors\ReorderMethodsRector;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;

--- a/src/Concerns/CallsTools.php
+++ b/src/Concerns/CallsTools.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MultipleItemsFoundException;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Tool;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 use Throwable;
 
 trait CallsTools

--- a/src/Concerns/ChecksSelf.php
+++ b/src/Concerns/ChecksSelf.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
 trait ChecksSelf
 {

--- a/src/Concerns/ConfiguresClient.php
+++ b/src/Concerns/ConfiguresClient.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
 use Closure;
 

--- a/src/Concerns/ConfiguresGeneration.php
+++ b/src/Concerns/ConfiguresGeneration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
 trait ConfiguresGeneration
 {

--- a/src/Concerns/ConfiguresModels.php
+++ b/src/Concerns/ConfiguresModels.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
 trait ConfiguresModels
 {

--- a/src/Concerns/ConfiguresProviders.php
+++ b/src/Concerns/ConfiguresProviders.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Enums\Provider as ProviderEnum;
-use PrismPHP\Prism\PrismManager;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Enums\Provider as ProviderEnum;
+use Prism\Prism\PrismManager;
 
 trait ConfiguresProviders
 {

--- a/src/Concerns/ConfiguresStructuredOutput.php
+++ b/src/Concerns/ConfiguresStructuredOutput.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
-use PrismPHP\Prism\Enums\StructuredMode;
+use Prism\Prism\Enums\StructuredMode;
 
 trait ConfiguresStructuredOutput
 {

--- a/src/Concerns/ConfiguresTools.php
+++ b/src/Concerns/ConfiguresTools.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
-use PrismPHP\Prism\Enums\ToolChoice;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Tool;
 
 trait ConfiguresTools
 {

--- a/src/Concerns/HasMessages.php
+++ b/src/Concerns/HasMessages.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
-use PrismPHP\Prism\Contracts\Message;
+use Prism\Prism\Contracts\Message;
 
 trait HasMessages
 {

--- a/src/Concerns/HasPrompts.php
+++ b/src/Concerns/HasPrompts.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
 use Illuminate\Contracts\View\View;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 trait HasPrompts
 {

--- a/src/Concerns/HasProviderMeta.php
+++ b/src/Concerns/HasProviderMeta.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Enums\Provider;
 
 trait HasProviderMeta
 {

--- a/src/Concerns/HasSchema.php
+++ b/src/Concerns/HasSchema.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
-use PrismPHP\Prism\Contracts\Schema;
+use Prism\Prism\Contracts\Schema;
 
 trait HasSchema
 {

--- a/src/Concerns/HasTools.php
+++ b/src/Concerns/HasTools.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Tool;
 
 trait HasTools
 {

--- a/src/Concerns/NullableSchema.php
+++ b/src/Concerns/NullableSchema.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PrismPHP\Prism\Concerns;
+namespace Prism\Prism\Concerns;
 
 trait NullableSchema
 {

--- a/src/Contracts/Message.php
+++ b/src/Contracts/Message.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Contracts;
+namespace Prism\Prism\Contracts;
 
 interface Message {}

--- a/src/Contracts/PrismRequest.php
+++ b/src/Contracts/PrismRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Contracts;
+namespace Prism\Prism\Contracts;
 
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Enums\Provider;
 
 interface PrismRequest
 {

--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Contracts;
+namespace Prism\Prism\Contracts;
 
 use Generator;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Stream\Chunk;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Stream\Chunk;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 interface Provider
 {

--- a/src/Contracts/Schema.php
+++ b/src/Contracts/Schema.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Contracts;
+namespace Prism\Prism\Contracts;
 
 interface Schema
 {

--- a/src/Embeddings/PendingRequest.php
+++ b/src/Embeddings/PendingRequest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Embeddings;
+namespace Prism\Prism\Embeddings;
 
-use PrismPHP\Prism\Concerns\ConfiguresClient;
-use PrismPHP\Prism\Concerns\ConfiguresProviders;
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Exceptions\PrismException;
+use Prism\Prism\Concerns\ConfiguresClient;
+use Prism\Prism\Concerns\ConfiguresProviders;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Exceptions\PrismException;
 
 class PendingRequest
 {
@@ -52,7 +52,7 @@ class PendingRequest
         return $this;
     }
 
-    public function generate(): \PrismPHP\Prism\Embeddings\Response
+    public function generate(): \Prism\Prism\Embeddings\Response
     {
         if ($this->inputs === []) {
             throw new PrismException('Embeddings input is required');

--- a/src/Embeddings/Request.php
+++ b/src/Embeddings/Request.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Embeddings;
+namespace Prism\Prism\Embeddings;
 
 use Closure;
-use PrismPHP\Prism\Concerns\ChecksSelf;
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Contracts\PrismRequest;
+use Prism\Prism\Concerns\ChecksSelf;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Contracts\PrismRequest;
 
 class Request implements PrismRequest
 {

--- a/src/Embeddings/Response.php
+++ b/src/Embeddings/Response.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Embeddings;
+namespace Prism\Prism\Embeddings;
 
-use PrismPHP\Prism\ValueObjects\Embedding;
-use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use PrismPHP\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Embedding;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
 
 readonly class Response
 {

--- a/src/Enums/FinishReason.php
+++ b/src/Enums/FinishReason.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Enums;
+namespace Prism\Prism\Enums;
 
 enum FinishReason
 {

--- a/src/Enums/Provider.php
+++ b/src/Enums/Provider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Enums;
+namespace Prism\Prism\Enums;
 
 enum Provider: string
 {

--- a/src/Enums/StructuredMode.php
+++ b/src/Enums/StructuredMode.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Enums;
+namespace Prism\Prism\Enums;
 
 enum StructuredMode
 {

--- a/src/Enums/ToolChoice.php
+++ b/src/Enums/ToolChoice.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Enums;
+namespace Prism\Prism\Enums;
 
 enum ToolChoice
 {

--- a/src/Exceptions/PrismChunkDecodeException.php
+++ b/src/Exceptions/PrismChunkDecodeException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Exceptions;
+namespace Prism\Prism\Exceptions;
 
 use Throwable;
 

--- a/src/Exceptions/PrismException.php
+++ b/src/Exceptions/PrismException.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Exceptions;
+namespace Prism\Prism\Exceptions;
 
 use Exception;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolCall;
 use Throwable;
 
 class PrismException extends Exception

--- a/src/Exceptions/PrismProviderOverloadedException.php
+++ b/src/Exceptions/PrismProviderOverloadedException.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Exceptions;
+namespace Prism\Prism\Exceptions;
 
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Enums\Provider;
 
 class PrismProviderOverloadedException extends PrismException
 {

--- a/src/Exceptions/PrismRateLimitedException.php
+++ b/src/Exceptions/PrismRateLimitedException.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Exceptions;
+namespace Prism\Prism\Exceptions;
 
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 
 class PrismRateLimitedException extends PrismException
 {

--- a/src/Exceptions/PrismRequestTooLargeException.php
+++ b/src/Exceptions/PrismRequestTooLargeException.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Exceptions;
+namespace Prism\Prism\Exceptions;
 
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Enums\Provider;
 
 class PrismRequestTooLargeException extends PrismException
 {

--- a/src/Exceptions/PrismServerException.php
+++ b/src/Exceptions/PrismServerException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Exceptions;
+namespace Prism\Prism\Exceptions;
 
 use Exception;
 use Throwable;

--- a/src/Exceptions/PrismStructuredDecodingException.php
+++ b/src/Exceptions/PrismStructuredDecodingException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Exceptions;
+namespace Prism\Prism\Exceptions;
 
 class PrismStructuredDecodingException extends PrismException
 {

--- a/src/Facades/PrismServer.php
+++ b/src/Facades/PrismServer.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Facades;
+namespace Prism\Prism\Facades;
 
 use Closure;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
-use PrismPHP\Prism\Text\PendingRequest;
+use Prism\Prism\Text\PendingRequest;
 
 /**
  * @method static self register(string $name, Closure():PendingRequest|callable():PendingRequest $prism)

--- a/src/Facades/Tool.php
+++ b/src/Facades/Tool.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Facades;
+namespace Prism\Prism\Facades;
 
 use Closure;
-use PrismPHP\Prism\Contracts\Schema;
-use PrismPHP\Prism\Tool as BaseTool;
+use Prism\Prism\Contracts\Schema;
+use Prism\Prism\Tool as BaseTool;
 
 /**
  * @method static BaseTool as(string $name)

--- a/src/Http/Controllers/PrismChatController.php
+++ b/src/Http/Controllers/PrismChatController.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace PrismPHP\Prism\Http\Controllers;
+namespace Prism\Prism\Http\Controllers;
 
 use Illuminate\Support\ItemNotFoundException;
-use PrismPHP\Prism\Exceptions\PrismServerException;
-use PrismPHP\Prism\Facades\PrismServer;
-use PrismPHP\Prism\Text\PendingRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Exceptions\PrismServerException;
+use Prism\Prism\Facades\PrismServer;
+use Prism\Prism\Text\PendingRequest;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 

--- a/src/Http/Controllers/PrismModelController.php
+++ b/src/Http/Controllers/PrismModelController.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Http\Controllers;
+namespace Prism\Prism\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
-use PrismPHP\Prism\Facades\PrismServer;
+use Prism\Prism\Facades\PrismServer;
 
 class PrismModelController
 {

--- a/src/Prism.php
+++ b/src/Prism.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism;
+namespace Prism\Prism;
 
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\PendingRequest as PendingEmbeddingRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
-use PrismPHP\Prism\Enums\Provider as ProviderEnum;
-use PrismPHP\Prism\Stream\PendingRequest as PendingStreamRequest;
-use PrismPHP\Prism\Structured\PendingRequest as PendingStructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Testing\PrismFake;
-use PrismPHP\Prism\Text\PendingRequest as PendingTextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\PendingRequest as PendingEmbeddingRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Enums\Provider as ProviderEnum;
+use Prism\Prism\Stream\PendingRequest as PendingStreamRequest;
+use Prism\Prism\Structured\PendingRequest as PendingStructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Testing\PrismFake;
+use Prism\Prism\Text\PendingRequest as PendingTextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 class Prism
 {

--- a/src/PrismManager.php
+++ b/src/PrismManager.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism;
+namespace Prism\Prism;
 
 use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use InvalidArgumentException;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Enums\Provider as ProviderEnum;
-use PrismPHP\Prism\Providers\Anthropic\Anthropic;
-use PrismPHP\Prism\Providers\DeepSeek\DeepSeek;
-use PrismPHP\Prism\Providers\Gemini\Gemini;
-use PrismPHP\Prism\Providers\Groq\Groq;
-use PrismPHP\Prism\Providers\Mistral\Mistral;
-use PrismPHP\Prism\Providers\Ollama\Ollama;
-use PrismPHP\Prism\Providers\OpenAI\OpenAI;
-use PrismPHP\Prism\Providers\VoyageAI\VoyageAI;
-use PrismPHP\Prism\Providers\XAI\XAI;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Enums\Provider as ProviderEnum;
+use Prism\Prism\Providers\Anthropic\Anthropic;
+use Prism\Prism\Providers\DeepSeek\DeepSeek;
+use Prism\Prism\Providers\Gemini\Gemini;
+use Prism\Prism\Providers\Groq\Groq;
+use Prism\Prism\Providers\Mistral\Mistral;
+use Prism\Prism\Providers\Ollama\Ollama;
+use Prism\Prism\Providers\OpenAI\OpenAI;
+use Prism\Prism\Providers\VoyageAI\VoyageAI;
+use Prism\Prism\Providers\XAI\XAI;
 use RuntimeException;
 
 class PrismManager

--- a/src/PrismServer.php
+++ b/src/PrismServer.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism;
+namespace Prism\Prism;
 
 use Closure;
 use Illuminate\Support\Collection;
-use PrismPHP\Prism\Text\PendingRequest;
+use Prism\Prism\Text\PendingRequest;
 
 readonly class PrismServer
 {

--- a/src/PrismServiceProvider.php
+++ b/src/PrismServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PrismPHP\Prism;
+namespace Prism\Prism;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Anthropic;
+namespace Prism\Prism\Providers\Anthropic;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Anthropic\Handlers\Structured;
-use PrismPHP\Prism\Providers\Anthropic\Handlers\Text;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Anthropic\Handlers\Structured;
+use Prism\Prism\Providers\Anthropic\Handlers\Text;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response;
 
 readonly class Anthropic implements Provider
 {

--- a/src/Providers/Anthropic/Enums/AnthropicCacheType.php
+++ b/src/Providers/Anthropic/Enums/AnthropicCacheType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PrismPHP\Prism\Providers\Anthropic\Enums;
+namespace Prism\Prism\Providers\Anthropic\Enums;
 
 enum AnthropicCacheType: string
 {

--- a/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
+++ b/src/Providers/Anthropic/Handlers/AnthropicHandlerAbstract.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Anthropic\Handlers;
+namespace Prism\Prism\Providers\Anthropic\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
-use PrismPHP\Prism\Contracts\PrismRequest;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Exceptions\PrismProviderOverloadedException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\Exceptions\PrismRequestTooLargeException;
-use PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Contracts\PrismRequest;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 use Throwable;
 
 abstract class AnthropicHandlerAbstract
@@ -68,7 +68,7 @@ abstract class AnthropicHandlerAbstract
             return null;
         }
 
-        return Arr::map(data_get($data, 'content', []), fn ($contentBlock): \PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations => MessagePartWithCitations::fromContentBlock($contentBlock));
+        return Arr::map(data_get($data, 'content', []), fn ($contentBlock): \Prism\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations => MessagePartWithCitations::fromContentBlock($contentBlock));
     }
 
     protected function handleResponseErrors(): void

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Anthropic\Handlers;
+namespace Prism\Prism\Providers\Anthropic\Handlers;
 
 use Illuminate\Support\Collection;
-use PrismPHP\Prism\Contracts\PrismRequest;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Providers\Anthropic\Maps\FinishReasonMap;
-use PrismPHP\Prism\Providers\Anthropic\Maps\MessageMap;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response;
-use PrismPHP\Prism\Structured\ResponseBuilder;
-use PrismPHP\Prism\Structured\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Contracts\PrismRequest;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Providers\Anthropic\Maps\FinishReasonMap;
+use Prism\Prism\Providers\Anthropic\Maps\MessageMap;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response;
+use Prism\Prism\Structured\ResponseBuilder;
+use Prism\Prism\Structured\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 
 class Structured extends AnthropicHandlerAbstract
 {

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -2,28 +2,28 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Anthropic\Handlers;
+namespace Prism\Prism\Providers\Anthropic\Handlers;
 
 use Illuminate\Support\Collection;
-use PrismPHP\Prism\Concerns\CallsTools;
-use PrismPHP\Prism\Contracts\PrismRequest;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Anthropic\Maps\FinishReasonMap;
-use PrismPHP\Prism\Providers\Anthropic\Maps\MessageMap;
-use PrismPHP\Prism\Providers\Anthropic\Maps\ToolChoiceMap;
-use PrismPHP\Prism\Providers\Anthropic\Maps\ToolMap;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response;
-use PrismPHP\Prism\Text\ResponseBuilder;
-use PrismPHP\Prism\Text\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Contracts\PrismRequest;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Anthropic\Maps\FinishReasonMap;
+use Prism\Prism\Providers\Anthropic\Maps\MessageMap;
+use Prism\Prism\Providers\Anthropic\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\Anthropic\Maps\ToolMap;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response;
+use Prism\Prism\Text\ResponseBuilder;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
 
 /**
  * @template TRequest of TextRequest

--- a/src/Providers/Anthropic/Maps/FinishReasonMap.php
+++ b/src/Providers/Anthropic/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Anthropic\Maps;
+namespace Prism\Prism\Providers\Anthropic\Maps;
 
-use PrismPHP\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/Anthropic/Maps/MessageMap.php
+++ b/src/Providers/Anthropic/Maps/MessageMap.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Anthropic\Maps;
+namespace Prism\Prism\Providers\Anthropic\Maps;
 
 use BackedEnum;
 use Exception;
 use InvalidArgumentException;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 
 class MessageMap
 {

--- a/src/Providers/Anthropic/Maps/ToolChoiceMap.php
+++ b/src/Providers/Anthropic/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Anthropic\Maps;
+namespace Prism\Prism\Providers\Anthropic\Maps;
 
 use InvalidArgumentException;
-use PrismPHP\Prism\Enums\ToolChoice;
+use Prism\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/Anthropic/Maps/ToolMap.php
+++ b/src/Providers/Anthropic/Maps/ToolMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Anthropic\Maps;
+namespace Prism\Prism\Providers\Anthropic\Maps;
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Tool as PrismTool;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Tool as PrismTool;
 use UnitEnum;
 
 class ToolMap

--- a/src/Providers/Anthropic/ValueObjects/Citation.php
+++ b/src/Providers/Anthropic/ValueObjects/Citation.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Anthropic\ValueObjects;
+namespace Prism\Prism\Providers\Anthropic\ValueObjects;
 
 class Citation
 {

--- a/src/Providers/Anthropic/ValueObjects/MessagePartWithCitations.php
+++ b/src/Providers/Anthropic/ValueObjects/MessagePartWithCitations.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Anthropic\ValueObjects;
+namespace Prism\Prism\Providers\Anthropic\ValueObjects;
 
 class MessagePartWithCitations
 {
@@ -21,7 +21,7 @@ class MessagePartWithCitations
     {
         return new self(
             $data['text'],
-            array_map(function (array $citation): \PrismPHP\Prism\Providers\Anthropic\ValueObjects\Citation {
+            array_map(function (array $citation): \Prism\Prism\Providers\Anthropic\ValueObjects\Citation {
                 $indexPropertyCommonPart = match ($citation['type']) {
                     'page_location' => 'page_number',
                     'char_location' => 'char_index',

--- a/src/Providers/DeepSeek/Concerns/MapsFinishReason.php
+++ b/src/Providers/DeepSeek/Concerns/MapsFinishReason.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\DeepSeek\Concerns;
+namespace Prism\Prism\Providers\DeepSeek\Concerns;
 
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Providers\DeepSeek\Maps\FinishReasonMap;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Providers\DeepSeek\Maps\FinishReasonMap;
 
 trait MapsFinishReason
 {

--- a/src/Providers/DeepSeek/Concerns/ValidatesResponses.php
+++ b/src/Providers/DeepSeek/Concerns/ValidatesResponses.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\DeepSeek\Concerns;
+namespace Prism\Prism\Providers\DeepSeek\Concerns;
 
-use PrismPHP\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismException;
 
 trait ValidatesResponses
 {

--- a/src/Providers/DeepSeek/DeepSeek.php
+++ b/src/Providers/DeepSeek/DeepSeek.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\DeepSeek;
+namespace Prism\Prism\Providers\DeepSeek;
 
 use Closure;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\DeepSeek\Handlers\Structured;
-use PrismPHP\Prism\Providers\DeepSeek\Handlers\Text;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\DeepSeek\Handlers\Structured;
+use Prism\Prism\Providers\DeepSeek\Handlers\Text;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 readonly class DeepSeek implements Provider
 {

--- a/src/Providers/DeepSeek/Handlers/Structured.php
+++ b/src/Providers/DeepSeek/Handlers/Structured.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace PrismPHP\Prism\Providers\DeepSeek\Handlers;
+namespace Prism\Prism\Providers\DeepSeek\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\DeepSeek\Concerns\MapsFinishReason;
-use PrismPHP\Prism\Providers\DeepSeek\Concerns\ValidatesResponses;
-use PrismPHP\Prism\Providers\DeepSeek\Maps\FinishReasonMap;
-use PrismPHP\Prism\Providers\DeepSeek\Maps\MessageMap;
-use PrismPHP\Prism\Structured\Request;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Structured\ResponseBuilder;
-use PrismPHP\Prism\Structured\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\DeepSeek\Concerns\MapsFinishReason;
+use Prism\Prism\Providers\DeepSeek\Concerns\ValidatesResponses;
+use Prism\Prism\Providers\DeepSeek\Maps\FinishReasonMap;
+use Prism\Prism\Providers\DeepSeek\Maps\MessageMap;
+use Prism\Prism\Structured\Request;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Structured\ResponseBuilder;
+use Prism\Prism\Structured\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Structured

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -2,27 +2,27 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\DeepSeek\Handlers;
+namespace Prism\Prism\Providers\DeepSeek\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
-use PrismPHP\Prism\Concerns\CallsTools;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\DeepSeek\Concerns\MapsFinishReason;
-use PrismPHP\Prism\Providers\DeepSeek\Concerns\ValidatesResponses;
-use PrismPHP\Prism\Providers\DeepSeek\Maps\MessageMap;
-use PrismPHP\Prism\Providers\DeepSeek\Maps\ToolCallMap;
-use PrismPHP\Prism\Providers\DeepSeek\Maps\ToolChoiceMap;
-use PrismPHP\Prism\Providers\DeepSeek\Maps\ToolMap;
-use PrismPHP\Prism\Text\Request;
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\Text\ResponseBuilder;
-use PrismPHP\Prism\Text\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ToolResult;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\DeepSeek\Concerns\MapsFinishReason;
+use Prism\Prism\Providers\DeepSeek\Concerns\ValidatesResponses;
+use Prism\Prism\Providers\DeepSeek\Maps\MessageMap;
+use Prism\Prism\Providers\DeepSeek\Maps\ToolCallMap;
+use Prism\Prism\Providers\DeepSeek\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\DeepSeek\Maps\ToolMap;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\Text\ResponseBuilder;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/DeepSeek/Maps/FinishReasonMap.php
+++ b/src/Providers/DeepSeek/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\DeepSeek\Maps;
+namespace Prism\Prism\Providers\DeepSeek\Maps;
 
-use PrismPHP\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/DeepSeek/Maps/MessageMap.php
+++ b/src/Providers/DeepSeek/Maps/MessageMap.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\DeepSeek\Maps;
+namespace Prism\Prism\Providers\DeepSeek\Maps;
 
 use Exception;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
 
 class MessageMap
 {

--- a/src/Providers/DeepSeek/Maps/ToolCallMap.php
+++ b/src/Providers/DeepSeek/Maps/ToolCallMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\DeepSeek\Maps;
+namespace Prism\Prism\Providers\DeepSeek\Maps;
 
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolCall;
 
 class ToolCallMap
 {

--- a/src/Providers/DeepSeek/Maps/ToolChoiceMap.php
+++ b/src/Providers/DeepSeek/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\DeepSeek\Maps;
+namespace Prism\Prism\Providers\DeepSeek\Maps;
 
 use InvalidArgumentException;
-use PrismPHP\Prism\Enums\ToolChoice;
+use Prism\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/DeepSeek/Maps/ToolMap.php
+++ b/src/Providers/DeepSeek/Maps/ToolMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\DeepSeek\Maps;
+namespace Prism\Prism\Providers\DeepSeek\Maps;
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/Gemini/Concerns/ValidatesResponse.php
+++ b/src/Providers/Gemini/Concerns/ValidatesResponse.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace PrismPHP\Prism\Providers\Gemini\Concerns;
+namespace Prism\Prism\Providers\Gemini\Concerns;
 
 use Illuminate\Http\Client\Response;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
 
 trait ValidatesResponse
 {

--- a/src/Providers/Gemini/Gemini.php
+++ b/src/Providers/Gemini/Gemini.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Gemini;
+namespace Prism\Prism\Providers\Gemini;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Gemini\Handlers\Embeddings;
-use PrismPHP\Prism\Providers\Gemini\Handlers\Structured;
-use PrismPHP\Prism\Providers\Gemini\Handlers\Text;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Gemini\Handlers\Embeddings;
+use Prism\Prism\Providers\Gemini\Handlers\Structured;
+use Prism\Prism\Providers\Gemini\Handlers\Text;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 readonly class Gemini implements Provider
 {

--- a/src/Providers/Gemini/Handlers/Embeddings.php
+++ b/src/Providers/Gemini/Handlers/Embeddings.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Gemini\Handlers;
+namespace Prism\Prism\Providers\Gemini\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
-use PrismPHP\Prism\Embeddings\Request;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\ValueObjects\Embedding;
-use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use PrismPHP\Prism\ValueObjects\Meta;
+use Prism\Prism\Embeddings\Request;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\ValueObjects\Embedding;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
 use Throwable;
 
 class Embeddings

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -1,22 +1,22 @@
 <?php
 
-namespace PrismPHP\Prism\Providers\Gemini\Handlers;
+namespace Prism\Prism\Providers\Gemini\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Gemini\Concerns\ValidatesResponse;
-use PrismPHP\Prism\Providers\Gemini\Maps\FinishReasonMap;
-use PrismPHP\Prism\Providers\Gemini\Maps\MessageMap;
-use PrismPHP\Prism\Providers\Gemini\Maps\SchemaMap;
-use PrismPHP\Prism\Structured\Request;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Structured\ResponseBuilder;
-use PrismPHP\Prism\Structured\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Gemini\Concerns\ValidatesResponse;
+use Prism\Prism\Providers\Gemini\Maps\FinishReasonMap;
+use Prism\Prism\Providers\Gemini\Maps\MessageMap;
+use Prism\Prism\Providers\Gemini\Maps\SchemaMap;
+use Prism\Prism\Structured\Request;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Structured\ResponseBuilder;
+use Prism\Prism\Structured\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Structured

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -2,29 +2,29 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Gemini\Handlers;
+namespace Prism\Prism\Providers\Gemini\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
-use PrismPHP\Prism\Concerns\CallsTools;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Gemini\Concerns\ValidatesResponse;
-use PrismPHP\Prism\Providers\Gemini\Maps\FinishReasonMap;
-use PrismPHP\Prism\Providers\Gemini\Maps\MessageMap;
-use PrismPHP\Prism\Providers\Gemini\Maps\ToolCallMap;
-use PrismPHP\Prism\Providers\Gemini\Maps\ToolChoiceMap;
-use PrismPHP\Prism\Providers\Gemini\Maps\ToolMap;
-use PrismPHP\Prism\Text\Request;
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\Text\ResponseBuilder;
-use PrismPHP\Prism\Text\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ToolResult;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Gemini\Concerns\ValidatesResponse;
+use Prism\Prism\Providers\Gemini\Maps\FinishReasonMap;
+use Prism\Prism\Providers\Gemini\Maps\MessageMap;
+use Prism\Prism\Providers\Gemini\Maps\ToolCallMap;
+use Prism\Prism\Providers\Gemini\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\Gemini\Maps\ToolMap;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\Text\ResponseBuilder;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/Gemini/Maps/FinishReasonMap.php
+++ b/src/Providers/Gemini/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Gemini\Maps;
+namespace Prism\Prism\Providers\Gemini\Maps;
 
-use PrismPHP\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/Gemini/Maps/MessageMap.php
+++ b/src/Providers/Gemini/Maps/MessageMap.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Gemini\Maps;
+namespace Prism\Prism\Providers\Gemini\Maps;
 
 use Exception;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 
 class MessageMap
 {

--- a/src/Providers/Gemini/Maps/SchemaMap.php
+++ b/src/Providers/Gemini/Maps/SchemaMap.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace PrismPHP\Prism\Providers\Gemini\Maps;
+namespace Prism\Prism\Providers\Gemini\Maps;
 
-use PrismPHP\Prism\Contracts\Schema;
-use PrismPHP\Prism\Schema\ArraySchema;
-use PrismPHP\Prism\Schema\BooleanSchema;
-use PrismPHP\Prism\Schema\NumberSchema;
-use PrismPHP\Prism\Schema\ObjectSchema;
+use Prism\Prism\Contracts\Schema;
+use Prism\Prism\Schema\ArraySchema;
+use Prism\Prism\Schema\BooleanSchema;
+use Prism\Prism\Schema\NumberSchema;
+use Prism\Prism\Schema\ObjectSchema;
 
 class SchemaMap
 {

--- a/src/Providers/Gemini/Maps/ToolCallMap.php
+++ b/src/Providers/Gemini/Maps/ToolCallMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Gemini\Maps;
+namespace Prism\Prism\Providers\Gemini\Maps;
 
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolCall;
 
 class ToolCallMap
 {
@@ -18,7 +18,7 @@ class ToolCallMap
             return [];
         }
 
-        return array_map(fn (array $toolCall): \PrismPHP\Prism\ValueObjects\ToolCall => new ToolCall(
+        return array_map(fn (array $toolCall): \Prism\Prism\ValueObjects\ToolCall => new ToolCall(
             id: data_get($toolCall, 'functionCall.name'),
             name: data_get($toolCall, 'functionCall.name'),
             arguments: data_get($toolCall, 'functionCall.args'),

--- a/src/Providers/Gemini/Maps/ToolChoiceMap.php
+++ b/src/Providers/Gemini/Maps/ToolChoiceMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Gemini\Maps;
+namespace Prism\Prism\Providers\Gemini\Maps;
 
-use PrismPHP\Prism\Enums\ToolChoice;
+use Prism\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/Gemini/Maps/ToolMap.php
+++ b/src/Providers/Gemini/Maps/ToolMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Gemini\Maps;
+namespace Prism\Prism\Providers\Gemini\Maps;
 
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/Groq/Concerns/ValidateResponse.php
+++ b/src/Providers/Groq/Concerns/ValidateResponse.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Groq\Concerns;
+namespace Prism\Prism\Providers\Groq\Concerns;
 
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 
 trait ValidateResponse
 {

--- a/src/Providers/Groq/Groq.php
+++ b/src/Providers/Groq/Groq.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Groq;
+namespace Prism\Prism\Providers\Groq;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Groq\Handlers\Text;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Groq\Handlers\Text;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response as TextResponse;
 
 readonly class Groq implements Provider
 {

--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -2,28 +2,28 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Groq\Handlers;
+namespace Prism\Prism\Providers\Groq\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
-use PrismPHP\Prism\Concerns\CallsTools;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Groq\Concerns\ValidateResponse;
-use PrismPHP\Prism\Providers\Groq\Maps\FinishReasonMap;
-use PrismPHP\Prism\Providers\Groq\Maps\MessageMap;
-use PrismPHP\Prism\Providers\Groq\Maps\ToolChoiceMap;
-use PrismPHP\Prism\Providers\Groq\Maps\ToolMap;
-use PrismPHP\Prism\Text\Request;
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\Text\ResponseBuilder;
-use PrismPHP\Prism\Text\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Groq\Concerns\ValidateResponse;
+use Prism\Prism\Providers\Groq\Maps\FinishReasonMap;
+use Prism\Prism\Providers\Groq\Maps\MessageMap;
+use Prism\Prism\Providers\Groq\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\Groq\Maps\ToolMap;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\Text\ResponseBuilder;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/Groq/Maps/FinishReasonMap.php
+++ b/src/Providers/Groq/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Groq\Maps;
+namespace Prism\Prism\Providers\Groq\Maps;
 
-use PrismPHP\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/Groq/Maps/MessageMap.php
+++ b/src/Providers/Groq/Maps/MessageMap.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Groq\Maps;
+namespace Prism\Prism\Providers\Groq\Maps;
 
 use Exception;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
 
 class MessageMap
 {

--- a/src/Providers/Groq/Maps/ToolChoiceMap.php
+++ b/src/Providers/Groq/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Groq\Maps;
+namespace Prism\Prism\Providers\Groq\Maps;
 
 use InvalidArgumentException;
-use PrismPHP\Prism\Enums\ToolChoice;
+use Prism\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/Groq/Maps/ToolMap.php
+++ b/src/Providers/Groq/Maps/ToolMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Groq\Maps;
+namespace Prism\Prism\Providers\Groq\Maps;
 
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/Mistral/Concerns/MapsFinishReason.php
+++ b/src/Providers/Mistral/Concerns/MapsFinishReason.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Mistral\Concerns;
+namespace Prism\Prism\Providers\Mistral\Concerns;
 
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Providers\Mistral\Maps\FinishReasonMap;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Providers\Mistral\Maps\FinishReasonMap;
 
 trait MapsFinishReason
 {

--- a/src/Providers/Mistral/Concerns/ValidatesResponse.php
+++ b/src/Providers/Mistral/Concerns/ValidatesResponse.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Mistral\Concerns;
+namespace Prism\Prism\Providers\Mistral\Concerns;
 
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Carbon;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 
 trait ValidatesResponse
 {

--- a/src/Providers/Mistral/Handlers/Embeddings.php
+++ b/src/Providers/Mistral/Handlers/Embeddings.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Mistral\Handlers;
+namespace Prism\Prism\Providers\Mistral\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
-use PrismPHP\Prism\Embeddings\Request;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Mistral\Concerns\ValidatesResponse;
-use PrismPHP\Prism\ValueObjects\Embedding;
-use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use PrismPHP\Prism\ValueObjects\Meta;
+use Prism\Prism\Embeddings\Request;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Mistral\Concerns\ValidatesResponse;
+use Prism\Prism\ValueObjects\Embedding;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
 use Throwable;
 
 class Embeddings
@@ -34,7 +34,7 @@ class Embeddings
         $data = $response->json();
 
         return new EmbeddingsResponse(
-            embeddings: array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($data, 'data', [])),
+            embeddings: array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($data, 'data', [])),
             usage: new EmbeddingsUsage(data_get($data, 'usage.total_tokens', null)),
             meta: new Meta(
                 id: data_get($data, 'id', ''),

--- a/src/Providers/Mistral/Handlers/Text.php
+++ b/src/Providers/Mistral/Handlers/Text.php
@@ -2,28 +2,28 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Mistral\Handlers;
+namespace Prism\Prism\Providers\Mistral\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
-use PrismPHP\Prism\Concerns\CallsTools;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Mistral\Concerns\MapsFinishReason;
-use PrismPHP\Prism\Providers\Mistral\Concerns\ValidatesResponse;
-use PrismPHP\Prism\Providers\Mistral\Maps\MessageMap;
-use PrismPHP\Prism\Providers\Mistral\Maps\ToolChoiceMap;
-use PrismPHP\Prism\Providers\Mistral\Maps\ToolMap;
-use PrismPHP\Prism\Text\Request;
-use PrismPHP\Prism\Text\Response;
-use PrismPHP\Prism\Text\ResponseBuilder;
-use PrismPHP\Prism\Text\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Mistral\Concerns\MapsFinishReason;
+use Prism\Prism\Providers\Mistral\Concerns\ValidatesResponse;
+use Prism\Prism\Providers\Mistral\Maps\MessageMap;
+use Prism\Prism\Providers\Mistral\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\Mistral\Maps\ToolMap;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response;
+use Prism\Prism\Text\ResponseBuilder;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text
@@ -156,7 +156,7 @@ class Text
             return [];
         }
 
-        return array_map(fn ($toolCall): \PrismPHP\Prism\ValueObjects\ToolCall => new ToolCall(
+        return array_map(fn ($toolCall): \Prism\Prism\ValueObjects\ToolCall => new ToolCall(
             id: data_get($toolCall, 'id'),
             name: data_get($toolCall, 'function.name'),
             arguments: data_get($toolCall, 'function.arguments'),

--- a/src/Providers/Mistral/Maps/FinishReasonMap.php
+++ b/src/Providers/Mistral/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Mistral\Maps;
+namespace Prism\Prism\Providers\Mistral\Maps;
 
-use PrismPHP\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/Mistral/Maps/MessageMap.php
+++ b/src/Providers/Mistral/Maps/MessageMap.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Mistral\Maps;
+namespace Prism\Prism\Providers\Mistral\Maps;
 
 use Exception;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
 
 class MessageMap
 {

--- a/src/Providers/Mistral/Maps/ToolChoiceMap.php
+++ b/src/Providers/Mistral/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Mistral\Maps;
+namespace Prism\Prism\Providers\Mistral\Maps;
 
 use InvalidArgumentException;
-use PrismPHP\Prism\Enums\ToolChoice;
+use Prism\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/Mistral/Maps/ToolMap.php
+++ b/src/Providers/Mistral/Maps/ToolMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Mistral\Maps;
+namespace Prism\Prism\Providers\Mistral\Maps;
 
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Mistral;
+namespace Prism\Prism\Providers\Mistral;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Mistral\Handlers\Embeddings;
-use PrismPHP\Prism\Providers\Mistral\Handlers\Text;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Mistral\Handlers\Embeddings;
+use Prism\Prism\Providers\Mistral\Handlers\Text;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 readonly class Mistral implements Provider
 {

--- a/src/Providers/Ollama/Concerns/MapsFinishReason.php
+++ b/src/Providers/Ollama/Concerns/MapsFinishReason.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Ollama\Concerns;
+namespace Prism\Prism\Providers\Ollama\Concerns;
 
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Providers\Ollama\Maps\FinishReasonMap;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Providers\Ollama\Maps\FinishReasonMap;
 
 trait MapsFinishReason
 {

--- a/src/Providers/Ollama/Concerns/MapsToolCalls.php
+++ b/src/Providers/Ollama/Concerns/MapsToolCalls.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Ollama\Concerns;
+namespace Prism\Prism\Providers\Ollama\Concerns;
 
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolCall;
 
 trait MapsToolCalls
 {

--- a/src/Providers/Ollama/Concerns/ValidatesResponse.php
+++ b/src/Providers/Ollama/Concerns/ValidatesResponse.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Ollama\Concerns;
+namespace Prism\Prism\Providers\Ollama\Concerns;
 
-use PrismPHP\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismException;
 
 trait ValidatesResponse
 {

--- a/src/Providers/Ollama/Handlers/Embeddings.php
+++ b/src/Providers/Ollama/Handlers/Embeddings.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Ollama\Handlers;
+namespace Prism\Prism\Providers\Ollama\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
-use PrismPHP\Prism\Embeddings\Request;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\ValueObjects\Embedding;
-use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use PrismPHP\Prism\ValueObjects\Meta;
+use Prism\Prism\Embeddings\Request;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\ValueObjects\Embedding;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
 use Throwable;
 
 class Embeddings
@@ -35,7 +35,7 @@ class Embeddings
         }
 
         return new EmbeddingsResponse(
-            embeddings: array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($data, 'embeddings', [])),
+            embeddings: array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($data, 'embeddings', [])),
             usage: new EmbeddingsUsage(data_get($data, 'prompt_eval_count', null)),
             meta: new Meta(
                 id: '',

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -2,20 +2,20 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Ollama\Handlers;
+namespace Prism\Prism\Providers\Ollama\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Ollama\Concerns\MapsFinishReason;
-use PrismPHP\Prism\Providers\Ollama\Concerns\ValidatesResponse;
-use PrismPHP\Prism\Providers\Ollama\Maps\MessageMap;
-use PrismPHP\Prism\Structured\Request;
-use PrismPHP\Prism\Structured\Response;
-use PrismPHP\Prism\Structured\ResponseBuilder;
-use PrismPHP\Prism\Structured\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Ollama\Concerns\MapsFinishReason;
+use Prism\Prism\Providers\Ollama\Concerns\ValidatesResponse;
+use Prism\Prism\Providers\Ollama\Maps\MessageMap;
+use Prism\Prism\Structured\Request;
+use Prism\Prism\Structured\Response;
+use Prism\Prism\Structured\ResponseBuilder;
+use Prism\Prism\Structured\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Structured

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -2,26 +2,26 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Ollama\Handlers;
+namespace Prism\Prism\Providers\Ollama\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
-use PrismPHP\Prism\Concerns\CallsTools;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Ollama\Concerns\MapsFinishReason;
-use PrismPHP\Prism\Providers\Ollama\Concerns\MapsToolCalls;
-use PrismPHP\Prism\Providers\Ollama\Concerns\ValidatesResponse;
-use PrismPHP\Prism\Providers\Ollama\Maps\MessageMap;
-use PrismPHP\Prism\Providers\Ollama\Maps\ToolMap;
-use PrismPHP\Prism\Text\Request;
-use PrismPHP\Prism\Text\Response;
-use PrismPHP\Prism\Text\ResponseBuilder;
-use PrismPHP\Prism\Text\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ToolResult;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Ollama\Concerns\MapsFinishReason;
+use Prism\Prism\Providers\Ollama\Concerns\MapsToolCalls;
+use Prism\Prism\Providers\Ollama\Concerns\ValidatesResponse;
+use Prism\Prism\Providers\Ollama\Maps\MessageMap;
+use Prism\Prism\Providers\Ollama\Maps\ToolMap;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response;
+use Prism\Prism\Text\ResponseBuilder;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/Ollama/Maps/FinishReasonMap.php
+++ b/src/Providers/Ollama/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Ollama\Maps;
+namespace Prism\Prism\Providers\Ollama\Maps;
 
-use PrismPHP\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/Ollama/Maps/MessageMap.php
+++ b/src/Providers/Ollama/Maps/MessageMap.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Ollama\Maps;
+namespace Prism\Prism\Providers\Ollama\Maps;
 
 use Exception;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 
 class MessageMap
 {

--- a/src/Providers/Ollama/Maps/ToolMap.php
+++ b/src/Providers/Ollama/Maps/ToolMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Ollama\Maps;
+namespace Prism\Prism\Providers\Ollama\Maps;
 
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/Ollama/Ollama.php
+++ b/src/Providers/Ollama/Ollama.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\Ollama;
+namespace Prism\Prism\Providers\Ollama;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Ollama\Handlers\Embeddings;
-use PrismPHP\Prism\Providers\Ollama\Handlers\Structured;
-use PrismPHP\Prism\Providers\Ollama\Handlers\Text;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Ollama\Handlers\Embeddings;
+use Prism\Prism\Providers\Ollama\Handlers\Structured;
+use Prism\Prism\Providers\Ollama\Handlers\Text;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 readonly class Ollama implements Provider
 {

--- a/src/Providers/OpenAI/Concerns/MapsFinishReason.php
+++ b/src/Providers/OpenAI/Concerns/MapsFinishReason.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Concerns;
+namespace Prism\Prism\Providers\OpenAI\Concerns;
 
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Providers\OpenAI\Maps\FinishReasonMap;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Providers\OpenAI\Maps\FinishReasonMap;
 
 trait MapsFinishReason
 {

--- a/src/Providers/OpenAI/Concerns/ProcessesRateLimits.php
+++ b/src/Providers/OpenAI/Concerns/ProcessesRateLimits.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace PrismPHP\Prism\Providers\OpenAI\Concerns;
+namespace Prism\Prism\Providers\OpenAI\Concerns;
 
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 
 trait ProcessesRateLimits
 {

--- a/src/Providers/OpenAI/Concerns/ValidatesResponse.php
+++ b/src/Providers/OpenAI/Concerns/ValidatesResponse.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Concerns;
+namespace Prism\Prism\Providers\OpenAI\Concerns;
 
 use Illuminate\Http\Client\Response;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
 
 trait ValidatesResponse
 {

--- a/src/Providers/OpenAI/Handlers/Embeddings.php
+++ b/src/Providers/OpenAI/Handlers/Embeddings.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Handlers;
+namespace Prism\Prism\Providers\OpenAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
-use PrismPHP\Prism\Embeddings\Request;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponse;
-use PrismPHP\Prism\ValueObjects\Embedding;
-use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use PrismPHP\Prism\ValueObjects\Meta;
+use Prism\Prism\Embeddings\Request;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
+use Prism\Prism\Providers\OpenAI\Concerns\ValidatesResponse;
+use Prism\Prism\ValueObjects\Embedding;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
 use Throwable;
 
 class Embeddings
@@ -35,7 +35,7 @@ class Embeddings
         $data = $response->json();
 
         return new EmbeddingsResponse(
-            embeddings: array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($data, 'data', [])),
+            embeddings: array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($data, 'data', [])),
             usage: new EmbeddingsUsage(data_get($data, 'usage.total_tokens', null)),
             meta: new Meta(
                 id: '',

--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -2,28 +2,28 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Handlers;
+namespace Prism\Prism\Providers\OpenAI\Handlers;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Str;
-use PrismPHP\Prism\Concerns\CallsTools;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismChunkDecodeException;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
-use PrismPHP\Prism\Providers\OpenAI\Maps\FinishReasonMap;
-use PrismPHP\Prism\Providers\OpenAI\Maps\MessageMap;
-use PrismPHP\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
-use PrismPHP\Prism\Providers\OpenAI\Maps\ToolMap;
-use PrismPHP\Prism\Stream\Chunk;
-use PrismPHP\Prism\Text\Request;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismChunkDecodeException;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
+use Prism\Prism\Providers\OpenAI\Maps\FinishReasonMap;
+use Prism\Prism\Providers\OpenAI\Maps\MessageMap;
+use Prism\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\OpenAI\Maps\ToolMap;
+use Prism\Prism\Stream\Chunk;
+use Prism\Prism\Text\Request;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\ToolCall;
 use Psr\Http\Message\StreamInterface;
 use Throwable;
 

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -1,25 +1,25 @@
 <?php
 
-namespace PrismPHP\Prism\Providers\OpenAI\Handlers;
+namespace Prism\Prism\Providers\OpenAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Enums\StructuredMode;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponse;
-use PrismPHP\Prism\Providers\OpenAI\Maps\MessageMap;
-use PrismPHP\Prism\Providers\OpenAI\Support\StructuredModeResolver;
-use PrismPHP\Prism\Structured\Request;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Structured\ResponseBuilder;
-use PrismPHP\Prism\Structured\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
+use Prism\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
+use Prism\Prism\Providers\OpenAI\Concerns\ValidatesResponse;
+use Prism\Prism\Providers\OpenAI\Maps\MessageMap;
+use Prism\Prism\Providers\OpenAI\Support\StructuredModeResolver;
+use Prism\Prism\Structured\Request;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Structured\ResponseBuilder;
+use Prism\Prism\Structured\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Structured

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -2,29 +2,29 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Handlers;
+namespace Prism\Prism\Providers\OpenAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
-use PrismPHP\Prism\Concerns\CallsTools;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ValidatesResponse;
-use PrismPHP\Prism\Providers\OpenAI\Maps\MessageMap;
-use PrismPHP\Prism\Providers\OpenAI\Maps\ToolCallMap;
-use PrismPHP\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
-use PrismPHP\Prism\Providers\OpenAI\Maps\ToolMap;
-use PrismPHP\Prism\Text\Request;
-use PrismPHP\Prism\Text\Response;
-use PrismPHP\Prism\Text\ResponseBuilder;
-use PrismPHP\Prism\Text\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ToolResult;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\OpenAI\Concerns\MapsFinishReason;
+use Prism\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
+use Prism\Prism\Providers\OpenAI\Concerns\ValidatesResponse;
+use Prism\Prism\Providers\OpenAI\Maps\MessageMap;
+use Prism\Prism\Providers\OpenAI\Maps\ToolCallMap;
+use Prism\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\OpenAI\Maps\ToolMap;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response;
+use Prism\Prism\Text\ResponseBuilder;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/OpenAI/Maps/FinishReasonMap.php
+++ b/src/Providers/OpenAI/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Maps;
+namespace Prism\Prism\Providers\OpenAI\Maps;
 
-use PrismPHP\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/OpenAI/Maps/MessageMap.php
+++ b/src/Providers/OpenAI/Maps/MessageMap.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Maps;
+namespace Prism\Prism\Providers\OpenAI\Maps;
 
 use Exception;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
 
 class MessageMap
 {

--- a/src/Providers/OpenAI/Maps/ToolCallMap.php
+++ b/src/Providers/OpenAI/Maps/ToolCallMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Maps;
+namespace Prism\Prism\Providers\OpenAI\Maps;
 
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolCall;
 
 class ToolCallMap
 {

--- a/src/Providers/OpenAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/OpenAI/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Maps;
+namespace Prism\Prism\Providers\OpenAI\Maps;
 
 use InvalidArgumentException;
-use PrismPHP\Prism\Enums\ToolChoice;
+use Prism\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/OpenAI/Maps/ToolMap.php
+++ b/src/Providers/OpenAI/Maps/ToolMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Maps;
+namespace Prism\Prism\Providers\OpenAI\Maps;
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI;
+namespace Prism\Prism\Providers\OpenAI;
 
 use Closure;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Providers\OpenAI\Handlers\Embeddings;
-use PrismPHP\Prism\Providers\OpenAI\Handlers\Stream;
-use PrismPHP\Prism\Providers\OpenAI\Handlers\Structured;
-use PrismPHP\Prism\Providers\OpenAI\Handlers\Text;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Providers\OpenAI\Handlers\Embeddings;
+use Prism\Prism\Providers\OpenAI\Handlers\Stream;
+use Prism\Prism\Providers\OpenAI\Handlers\Structured;
+use Prism\Prism\Providers\OpenAI\Handlers\Text;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 readonly class OpenAI implements Provider
 {

--- a/src/Providers/OpenAI/Support/StructuredModeResolver.php
+++ b/src/Providers/OpenAI/Support/StructuredModeResolver.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\OpenAI\Support;
+namespace Prism\Prism\Providers\OpenAI\Support;
 
-use PrismPHP\Prism\Enums\StructuredMode;
-use PrismPHP\Prism\Exceptions\PrismException;
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Exceptions\PrismException;
 
 class StructuredModeResolver
 {

--- a/src/Providers/VoyageAI/Embeddings.php
+++ b/src/Providers/VoyageAI/Embeddings.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace PrismPHP\Prism\Providers\VoyageAI;
+namespace Prism\Prism\Providers\VoyageAI;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingsRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\ValueObjects\Embedding;
-use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use PrismPHP\Prism\ValueObjects\Meta;
+use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\ValueObjects\Embedding;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
 
 class Embeddings
 {

--- a/src/Providers/VoyageAI/VoyageAI.php
+++ b/src/Providers/VoyageAI/VoyageAI.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace PrismPHP\Prism\Providers\VoyageAI;
+namespace Prism\Prism\Providers\VoyageAI;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingsResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 class VoyageAI implements Provider
 {

--- a/src/Providers/XAI/Concerns/MapsFinishReason.php
+++ b/src/Providers/XAI/Concerns/MapsFinishReason.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\XAI\Concerns;
+namespace Prism\Prism\Providers\XAI\Concerns;
 
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Providers\XAI\Maps\FinishReasonMap;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Providers\XAI\Maps\FinishReasonMap;
 
 trait MapsFinishReason
 {

--- a/src/Providers/XAI/Concerns/ValidatesResponses.php
+++ b/src/Providers/XAI/Concerns/ValidatesResponses.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\XAI\Concerns;
+namespace Prism\Prism\Providers\XAI\Concerns;
 
 use Illuminate\Http\Client\Response;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
 
 trait ValidatesResponses
 {

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -2,28 +2,28 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\XAI\Handlers;
+namespace Prism\Prism\Providers\XAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
-use PrismPHP\Prism\Concerns\CallsTools;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\XAI\Concerns\MapsFinishReason;
-use PrismPHP\Prism\Providers\XAI\Concerns\ValidatesResponses;
-use PrismPHP\Prism\Providers\XAI\Maps\MessageMap;
-use PrismPHP\Prism\Providers\XAI\Maps\ToolChoiceMap;
-use PrismPHP\Prism\Providers\XAI\Maps\ToolMap;
-use PrismPHP\Prism\Text\Request;
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\Text\ResponseBuilder;
-use PrismPHP\Prism\Text\Step;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\XAI\Concerns\MapsFinishReason;
+use Prism\Prism\Providers\XAI\Concerns\ValidatesResponses;
+use Prism\Prism\Providers\XAI\Maps\MessageMap;
+use Prism\Prism\Providers\XAI\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\XAI\Maps\ToolMap;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\Text\ResponseBuilder;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
 
 class Text

--- a/src/Providers/XAI/Maps/FinishReasonMap.php
+++ b/src/Providers/XAI/Maps/FinishReasonMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\XAI\Maps;
+namespace Prism\Prism\Providers\XAI\Maps;
 
-use PrismPHP\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\FinishReason;
 
 class FinishReasonMap
 {

--- a/src/Providers/XAI/Maps/MessageMap.php
+++ b/src/Providers/XAI/Maps/MessageMap.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\XAI\Maps;
+namespace Prism\Prism\Providers\XAI\Maps;
 
 use Exception;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
 
 class MessageMap
 {

--- a/src/Providers/XAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/XAI/Maps/ToolChoiceMap.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\XAI\Maps;
+namespace Prism\Prism\Providers\XAI\Maps;
 
 use InvalidArgumentException;
-use PrismPHP\Prism\Enums\ToolChoice;
+use Prism\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
 {

--- a/src/Providers/XAI/Maps/ToolMap.php
+++ b/src/Providers/XAI/Maps/ToolMap.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\XAI\Maps;
+namespace Prism\Prism\Providers\XAI\Maps;
 
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Tool;
 
 class ToolMap
 {

--- a/src/Providers/XAI/XAI.php
+++ b/src/Providers/XAI/XAI.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Providers\XAI;
+namespace Prism\Prism\Providers\XAI;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\XAI\Handlers\Text;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\XAI\Handlers\Text;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 readonly class XAI implements Provider
 {

--- a/src/Rectors/ReorderMethodsRector.php
+++ b/src/Rectors/ReorderMethodsRector.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PrismPHP\Prism\Rectors;
+namespace Prism\Prism\Rectors;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;

--- a/src/Routes/PrismServer.php
+++ b/src/Routes/PrismServer.php
@@ -1,8 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use PrismPHP\Prism\Http\Controllers\PrismChatController;
-use PrismPHP\Prism\Http\Controllers\PrismModelController;
+use Prism\Prism\Http\Controllers\PrismChatController;
+use Prism\Prism\Http\Controllers\PrismModelController;
 
 Route::prefix('/prism/openai/v1')
     ->group(function (): void {

--- a/src/Schema/ArraySchema.php
+++ b/src/Schema/ArraySchema.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Schema;
+namespace Prism\Prism\Schema;
 
-use PrismPHP\Prism\Concerns\NullableSchema;
-use PrismPHP\Prism\Contracts\Schema;
+use Prism\Prism\Concerns\NullableSchema;
+use Prism\Prism\Contracts\Schema;
 
 class ArraySchema implements Schema
 {

--- a/src/Schema/BooleanSchema.php
+++ b/src/Schema/BooleanSchema.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Schema;
+namespace Prism\Prism\Schema;
 
-use PrismPHP\Prism\Concerns\NullableSchema;
-use PrismPHP\Prism\Contracts\Schema;
+use Prism\Prism\Concerns\NullableSchema;
+use Prism\Prism\Contracts\Schema;
 
 class BooleanSchema implements Schema
 {

--- a/src/Schema/EnumSchema.php
+++ b/src/Schema/EnumSchema.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Schema;
+namespace Prism\Prism\Schema;
 
-use PrismPHP\Prism\Contracts\Schema;
+use Prism\Prism\Contracts\Schema;
 
 readonly class EnumSchema implements Schema
 {

--- a/src/Schema/NumberSchema.php
+++ b/src/Schema/NumberSchema.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Schema;
+namespace Prism\Prism\Schema;
 
-use PrismPHP\Prism\Concerns\NullableSchema;
-use PrismPHP\Prism\Contracts\Schema;
+use Prism\Prism\Concerns\NullableSchema;
+use Prism\Prism\Contracts\Schema;
 
 class NumberSchema implements Schema
 {

--- a/src/Schema/ObjectSchema.php
+++ b/src/Schema/ObjectSchema.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Schema;
+namespace Prism\Prism\Schema;
 
-use PrismPHP\Prism\Concerns\NullableSchema;
-use PrismPHP\Prism\Contracts\Schema;
+use Prism\Prism\Concerns\NullableSchema;
+use Prism\Prism\Contracts\Schema;
 
 class ObjectSchema implements Schema
 {

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Schema;
+namespace Prism\Prism\Schema;
 
-use PrismPHP\Prism\Concerns\NullableSchema;
-use PrismPHP\Prism\Contracts\Schema;
+use Prism\Prism\Concerns\NullableSchema;
+use Prism\Prism\Contracts\Schema;
 
 class StringSchema implements Schema
 {

--- a/src/Stream/Chunk.php
+++ b/src/Stream/Chunk.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Stream;
+namespace Prism\Prism\Stream;
 
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 
 readonly class Chunk
 {

--- a/src/Stream/PendingRequest.php
+++ b/src/Stream/PendingRequest.php
@@ -2,20 +2,20 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Stream;
+namespace Prism\Prism\Stream;
 
 use Generator;
-use PrismPHP\Prism\Concerns\ConfiguresClient;
-use PrismPHP\Prism\Concerns\ConfiguresGeneration;
-use PrismPHP\Prism\Concerns\ConfiguresModels;
-use PrismPHP\Prism\Concerns\ConfiguresProviders;
-use PrismPHP\Prism\Concerns\ConfiguresTools;
-use PrismPHP\Prism\Concerns\HasMessages;
-use PrismPHP\Prism\Concerns\HasPrompts;
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Concerns\HasTools;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Concerns\ConfiguresClient;
+use Prism\Prism\Concerns\ConfiguresGeneration;
+use Prism\Prism\Concerns\ConfiguresModels;
+use Prism\Prism\Concerns\ConfiguresProviders;
+use Prism\Prism\Concerns\ConfiguresTools;
+use Prism\Prism\Concerns\HasMessages;
+use Prism\Prism\Concerns\HasPrompts;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Concerns\HasTools;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 
 class PendingRequest
 {

--- a/src/Stream/Request.php
+++ b/src/Stream/Request.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Stream;
+namespace Prism\Prism\Stream;
 
-use PrismPHP\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Request as TextRequest;
 
 class Request extends TextRequest
 {

--- a/src/Stream/Response.php
+++ b/src/Stream/Response.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Stream;
+namespace Prism\Prism\Stream;
 
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Text\Response as TextResponse;
 
 readonly class Response extends TextResponse
 {

--- a/src/Stream/ResponseBuilder.php
+++ b/src/Stream/ResponseBuilder.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Stream;
+namespace Prism\Prism\Stream;
 
-use PrismPHP\Prism\Text\ResponseBuilder as TextResponseBuilder;
+use Prism\Prism\Text\ResponseBuilder as TextResponseBuilder;
 
 readonly class ResponseBuilder extends TextResponseBuilder
 {

--- a/src/Stream/Step.php
+++ b/src/Stream/Step.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Stream;
+namespace Prism\Prism\Stream;
 
-use PrismPHP\Prism\Text\Step as TextStep;
+use Prism\Prism\Text\Step as TextStep;
 
 readonly class Step extends TextStep
 {

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Structured;
+namespace Prism\Prism\Structured;
 
-use PrismPHP\Prism\Concerns\ConfiguresClient;
-use PrismPHP\Prism\Concerns\ConfiguresModels;
-use PrismPHP\Prism\Concerns\ConfiguresProviders;
-use PrismPHP\Prism\Concerns\ConfiguresStructuredOutput;
-use PrismPHP\Prism\Concerns\HasMessages;
-use PrismPHP\Prism\Concerns\HasPrompts;
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Concerns\HasSchema;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Concerns\ConfiguresClient;
+use Prism\Prism\Concerns\ConfiguresModels;
+use Prism\Prism\Concerns\ConfiguresProviders;
+use Prism\Prism\Concerns\ConfiguresStructuredOutput;
+use Prism\Prism\Concerns\HasMessages;
+use Prism\Prism\Concerns\HasPrompts;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Concerns\HasSchema;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 
 class PendingRequest
 {
@@ -43,7 +43,7 @@ class PendingRequest
             $messages[] = new UserMessage($this->prompt);
         }
 
-        if (! $this->schema instanceof \PrismPHP\Prism\Contracts\Schema) {
+        if (! $this->schema instanceof \Prism\Prism\Contracts\Schema) {
             throw new PrismException('A schema is required for structured output');
         }
 

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Structured;
+namespace Prism\Prism\Structured;
 
 use Closure;
-use PrismPHP\Prism\Concerns\ChecksSelf;
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\Contracts\PrismRequest;
-use PrismPHP\Prism\Contracts\Schema;
-use PrismPHP\Prism\Enums\StructuredMode;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\Concerns\ChecksSelf;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\Contracts\PrismRequest;
+use Prism\Prism\Contracts\Schema;
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 class Request implements PrismRequest
 {

--- a/src/Structured/Response.php
+++ b/src/Structured/Response.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Structured;
+namespace Prism\Prism\Structured;
 
 use Illuminate\Support\Collection;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 
 readonly class Response
 {

--- a/src/Structured/ResponseBuilder.php
+++ b/src/Structured/ResponseBuilder.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Structured;
+namespace Prism\Prism\Structured;
 
 use Illuminate\Support\Collection;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismStructuredDecodingException;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismStructuredDecodingException;
+use Prism\Prism\ValueObjects\Usage;
 
 readonly class ResponseBuilder
 {

--- a/src/Structured/Step.php
+++ b/src/Structured/Step.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Structured;
+namespace Prism\Prism\Structured;
 
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 
 readonly class Step
 {

--- a/src/Testing/PrismFake.php
+++ b/src/Testing/PrismFake.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Testing;
+namespace Prism\Prism\Testing;
 
 use Closure;
 use Exception;
 use Generator;
 use PHPUnit\Framework\Assert as PHPUnit;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 
 class PrismFake implements Provider
 {

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Text;
+namespace Prism\Prism\Text;
 
-use PrismPHP\Prism\Concerns\ConfiguresClient;
-use PrismPHP\Prism\Concerns\ConfiguresGeneration;
-use PrismPHP\Prism\Concerns\ConfiguresModels;
-use PrismPHP\Prism\Concerns\ConfiguresProviders;
-use PrismPHP\Prism\Concerns\ConfiguresTools;
-use PrismPHP\Prism\Concerns\HasMessages;
-use PrismPHP\Prism\Concerns\HasPrompts;
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Concerns\HasTools;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Concerns\ConfiguresClient;
+use Prism\Prism\Concerns\ConfiguresGeneration;
+use Prism\Prism\Concerns\ConfiguresModels;
+use Prism\Prism\Concerns\ConfiguresProviders;
+use Prism\Prism\Concerns\ConfiguresTools;
+use Prism\Prism\Concerns\HasMessages;
+use Prism\Prism\Concerns\HasPrompts;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Concerns\HasTools;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 
 class PendingRequest
 {

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Text;
+namespace Prism\Prism\Text;
 
 use Closure;
-use PrismPHP\Prism\Concerns\ChecksSelf;
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\Contracts\PrismRequest;
-use PrismPHP\Prism\Enums\ToolChoice;
-use PrismPHP\Prism\Tool;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\Concerns\ChecksSelf;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\Contracts\PrismRequest;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 class Request implements PrismRequest
 {

--- a/src/Text/Response.php
+++ b/src/Text/Response.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Text;
+namespace Prism\Prism\Text;
 
 use Illuminate\Support\Collection;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
 
 readonly class Response
 {

--- a/src/Text/ResponseBuilder.php
+++ b/src/Text/ResponseBuilder.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Text;
+namespace Prism\Prism\Text;
 
 use Illuminate\Support\Collection;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\ValueObjects\Usage;
 
 readonly class ResponseBuilder
 {

--- a/src/Text/Step.php
+++ b/src/Text/Step.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\Text;
+namespace Prism\Prism\Text;
 
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
 
 readonly class Step
 {

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism;
+namespace Prism\Prism;
 
 use ArgumentCountError;
 use Closure;
 use Error;
 use InvalidArgumentException;
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Contracts\Schema;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Schema\ArraySchema;
-use PrismPHP\Prism\Schema\BooleanSchema;
-use PrismPHP\Prism\Schema\EnumSchema;
-use PrismPHP\Prism\Schema\NumberSchema;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Contracts\Schema;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Schema\ArraySchema;
+use Prism\Prism\Schema\BooleanSchema;
+use Prism\Prism\Schema\EnumSchema;
+use Prism\Prism\Schema\NumberSchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
 use Throwable;
 use TypeError;
 

--- a/src/ValueObjects/Embedding.php
+++ b/src/ValueObjects/Embedding.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects;
+namespace Prism\Prism\ValueObjects;
 
 class Embedding
 {

--- a/src/ValueObjects/EmbeddingsUsage.php
+++ b/src/ValueObjects/EmbeddingsUsage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects;
+namespace Prism\Prism\ValueObjects;
 
 readonly class EmbeddingsUsage
 {

--- a/src/ValueObjects/Messages/AssistantMessage.php
+++ b/src/ValueObjects/Messages/AssistantMessage.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects\Messages;
+namespace Prism\Prism\ValueObjects\Messages;
 
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\ValueObjects\ToolCall;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\ValueObjects\ToolCall;
 
 class AssistantMessage implements Message
 {

--- a/src/ValueObjects/Messages/Support/Document.php
+++ b/src/ValueObjects/Messages/Support/Document.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects\Messages\Support;
+namespace Prism\Prism\ValueObjects\Messages\Support;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use PrismPHP\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Concerns\HasProviderMeta;
 
 /**
  * Note: Prism currently only supports Documents with Anthropic.

--- a/src/ValueObjects/Messages/Support/Image.php
+++ b/src/ValueObjects/Messages/Support/Image.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects\Messages\Support;
+namespace Prism\Prism\ValueObjects\Messages\Support;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;

--- a/src/ValueObjects/Messages/Support/Text.php
+++ b/src/ValueObjects/Messages/Support/Text.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects\Messages\Support;
+namespace Prism\Prism\ValueObjects\Messages\Support;
 
 readonly class Text
 {

--- a/src/ValueObjects/Messages/SystemMessage.php
+++ b/src/ValueObjects/Messages/SystemMessage.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects\Messages;
+namespace Prism\Prism\ValueObjects\Messages;
 
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Contracts\Message;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Contracts\Message;
 
 class SystemMessage implements Message
 {

--- a/src/ValueObjects/Messages/ToolResultMessage.php
+++ b/src/ValueObjects/Messages/ToolResultMessage.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects\Messages;
+namespace Prism\Prism\ValueObjects\Messages;
 
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\ValueObjects\ToolResult;
 
 readonly class ToolResultMessage implements Message
 {

--- a/src/ValueObjects/Messages/UserMessage.php
+++ b/src/ValueObjects/Messages/UserMessage.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects\Messages;
+namespace Prism\Prism\ValueObjects\Messages;
 
-use PrismPHP\Prism\Concerns\HasProviderMeta;
-use PrismPHP\Prism\Contracts\Message;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Text;
+use Prism\Prism\Concerns\HasProviderMeta;
+use Prism\Prism\Contracts\Message;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\Support\Text;
 
 class UserMessage implements Message
 {

--- a/src/ValueObjects/Meta.php
+++ b/src/ValueObjects/Meta.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects;
+namespace Prism\Prism\ValueObjects;
 
 readonly class Meta
 {

--- a/src/ValueObjects/ProviderRateLimit.php
+++ b/src/ValueObjects/ProviderRateLimit.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PrismPHP\Prism\ValueObjects;
+namespace Prism\Prism\ValueObjects;
 
 use Carbon\Carbon;
 

--- a/src/ValueObjects/ToolCall.php
+++ b/src/ValueObjects/ToolCall.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects;
+namespace Prism\Prism\ValueObjects;
 
 class ToolCall
 {

--- a/src/ValueObjects/ToolResult.php
+++ b/src/ValueObjects/ToolResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects;
+namespace Prism\Prism\ValueObjects;
 
 readonly class ToolResult
 {

--- a/src/ValueObjects/Usage.php
+++ b/src/ValueObjects/Usage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PrismPHP\Prism\ValueObjects;
+namespace Prism\Prism\ValueObjects;
 
 readonly class Usage
 {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\App;
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Prism;
 
 if (! function_exists('prism')) {
 

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,5 +1,5 @@
 providers:
-  - PrismPHP\Prism\PrismServiceProvider
+  - Prism\Prism\PrismServiceProvider
   - Workbench\App\Providers\WorkbenchServiceProvider
 
 migrations:

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -8,13 +8,13 @@ describe('Arch presets', function (): void {
 
 describe('Custom relaxed preset', function (): void {
     arch('No final classes')
-        ->expect('PrismPHP\Prism')
+        ->expect('Prism\Prism')
         ->classes()
         ->not
         ->toBeFinal();
 
     arch('No private methods')
-        ->expect('PrismPHP\Prism')
+        ->expect('Prism\Prism')
         ->classes()
         ->not
         ->toHavePrivateMethods();

--- a/tests/Concerns/HasProviderMetaTest.php
+++ b/tests/Concerns/HasProviderMetaTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Http;
 
-use PrismPHP\Prism\Text\PendingRequest;
+use Prism\Prism\Text\PendingRequest;
 
 test('providerMeta returns an array with all providerMeta if no valuePath is provided.', function (): void {
     $class = new PendingRequest;

--- a/tests/Fixtures/test-embedding-file.md
+++ b/tests/Fixtures/test-embedding-file.md
@@ -7,8 +7,8 @@ Prism provides a powerful interface for generating text using Large Language Mod
 At its simplest, you can generate text with just a few lines of code:
 
 ```php
-use PrismPHP\Prism\Facades\Prism;
-use PrismPHP\Prism\Enums\Provider;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Enums\Provider;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-sonnet')
@@ -47,8 +47,8 @@ You an also pass a View to the `withPrompt` method.
 For interactive conversations, use message chains to maintain context:
 
 ```php
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-sonnet')
@@ -75,7 +75,7 @@ $response = Prism::text()
 Prism supports including images in your messages for visual analysis:
 
 ```php
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
 
 // From a local file
 $message = new UserMessage(
@@ -188,7 +188,7 @@ case Unknown;
 Remember to handle potential errors in your generations:
 
 ```php
-use PrismPHP\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismException;
 use Throwable;
 
 try {

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Prism;
 
 it('can resolve prism from the container with helper function', function (): void {
     expect(prism())->toBeInstanceOf(Prism::class);

--- a/tests/Http/PrismChatControllerTest.php
+++ b/tests/Http/PrismChatControllerTest.php
@@ -6,14 +6,14 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 use Mockery;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Facades\PrismServer;
-use PrismPHP\Prism\Text\PendingRequest;
-use PrismPHP\Prism\Text\Response;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Facades\PrismServer;
+use Prism\Prism\Text\PendingRequest;
+use Prism\Prism\Text\Response;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 
 beforeEach(function (): void {
     config()->set('prism.prism_server.enabled', true);

--- a/tests/Http/PrismModelControllerTest.php
+++ b/tests/Http/PrismModelControllerTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Tests\Http;
 
 use Illuminate\Testing\TestResponse;
-use PrismPHP\Prism\Facades\PrismServer;
-use PrismPHP\Prism\Text\Generator;
+use Prism\Prism\Facades\PrismServer;
+use Prism\Prism\Text\Generator;
 
 it('it returns prisms', function (): void {
-    PrismServer::register('nyx', fn (): \PrismPHP\Prism\Text\Generator => new Generator);
-    PrismServer::register('omni', fn (): \PrismPHP\Prism\Text\Generator => new Generator);
+    PrismServer::register('nyx', fn (): \Prism\Prism\Text\Generator => new Generator);
+    PrismServer::register('omni', fn (): \Prism\Prism\Text\Generator => new Generator);
 
     /** @var TestResponse */
     $response = $this->getJson('/prism/openai/v1/models');

--- a/tests/PrismManagerTest.php
+++ b/tests/PrismManagerTest.php
@@ -6,16 +6,16 @@ namespace Tests;
 
 use Illuminate\Contracts\Foundation\Application;
 use Mockery;
-use PrismPHP\Prism\Contracts\Provider as ContractsProvider;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\PrismManager;
-use PrismPHP\Prism\Providers\Anthropic\Anthropic;
-use PrismPHP\Prism\Providers\DeepSeek\DeepSeek;
-use PrismPHP\Prism\Providers\Gemini\Gemini;
-use PrismPHP\Prism\Providers\Mistral\Mistral;
-use PrismPHP\Prism\Providers\Ollama\Ollama;
-use PrismPHP\Prism\Providers\OpenAI\OpenAI;
-use PrismPHP\Prism\Providers\XAI\XAI;
+use Prism\Prism\Contracts\Provider as ContractsProvider;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\PrismManager;
+use Prism\Prism\Providers\Anthropic\Anthropic;
+use Prism\Prism\Providers\DeepSeek\DeepSeek;
+use Prism\Prism\Providers\Gemini\Gemini;
+use Prism\Prism\Providers\Mistral\Mistral;
+use Prism\Prism\Providers\Ollama\Ollama;
+use Prism\Prism\Providers\OpenAI\OpenAI;
+use Prism\Prism\Providers\XAI\XAI;
 
 it('can resolve Anthropic', function (): void {
     $manager = new PrismManager($this->app);

--- a/tests/Providers/Anthropic/AnthropicExceptionsTest.php
+++ b/tests/Providers/Anthropic/AnthropicExceptionsTest.php
@@ -2,11 +2,11 @@
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Exceptions\PrismProviderOverloadedException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\Exceptions\PrismRequestTooLargeException;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 
 it('throws a RateLimitException if the Anthropic responds with a 429', function (): void {
     Http::fake([

--- a/tests/Providers/Anthropic/AnthropicTextTest.php
+++ b/tests/Providers/Anthropic/AnthropicTextTest.php
@@ -7,15 +7,15 @@ namespace Tests\Providers\Anthropic;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Providers\Anthropic\Handlers\Text;
-use PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Prism;
+use Prism\Prism\Providers\Anthropic\Handlers\Text;
+use Prism\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/Anthropic/MessageMapTest.php
+++ b/tests/Providers/Anthropic/MessageMapTest.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace Tests\Providers\Anthropic;
 
 use InvalidArgumentException;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
-use PrismPHP\Prism\Providers\Anthropic\Maps\MessageMap;
-use PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
+use Prism\Prism\Providers\Anthropic\Maps\MessageMap;
+use Prism\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 
 describe('Anthropic user message mapping', function (): void {
 

--- a/tests/Providers/Anthropic/StructuredTest.php
+++ b/tests/Providers/Anthropic/StructuredTest.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Tests\Providers\Anthropic;
 
 use Illuminate\Support\Carbon;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Providers\Anthropic\Handlers\Structured;
-use PrismPHP\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
-use PrismPHP\Prism\Schema\BooleanSchema;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Providers\Anthropic\Handlers\Structured;
+use Prism\Prism\Providers\Anthropic\ValueObjects\MessagePartWithCitations;
+use Prism\Prism\Schema\BooleanSchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/Anthropic/ToolMapTest.php
+++ b/tests/Providers/Anthropic/ToolMapTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Anthropic;
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
-use PrismPHP\Prism\Providers\Anthropic\Maps\ToolMap;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Providers\Anthropic\Enums\AnthropicCacheType;
+use Prism\Prism\Providers\Anthropic\Maps\ToolMap;
+use Prism\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/DeepSeek/EmbeddingsTest.php
+++ b/tests/Providers/DeepSeek/EmbeddingsTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Prism;
 
 beforeEach(function (): void {
     config()->set('prism.providers.deepseek.api_key', env('DEEPSEEK_API_KEY'));

--- a/tests/Providers/DeepSeek/MessageMapTest.php
+++ b/tests/Providers/DeepSeek/MessageMapTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Providers\DeepSeek\Maps\MessageMap;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Providers\DeepSeek\Maps\MessageMap;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/DeepSeek/StructuredTest.php
+++ b/tests/Providers/DeepSeek/StructuredTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Schema\BooleanSchema;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Schema\BooleanSchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Structured\Response as StructuredResponse;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/DeepSeek/TextTest.php
+++ b/tests/Providers/DeepSeek/TextTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Text\Response as TextResponse;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Prism;
+use Prism\Prism\Text\Response as TextResponse;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/DeepSeek/ToolTest.php
+++ b/tests/Providers/DeepSeek/ToolTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Providers\DeepSeek\Maps\ToolMap;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Providers\DeepSeek\Maps\ToolMap;
+use Prism\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/Gemini/EmbeddingsTest.php
+++ b/tests/Providers/Gemini/EmbeddingsTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tests\Providers\Gemini;
 
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Embedding;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Embedding;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/Gemini/GeminiExceptionsTest.php
+++ b/tests/Providers/Gemini/GeminiExceptionsTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tests\Providers\Gemini;
 
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Providers\Gemini\Concerns\ValidatesResponse;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Prism;
+use Prism\Prism\Providers\Gemini\Concerns\ValidatesResponse;
 
 arch()->expect([
     'Providers\Gemini\Handlers\Text',

--- a/tests/Providers/Gemini/GeminiStructuredTest.php
+++ b/tests/Providers/Gemini/GeminiStructuredTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Schema\ArraySchema;
-use PrismPHP\Prism\Schema\BooleanSchema;
-use PrismPHP\Prism\Schema\EnumSchema;
-use PrismPHP\Prism\Schema\NumberSchema;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Schema\ArraySchema;
+use Prism\Prism\Schema\BooleanSchema;
+use Prism\Prism\Schema\EnumSchema;
+use Prism\Prism\Schema\NumberSchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/Gemini/GeminiTextTest.php
+++ b/tests/Providers/Gemini/GeminiTextTest.php
@@ -6,13 +6,13 @@ namespace Tests\Providers\Gemini;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Tool;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/Gemini/MessageMapTest.php
+++ b/tests/Providers/Gemini/MessageMapTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Gemini;
 
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Providers\Gemini\Maps\MessageMap;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Gemini\Maps\MessageMap;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/Gemini/SchemaMapTest.php
+++ b/tests/Providers/Gemini/SchemaMapTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Providers\Gemini\Maps\SchemaMap;
-use PrismPHP\Prism\Schema\ArraySchema;
-use PrismPHP\Prism\Schema\BooleanSchema;
-use PrismPHP\Prism\Schema\EnumSchema;
-use PrismPHP\Prism\Schema\NumberSchema;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Providers\Gemini\Maps\SchemaMap;
+use Prism\Prism\Schema\ArraySchema;
+use Prism\Prism\Schema\BooleanSchema;
+use Prism\Prism\Schema\EnumSchema;
+use Prism\Prism\Schema\NumberSchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
 
 it('maps array schema correctly', function (): void {
     $map = (new SchemaMap(new ArraySchema(

--- a/tests/Providers/Gemini/ToolChoiceMapTest.php
+++ b/tests/Providers/Gemini/ToolChoiceMapTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Gemini;
 
-use PrismPHP\Prism\Enums\ToolChoice;
-use PrismPHP\Prism\Providers\Gemini\Maps\ToolChoiceMap;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Providers\Gemini\Maps\ToolChoiceMap;
 
 it('maps string tool choice to ANY mode with allowed function', function (): void {
     expect(ToolChoiceMap::map('weather'))->toBe([

--- a/tests/Providers/Gemini/ToolTest.php
+++ b/tests/Providers/Gemini/ToolTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Gemini;
 
-use PrismPHP\Prism\Providers\Gemini\Maps\ToolMap;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Providers\Gemini\Maps\ToolMap;
+use Prism\Prism\Tool;
 
 it('maps tools to gemini format', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/Groq/GroqTextTest.php
+++ b/tests/Providers/Groq/GroqTextTest.php
@@ -7,15 +7,15 @@ namespace Tests\Providers\Groq;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Enums\ToolChoice;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/Groq/MessageMapTest.php
+++ b/tests/Providers/Groq/MessageMapTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Groq;
 
-use PrismPHP\Prism\Providers\Groq\Maps\MessageMap;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Providers\Groq\Maps\MessageMap;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/Groq/ToolTest.php
+++ b/tests/Providers/Groq/ToolTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Groq;
 
-use PrismPHP\Prism\Providers\Groq\Maps\ToolMap;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Providers\Groq\Maps\ToolMap;
+use Prism\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/Mistral/EmbeddingsTest.php
+++ b/tests/Providers/Mistral/EmbeddingsTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tests\Providers\OpenAI;
 
 use Illuminate\Support\Carbon;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Embedding;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Embedding;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {
@@ -41,7 +41,7 @@ it('returns embeddings from file', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/mistral/embeddings-file-1.json'), true);
-    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
+    $embeddings = array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);
@@ -60,7 +60,7 @@ it('works with multiple embeddings', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/mistral/embeddings-multiple-inputs-1.json'), true);
-    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
+    $embeddings = array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);

--- a/tests/Providers/Mistral/MessageMapTest.php
+++ b/tests/Providers/Mistral/MessageMapTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Mistral;
 
-use PrismPHP\Prism\Providers\Mistral\Maps\MessageMap;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Providers\Mistral\Maps\MessageMap;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/Mistral/MistralExceptionsTest.php
+++ b/tests/Providers/Mistral/MistralExceptionsTest.php
@@ -6,11 +6,11 @@ namespace Tests\Providers\Mistral;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Providers\Mistral\Concerns\ValidatesResponse;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Prism;
+use Prism\Prism\Providers\Mistral\Concerns\ValidatesResponse;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 
 arch()->expect([
     'Providers\Mistral\Handlers\Text',

--- a/tests/Providers/Mistral/MistralTextTest.php
+++ b/tests/Providers/Mistral/MistralTextTest.php
@@ -7,14 +7,14 @@ namespace Tests\Providers\Mistral;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Enums\ToolChoice;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/Mistral/ToolTest.php
+++ b/tests/Providers/Mistral/ToolTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Mistral;
 
-use PrismPHP\Prism\Providers\Mistral\Maps\ToolMap;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Providers\Mistral\Maps\ToolMap;
+use Prism\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/Ollama/EmbeddingsTest.php
+++ b/tests/Providers/Ollama/EmbeddingsTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Ollama;
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Embedding;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Embedding;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns embeddings from input', function (): void {
@@ -18,7 +18,7 @@ it('returns embeddings from input', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/ollama/embeddings-input-1.json'), true);
-    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
+    $embeddings = array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
 
     expect($response->meta->model)->toBe('mxbai-embed-large');
     expect($response->embeddings)->toBeArray();
@@ -35,7 +35,7 @@ it('returns embeddings from file', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/ollama/embeddings-file-1.json'), true);
-    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
+    $embeddings = array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);
@@ -54,7 +54,7 @@ it('works with multiple embeddings', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/ollama/embeddings-multiple-inputs-1.json'), true);
-    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
+    $embeddings = array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);

--- a/tests/Providers/Ollama/MessageMapTest.php
+++ b/tests/Providers/Ollama/MessageMapTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Providers\Ollama\Maps\MessageMap;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Providers\Ollama\Maps\MessageMap;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolResult;
 
 it('maps system messages correctly', function (): void {
     $systemMessage = new SystemMessage('System instruction');
@@ -135,7 +135,7 @@ it('maps multiple messages in sequence correctly', function (): void {
 });
 
 it('throws exception for unknown message type', function (): void {
-    $invalidMessage = new class implements \PrismPHP\Prism\Contracts\Message {};
+    $invalidMessage = new class implements \Prism\Prism\Contracts\Message {};
     $messageMap = new MessageMap([$invalidMessage]);
 
     expect(fn (): array => $messageMap->map())

--- a/tests/Providers/Ollama/StructuredTest.php
+++ b/tests/Providers/Ollama/StructuredTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Tests\Providers\Ollama;
 
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Schema\ArraySchema;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Prism;
+use Prism\Prism\Schema\ArraySchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/Ollama/TextTest.php
+++ b/tests/Providers/Ollama/TextTest.php
@@ -6,13 +6,13 @@ namespace Tests\Providers\Ollama;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Tests\Fixtures\FixtureResponse;
 
 describe('Text generation', function (): void {

--- a/tests/Providers/Ollama/ToolTest.php
+++ b/tests/Providers/Ollama/ToolTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use PrismPHP\Prism\Providers\Ollama\Maps\ToolMap;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Providers\Ollama\Maps\ToolMap;
+use Prism\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/OpenAI/EmbeddingsTest.php
+++ b/tests/Providers/OpenAI/EmbeddingsTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tests\Providers\OpenAI;
 
 use Illuminate\Support\Carbon;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Embedding;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Embedding;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {
@@ -24,7 +24,7 @@ it('returns embeddings from input', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/openai/embeddings-input-1.json'), true);
-    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
+    $embeddings = array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
 
     expect($response->meta->model)->toBe('text-embedding-ada-002');
 
@@ -42,7 +42,7 @@ it('returns embeddings from file', function (): void {
         ->generate();
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/openai/embeddings-file-1.json'), true);
-    $embeddings = array_map(fn (array $item): \PrismPHP\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
+    $embeddings = array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item['embedding']), data_get($embeddings, 'data'));
 
     expect($response->embeddings)->toBeArray();
     expect($response->embeddings[0]->embedding)->toBe($embeddings[0]->embedding);

--- a/tests/Providers/OpenAI/MessageMapTest.php
+++ b/tests/Providers/OpenAI/MessageMapTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use PrismPHP\Prism\Providers\OpenAI\Maps\MessageMap;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Providers\OpenAI\Maps\MessageMap;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/OpenAI/OpenAIExceptionsTest.php
+++ b/tests/Providers/OpenAI/OpenAIExceptionsTest.php
@@ -6,11 +6,11 @@ namespace Tests\Providers\OpenAI;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
-use PrismPHP\Prism\ValueObjects\ProviderRateLimit;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Prism;
+use Prism\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
 
 arch()->expect([
     'Providers\OpenAI\Handlers\Text',

--- a/tests/Providers/OpenAI/StreamTest.php
+++ b/tests/Providers/OpenAI/StreamTest.php
@@ -6,9 +6,9 @@ namespace Tests\Providers\OpenAI;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Prism;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/OpenAI/StructuredTest.php
+++ b/tests/Providers/OpenAI/StructuredTest.php
@@ -7,12 +7,12 @@ namespace Tests\Providers\OpenAI;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Schema\BooleanSchema;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Prism;
+use Prism\Prism\Schema\BooleanSchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/OpenAI/TextTest.php
+++ b/tests/Providers/OpenAI/TextTest.php
@@ -7,10 +7,10 @@ namespace Tests\Providers\OpenAI;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\ToolChoice;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Prism;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Prism;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/Providers/OpenAI/ToolTest.php
+++ b/tests/Providers/OpenAI/ToolTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Providers\OpenAI;
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Providers\OpenAI\Maps\ToolMap;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Providers\OpenAI\Maps\ToolMap;
+use Prism\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/VoyageAI/EmbeddingsTest.php
+++ b/tests/Providers/VoyageAI/EmbeddingsTest.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\ValueObjects\Embedding;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Prism;
+use Prism\Prism\ValueObjects\Embedding;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns embeddings from input', function (): void {

--- a/tests/Providers/VoyageAI/VoyageAITest.php
+++ b/tests/Providers/VoyageAI/VoyageAITest.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Schema\ObjectSchema;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Prism;
+use Prism\Prism\Schema\ObjectSchema;
 
 it('throws an exception for text', function (): void {
     Http::fake()->preventStrayRequests();
@@ -15,7 +15,7 @@ it('throws an exception for text', function (): void {
         ->using(Provider::VoyageAI, 'test-model')
         ->withPrompt('Hello world.')
         ->generate();
-})->throws(PrismException::class, 'PrismPHP\Prism\Providers\VoyageAI\VoyageAI::text is not supported by VoyageAI');
+})->throws(PrismException::class, 'Prism\Prism\Providers\VoyageAI\VoyageAI::text is not supported by VoyageAI');
 
 it('throws an exception for structured', function (): void {
     Http::fake()->preventStrayRequests();
@@ -25,4 +25,4 @@ it('throws an exception for structured', function (): void {
         ->withSchema(new ObjectSchema('', '', []))
         ->withPrompt('Hello world.')
         ->generate();
-})->throws(PrismException::class, 'PrismPHP\Prism\Providers\VoyageAI\VoyageAI::structured is not supported by VoyageAI');
+})->throws(PrismException::class, 'Prism\Prism\Providers\VoyageAI\VoyageAI::structured is not supported by VoyageAI');

--- a/tests/Providers/XAI/MessageMapTest.php
+++ b/tests/Providers/XAI/MessageMapTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Providers\XAI;
 
-use PrismPHP\Prism\Providers\XAI\Maps\MessageMap;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\ToolResultMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
-use PrismPHP\Prism\ValueObjects\ToolCall;
-use PrismPHP\Prism\ValueObjects\ToolResult;
+use Prism\Prism\Providers\XAI\Maps\MessageMap;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 
 it('maps user messages', function (): void {
     $messageMap = new MessageMap(

--- a/tests/Providers/XAI/ToolTest.php
+++ b/tests/Providers/XAI/ToolTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\XAI;
 
-use PrismPHP\Prism\Providers\XAI\Maps\ToolMap;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Providers\XAI\Maps\ToolMap;
+use Prism\Prism\Tool;
 
 it('maps tools', function (): void {
     $tool = (new Tool)

--- a/tests/Providers/XAI/XAITextTest.php
+++ b/tests/Providers/XAI/XAITextTest.php
@@ -6,15 +6,15 @@ namespace Tests\Providers\XAI;
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Enums\ToolChoice;
-use PrismPHP\Prism\Exceptions\PrismRateLimitedException;
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Prism;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Tests\Fixtures\FixtureResponse;
 
 beforeEach(function (): void {

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use PrismPHP\Prism\Schema\ArraySchema;
-use PrismPHP\Prism\Schema\BooleanSchema;
-use PrismPHP\Prism\Schema\EnumSchema;
-use PrismPHP\Prism\Schema\NumberSchema;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
+use Prism\Prism\Schema\ArraySchema;
+use Prism\Prism\Schema\BooleanSchema;
+use Prism\Prism\Schema\EnumSchema;
+use Prism\Prism\Schema\NumberSchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
 
 it('they can have nested properties', function (): void {
     $schema = new ObjectSchema(

--- a/tests/Structured/PendingRequestTest.php
+++ b/tests/Structured/PendingRequestTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Enums\StructuredMode;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Schema\StringSchema;
-use PrismPHP\Prism\Structured\PendingRequest;
-use PrismPHP\Prism\Structured\Request;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Structured\PendingRequest;
+use Prism\Prism\Structured\Request;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 
 beforeEach(function (): void {
     $this->pendingRequest = new PendingRequest;

--- a/tests/Structured/ResponseBuilderTest.php
+++ b/tests/Structured/ResponseBuilderTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismStructuredDecodingException;
-use PrismPHP\Prism\Structured\ResponseBuilder;
-use PrismPHP\Prism\Structured\Step;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismStructuredDecodingException;
+use Prism\Prism\Structured\ResponseBuilder;
+use Prism\Prism\Structured\Step;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 
 test('throws a PrismStructuredDecodingException if the response is not valid json', function (): void {
     $builder = new ResponseBuilder;

--- a/tests/TestDoubles/TestProvider.php
+++ b/tests/TestDoubles/TestProvider.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 namespace Tests\TestDoubles;
 
 use Generator;
-use PrismPHP\Prism\Contracts\Provider;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Stream\Request as StreamRequest;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\ProviderResponse;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Stream\Request as StreamRequest;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ProviderResponse;
+use Prism\Prism\ValueObjects\Usage;
 
 class TestProvider implements Provider
 {

--- a/tests/Testing/PrismFakeTest.php
+++ b/tests/Testing/PrismFakeTest.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 namespace Tests\Testing;
 
 use Exception;
-use PrismPHP\Prism\Embeddings\Request as EmbeddingRequest;
-use PrismPHP\Prism\Embeddings\Response as EmbeddingResponse;
-use PrismPHP\Prism\Enums\FinishReason;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Prism;
-use PrismPHP\Prism\Schema\ObjectSchema;
-use PrismPHP\Prism\Schema\StringSchema;
-use PrismPHP\Prism\Structured\Request as StructuredRequest;
-use PrismPHP\Prism\Structured\Response as StructuredResponse;
-use PrismPHP\Prism\Text\Request as TextRequest;
-use PrismPHP\Prism\Text\Response as TextResponse;
-use PrismPHP\Prism\ValueObjects\EmbeddingsUsage;
-use PrismPHP\Prism\ValueObjects\Meta;
-use PrismPHP\Prism\ValueObjects\Usage;
+use Prism\Prism\Embeddings\Request as EmbeddingRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 
 it('fake responses using the prism fake for text', function (): void {
     $fake = Prism::fake([

--- a/tests/Text/PendingRequestTest.php
+++ b/tests/Text/PendingRequestTest.php
@@ -3,15 +3,15 @@
 declare(strict_types=1);
 
 use Illuminate\Contracts\View\View;
-use PrismPHP\Prism\Contracts\Provider as ProviderContract;
-use PrismPHP\Prism\Enums\Provider;
-use PrismPHP\Prism\Enums\ToolChoice;
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Facades\Tool;
-use PrismPHP\Prism\Text\PendingRequest;
-use PrismPHP\Prism\ValueObjects\Messages\AssistantMessage;
-use PrismPHP\Prism\ValueObjects\Messages\SystemMessage;
-use PrismPHP\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\Contracts\Provider as ProviderContract;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Text\PendingRequest;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Tests\TestDoubles\TestProvider;
 
 beforeEach(function (): void {

--- a/tests/ToolTest.php
+++ b/tests/ToolTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use PrismPHP\Prism\Exceptions\PrismException;
-use PrismPHP\Prism\Facades\Tool as ToolFacade;
-use PrismPHP\Prism\Schema\BooleanSchema;
-use PrismPHP\Prism\Schema\StringSchema;
-use PrismPHP\Prism\Tool;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Facades\Tool as ToolFacade;
+use Prism\Prism\Schema\BooleanSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Tool;
 
 it('can return tool details', function (): void {
     $searchTool = (new Tool)

--- a/tests/ValueObjects/Messages/Support/DocumentTest.php
+++ b/tests/ValueObjects/Messages/Support/DocumentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use PrismPHP\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
 
 it('can create a document from chunks', function (): void {
     $document = Document::fromChunks(['chunk1', 'chunk2'], 'title', 'context');

--- a/tests/ValueObjects/Messages/Support/ImageTest.php
+++ b/tests/ValueObjects/Messages/Support/ImageTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\ValueOpjects\Messages\Support;
 
-use PrismPHP\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
 
 it('can create an image from a file', function (): void {
     $image = Image::fromPath('tests/Fixtures/test-image.png');


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Related to #197 

Updates the packages namespace from `PrismPHP\Prism` to `Prism\Prism`