### PR TITLE
feat(openai): set the name of unmatched OpenAI rate limit errors

### DIFF
--- a/src/Providers/OpenAI/Concerns/ProcessesRateLimits.php
+++ b/src/Providers/OpenAI/Concerns/ProcessesRateLimits.php
@@ -26,6 +26,19 @@ trait ProcessesRateLimits
             $rateLimits[$limitName][$fieldName] = $headerValues[0];
         }
 
+        if ($rateLimits === []) {
+            $error = data_get($response->json(), 'error');
+            if (is_null($error)) {
+                return [];
+            }
+
+            return [
+                new ProviderRateLimit(
+                    name: data_get($error, 'type'),
+                ),
+            ];
+        }
+
         return array_values(Arr::map($rateLimits, function ($fields, $limitName): ProviderRateLimit {
             $resetsAt = data_get($fields, 'reset', '');
 

--- a/tests/Fixtures/FixtureResponse.php
+++ b/tests/Fixtures/FixtureResponse.php
@@ -12,8 +12,13 @@ class FixtureResponse
     /**
      * @param  array<string, string>  $headers
      */
-    public static function fakeResponseSequence(string $requestPath, string $name, array $headers = [], $forceRecording = false): void
-    {
+    public static function fakeResponseSequence(
+        string $requestPath,
+        string $name,
+        array $headers = [],
+        int $status = 200,
+        bool $forceRecording = false,
+    ): void {
         $basePath = dirname(static::filePath($name));
         $pathInfo = pathinfo($name);
         $filename = $pathInfo['filename'];
@@ -74,7 +79,7 @@ class FixtureResponse
             ->map(fn ($filename): string => $basePath.'/'.$filename)
             ->map(fn ($filePath) => Http::response(
                 file_get_contents($filePath),
-                200,
+                $status,
                 $headers
             ));
 

--- a/tests/Fixtures/openai/insufficient-quota-response-1.json
+++ b/tests/Fixtures/openai/insufficient-quota-response-1.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-BBoWJlIdY1LQQYArl5iOzodJzGaqe",
+  "object": "chat.completion",
+  "created": 1742155507,
+  "model": "gpt-4-0613",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "I am an artificial intelligence assistant designed to provide information and answer your questions to the best of my ability.",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 11,
+    "completion_tokens": 22,
+    "total_tokens": 33,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}

--- a/tests/Providers/OpenAI/OpenAIExceptionsTest.php
+++ b/tests/Providers/OpenAI/OpenAIExceptionsTest.php
@@ -105,7 +105,11 @@ it('works with milleseconds', function (): void {
 it('works without rate limit headers', function (): void {
     $this->expectException(PrismRateLimitedException::class);
 
-    FixtureResponse::fakeResponseSequence('v1/chat/completions', 'openai/insufficient-quota-response', status: 429);
+    FixtureResponse::fakeResponseSequence(
+        'v1/chat/completions',
+        'openai/insufficient-quota-response',
+        status: 429
+    );
 
     Prism::text()
         ->using('openai', 'gpt-4')

--- a/tests/Providers/OpenAI/OpenAIExceptionsTest.php
+++ b/tests/Providers/OpenAI/OpenAIExceptionsTest.php
@@ -103,19 +103,12 @@ it('works with milleseconds', function (): void {
 });
 
 it('works without rate limit headers', function (): void {
+    $this->expectException(PrismRateLimitedException::class);
+
     FixtureResponse::fakeResponseSequence('v1/chat/completions', 'openai/insufficient-quota-response', status: 429);
 
-    try {
-        Prism::text()
-            ->using('openai', 'gpt-4')
-            ->withPrompt('Who are you?')
-            ->generate();
-
-        // If we get here, the test failed because an exception should have been thrown
-        expect(false)->toBeTrue('Expected PrismRateLimitedException was not thrown');
-    } catch (PrismRateLimitedException $e) {
-        // The test passes if we catch the exception, even if rate limits aren't set correctly yet
-        // This will be fixed in a follow-up PR
-        expect(true)->toBeTrue();
-    }
+    Prism::text()
+        ->using('openai', 'gpt-4')
+        ->withPrompt('Who are you?')
+        ->asText();
 });


### PR DESCRIPTION
Handles OpenAI rate-limit errors (e.g. `insufficient_quota`) where no headers are set and the error is provided in the response.