### PR TITLE
feat(openai): retry after header

### DIFF
--- a/src/Providers/OpenAI/Concerns/ValidatesResponse.php
+++ b/src/Providers/OpenAI/Concerns/ValidatesResponse.php
@@ -15,7 +15,7 @@ trait ValidatesResponse
         if ($response->getStatusCode() === 429) {
             throw PrismRateLimitedException::make(
                 rateLimits: $this->processRateLimits($response),
-                retryAfter: null
+                retryAfter: $response->header('retry-after') === '' ? null : (int) $response->header('retry-after'),
             );
         }
 

--- a/tests/Providers/OpenAI/OpenAIExceptionsTest.php
+++ b/tests/Providers/OpenAI/OpenAIExceptionsTest.php
@@ -41,6 +41,7 @@ it('sets the correct data on the PrismRateLimitedException', function (): void {
             '*' => Http::response(
                 status: 429,
                 headers: [
+                    'retry-after' => 29,
                     'x-ratelimit-limit-requests' => 60,
                     'x-ratelimit-limit-tokens' => 150000,
                     'x-ratelimit-remaining-requests' => 0,
@@ -57,7 +58,7 @@ it('sets the correct data on the PrismRateLimitedException', function (): void {
                 ->withPrompt('Hello world!')
                 ->generate();
         } catch (PrismRateLimitedException $e) {
-            expect($e->retryAfter)->toEqual(null);
+            expect($e->retryAfter)->toEqual(29);
             expect($e->rateLimits)->toHaveCount(2);
             expect($e->rateLimits[0])->toBeInstanceOf(ProviderRateLimit::class);
             expect($e->rateLimits[0]->name)->toEqual('requests');


### PR DESCRIPTION
This matches the `retryAfter` value of an OpenAI 429 rate limited response using the [same header as their Python library](https://github.com/openai/openai-python/blob/e36956673d9049713c91bca6ce7aebe58638f483/src/openai/_base_client.py#L621)