### PR TITLE
feat(gemini): text search grounding

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -222,7 +222,7 @@ use Prism\Prism\Providers\Anthropic\ValueObjects\Citation;
 $messageChunks = $response->additionalContent['messagePartsWithCitations'];
 
 $text = '';
-$footnotes = '';
+$footnotes = [];
 
 $footnoteId = 1;
 

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -7,3 +7,21 @@
     'url' => env('GEMINI_URL', 'https://generativelanguage.googleapis.com/v1beta/models'),
 ],
 ```
+
+## Search grounding
+
+You may enable Google search grounding on text requests using providerMeta:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+
+Prism::text()
+    ->using(Provider::Gemini, 'gemini-2.0-flash')
+    ->withPrompt('What is the stock price of Google right now?')
+    // Enable search grounding
+    ->withProviderMeta(Provider::Gemini, ['searchGrounding' => true])
+    ->generate();
+```
+
+Note, Prism does not yet support interacting with returned citations.

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -16,7 +16,7 @@ You may enable Google search grounding on text requests using providerMeta:
 use Prism\Prism\Prism;
 use Prism\Prism\Enums\Provider;
 
-Prism::text()
+$response = Prism::text()
     ->using(Provider::Gemini, 'gemini-2.0-flash')
     ->withPrompt('What is the stock price of Google right now?')
     // Enable search grounding
@@ -24,4 +24,52 @@ Prism::text()
     ->generate();
 ```
 
-Note, Prism does not yet support interacting with returned citations.
+If you use search groundings, Google require you meet certain [display requirements](https://ai.google.dev/gemini-api/docs/grounding/search-suggestions).
+
+The data you need to meet these display requirements, and to build e.g. footnote functionality will be saved to the response's `additionalContent` property.
+
+```php
+// The Google supplied and styled widget to click through to results.
+$response->additionalContent['searchEntryPoint'];
+
+// The search queries made by the model
+$response->additionalContent['searchQueries'];
+
+// The detail needed to build your citations
+$response->additionalContent['groundingSupports'];
+```
+
+`groundingSupports` is an array of `MessagePartWithSearchGroundings`, which you can use to build up footnotes as follows:
+
+```php
+use Prism\Prism\Providers\Gemini\ValueObjects\MessagePartWithSearchGroundings;
+use Prism\Prism\Providers\Gemini\ValueObjects\SearchGrounding;
+
+$text = '';
+$footnotes = [];
+
+$footnoteId = 1;
+
+/** @var MessagePartWithSearchGrounding $part */
+foreach ($response->additionalContent['groundingSupports'] as $part) {
+    $text .= $part->text;
+    
+    /** @var SearchGrounding $grounding */
+    foreach ($part->groundings as $grounding) {
+        $footnotes[] = [
+            'id' => $footnoteId,
+            'firstCharacter' => $part->startIndex,
+            'lastCharacter' => $part->endIndex,
+            'title' => $grounding->title,
+            'uri' => $grounding->uri,
+            'confidence' => $grounding->confidence // Float 0-1
+        ];
+    
+        $text .= '<sup><a href="#footnote-'.$footnoteId.'">'.$footnoteId.'</a></sup>';
+    
+        $footnoteId++;
+    }
+}
+
+// Pass $text and $footnotes to your frontend.
+```

--- a/src/Providers/Gemini/Concerns/ExtractSearchGroundings.php
+++ b/src/Providers/Gemini/Concerns/ExtractSearchGroundings.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\Gemini\Concerns;
+
+use Prism\Prism\Providers\Gemini\Maps\SearchGroundingMap;
+
+trait ExtractSearchGroundings
+{
+    /**
+     * @param  array<string,mixed>  $data
+     * @return array<string,mixed>
+     */
+    protected function extractSearchGroundingContent(array $data): array
+    {
+        if (data_get($data, 'candidates.0.groundingMetadata') === null) {
+            return [];
+        }
+
+        return [
+            'searchEntryPoint' => data_get($data, 'candidates.0.groundingMetadata.searchEntryPoint.renderedContent', ''),
+            'searchQueries' => data_get($data, 'candidates.0.groundingMetadata.webSearchQueries', []),
+            'groundingSupports' => SearchGroundingMap::map(
+                data_get($data, 'candidates.0.groundingMetadata.groundingSupports', []),
+                data_get($data, 'candidates.0.groundingMetadata.groundingChunks', [])
+            ),
+        ];
+    }
+}

--- a/src/Providers/Gemini/Concerns/ValidatesResponse.php
+++ b/src/Providers/Gemini/Concerns/ValidatesResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Prism\Prism\Providers\Gemini\Concerns;
 
 use Illuminate\Http\Client\Response;

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -11,6 +11,7 @@ use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Enums\Provider;
 use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Gemini\Concerns\ExtractSearchGroundings;
 use Prism\Prism\Providers\Gemini\Concerns\ValidatesResponse;
 use Prism\Prism\Providers\Gemini\Maps\FinishReasonMap;
 use Prism\Prism\Providers\Gemini\Maps\MessageMap;
@@ -29,7 +30,7 @@ use Throwable;
 
 class Text
 {
-    use CallsTools, ValidatesResponse;
+    use CallsTools, ExtractSearchGroundings, ValidatesResponse;
 
     protected ResponseBuilder $responseBuilder;
 
@@ -166,7 +167,9 @@ class Text
             ),
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
-            additionalContent: [],
+            additionalContent: [
+                ...$this->extractSearchGroundingContent($data),
+            ],
         ));
     }
 }

--- a/src/Providers/Gemini/Maps/SearchGroundingMap.php
+++ b/src/Providers/Gemini/Maps/SearchGroundingMap.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\Gemini\Maps;
+
+use Prism\Prism\Providers\Gemini\ValueObjects\MessagePartWithSearchGroundings;
+use Prism\Prism\Providers\Gemini\ValueObjects\SearchGrounding;
+
+class SearchGroundingMap
+{
+    /**
+     * @param  array<string,mixed>  $groundingSupports
+     * @param  array<array<string,array<string,string>>>  $groundingChunks
+     * @return MessagePartWithSearchGroundings[]
+     */
+    public static function map(array $groundingSupports, array $groundingChunks): array
+    {
+        return array_map(
+            fn ($groundingSupport): \Prism\Prism\Providers\Gemini\ValueObjects\MessagePartWithSearchGroundings => new MessagePartWithSearchGroundings(
+                text: data_get($groundingSupport, 'segment.text', ''),
+                startIndex: data_get($groundingSupport, 'segment.startIndex', 0),
+                endIndex: data_get($groundingSupport, 'segment.endIndex', 0),
+                groundings: static::mapGroundings($groundingSupport, $groundingChunks)
+            ),
+            $groundingSupports
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $groundingSupport
+     * @param  array<array<string,array<string,string>>>  $groundingChunks
+     * @return SearchGrounding[]
+     */
+    protected static function mapGroundings(array $groundingSupport, array $groundingChunks): array
+    {
+        return array_map(
+            function ($index) use ($groundingChunks, $groundingSupport): \Prism\Prism\Providers\Gemini\ValueObjects\SearchGrounding {
+                $i = 0;
+
+                $grounding = new SearchGrounding(
+                    title: data_get($groundingChunks[$index], 'web.title', ''),
+                    uri: data_get($groundingChunks[$index], 'web.uri', ''),
+                    confidence: data_get($groundingSupport, "confidenceScores.$i", 0.0)
+                );
+
+                $i++;
+
+                return $grounding;
+            },
+            data_get($groundingSupport, 'groundingChunkIndices', [])
+        );
+    }
+}

--- a/src/Providers/Gemini/ValueObjects/MessagePartWithSearchGroundings.php
+++ b/src/Providers/Gemini/ValueObjects/MessagePartWithSearchGroundings.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\Gemini\ValueObjects;
 
-class MessagePartWithSearchGroundings
+use Illuminate\Contracts\Support\Arrayable;
+
+/**
+ * @implements Arrayable<string,mixed>
+ */
+class MessagePartWithSearchGroundings implements Arrayable
 {
     /**
      * @param  SearchGrounding[]  $groundings
@@ -15,4 +20,21 @@ class MessagePartWithSearchGroundings
         public readonly int $endIndex,
         public readonly array $groundings = []
     ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    #[\Override]
+    public function toArray(): array
+    {
+        return [
+            'text' => $this->text,
+            'startIndex' => $this->startIndex,
+            'endIndex' => $this->endIndex,
+            'groundings' => array_map(
+                fn (SearchGrounding $grounding): array => $grounding->toArray(),
+                $this->groundings
+            ),
+        ];
+    }
 }

--- a/src/Providers/Gemini/ValueObjects/MessagePartWithSearchGroundings.php
+++ b/src/Providers/Gemini/ValueObjects/MessagePartWithSearchGroundings.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\Gemini\ValueObjects;
+
+class MessagePartWithSearchGroundings
+{
+    /**
+     * @param  SearchGrounding[]  $groundings
+     */
+    public function __construct(
+        public readonly string $text,
+        public readonly int $startIndex,
+        public readonly int $endIndex,
+        public readonly array $groundings = []
+    ) {}
+}

--- a/src/Providers/Gemini/ValueObjects/SearchGrounding.php
+++ b/src/Providers/Gemini/ValueObjects/SearchGrounding.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\Gemini\ValueObjects;
+
+class SearchGrounding
+{
+    public function __construct(
+        public readonly string $title,
+        public readonly string $uri,
+        public readonly float $confidence
+    ) {}
+}

--- a/src/Providers/Gemini/ValueObjects/SearchGrounding.php
+++ b/src/Providers/Gemini/ValueObjects/SearchGrounding.php
@@ -4,11 +4,29 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\Gemini\ValueObjects;
 
-class SearchGrounding
+use Illuminate\Contracts\Support\Arrayable;
+
+/**
+ * @implements Arrayable<string,mixed>
+ */
+class SearchGrounding implements Arrayable
 {
     public function __construct(
         public readonly string $title,
         public readonly string $uri,
         public readonly float $confidence
     ) {}
+
+    /**
+     * @return array<string,mixed>
+     */
+    #[\Override]
+    public function toArray(): array
+    {
+        return [
+            'title' => $this->title,
+            'uri' => $this->uri,
+            'confidence' => $this->confidence,
+        ];
+    }
 }

--- a/tests/Fixtures/gemini/generate-text-with-search-grounding-1.json
+++ b/tests/Fixtures/gemini/generate-text-with-search-grounding-1.json
@@ -1,0 +1,122 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "As of March 14, 2025, at 20:00 BST, the closing stock price for Alphabet Inc. (GOOG:NSQ) was $167.62.\nHowever, other sources provide slightly different real-time data:\n\n*   **Robinhood:** Indicates a high today of $167.11 and a low today of $162.11.\n*   **TradingView:** Shows the current price of GOOGL as $162.76, a decrease of -2.30% in the past 24 hours.\n*   **Nasdaq:** Reports today's high/low as $166.13/$162.11 and the previous close as $167.11.\n"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "groundingMetadata": {
+        "searchEntryPoint": {
+          "renderedContent": "\u003cstyle\u003e\n.container {\n  align-items: center;\n  border-radius: 8px;\n  display: flex;\n  font-family: Google Sans, Roboto, sans-serif;\n  font-size: 14px;\n  line-height: 20px;\n  padding: 8px 12px;\n}\n.chip {\n  display: inline-block;\n  border: solid 1px;\n  border-radius: 16px;\n  min-width: 14px;\n  padding: 5px 16px;\n  text-align: center;\n  user-select: none;\n  margin: 0 8px;\n  -webkit-tap-highlight-color: transparent;\n}\n.carousel {\n  overflow: auto;\n  scrollbar-width: none;\n  white-space: nowrap;\n  margin-right: -12px;\n}\n.headline {\n  display: flex;\n  margin-right: 4px;\n}\n.gradient-container {\n  position: relative;\n}\n.gradient {\n  position: absolute;\n  transform: translate(3px, -9px);\n  height: 36px;\n  width: 9px;\n}\n@media (prefers-color-scheme: light) {\n  .container {\n    background-color: #fafafa;\n    box-shadow: 0 0 0 1px #0000000f;\n  }\n  .headline-label {\n    color: #1f1f1f;\n  }\n  .chip {\n    background-color: #ffffff;\n    border-color: #d2d2d2;\n    color: #5e5e5e;\n    text-decoration: none;\n  }\n  .chip:hover {\n    background-color: #f2f2f2;\n  }\n  .chip:focus {\n    background-color: #f2f2f2;\n  }\n  .chip:active {\n    background-color: #d8d8d8;\n    border-color: #b6b6b6;\n  }\n  .logo-dark {\n    display: none;\n  }\n  .gradient {\n    background: linear-gradient(90deg, #fafafa 15%, #fafafa00 100%);\n  }\n}\n@media (prefers-color-scheme: dark) {\n  .container {\n    background-color: #1f1f1f;\n    box-shadow: 0 0 0 1px #ffffff26;\n  }\n  .headline-label {\n    color: #fff;\n  }\n  .chip {\n    background-color: #2c2c2c;\n    border-color: #3c4043;\n    color: #fff;\n    text-decoration: none;\n  }\n  .chip:hover {\n    background-color: #353536;\n  }\n  .chip:focus {\n    background-color: #353536;\n  }\n  .chip:active {\n    background-color: #464849;\n    border-color: #53575b;\n  }\n  .logo-light {\n    display: none;\n  }\n  .gradient {\n    background: linear-gradient(90deg, #1f1f1f 15%, #1f1f1f00 100%);\n  }\n}\n\u003c/style\u003e\n\u003cdiv class=\"container\"\u003e\n  \u003cdiv class=\"headline\"\u003e\n    \u003csvg class=\"logo-light\" width=\"18\" height=\"18\" viewBox=\"9 9 35 35\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"\u003e\n      \u003cpath fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M42.8622 27.0064C42.8622 25.7839 42.7525 24.6084 42.5487 23.4799H26.3109V30.1568H35.5897C35.1821 32.3041 33.9596 34.1222 32.1258 35.3448V39.6864H37.7213C40.9814 36.677 42.8622 32.2571 42.8622 27.0064V27.0064Z\" fill=\"#4285F4\"/\u003e\n      \u003cpath fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M26.3109 43.8555C30.9659 43.8555 34.8687 42.3195 37.7213 39.6863L32.1258 35.3447C30.5898 36.3792 28.6306 37.0061 26.3109 37.0061C21.8282 37.0061 18.0195 33.9811 16.6559 29.906H10.9194V34.3573C13.7563 39.9841 19.5712 43.8555 26.3109 43.8555V43.8555Z\" fill=\"#34A853\"/\u003e\n      \u003cpath fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M16.6559 29.8904C16.3111 28.8559 16.1074 27.7588 16.1074 26.6146C16.1074 25.4704 16.3111 24.3733 16.6559 23.3388V18.8875H10.9194C9.74388 21.2072 9.06992 23.8247 9.06992 26.6146C9.06992 29.4045 9.74388 32.022 10.9194 34.3417L15.3864 30.8621L16.6559 29.8904V29.8904Z\" fill=\"#FBBC05\"/\u003e\n      \u003cpath fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M26.3109 16.2386C28.85 16.2386 31.107 17.1164 32.9095 18.8091L37.8466 13.8719C34.853 11.082 30.9659 9.3736 26.3109 9.3736C19.5712 9.3736 13.7563 13.245 10.9194 18.8875L16.6559 23.3388C18.0195 19.2636 21.8282 16.2386 26.3109 16.2386V16.2386Z\" fill=\"#EA4335\"/\u003e\n    \u003c/svg\u003e\n    \u003csvg class=\"logo-dark\" width=\"18\" height=\"18\" viewBox=\"0 0 48 48\" xmlns=\"http://www.w3.org/2000/svg\"\u003e\n      \u003ccircle cx=\"24\" cy=\"23\" fill=\"#FFF\" r=\"22\"/\u003e\n      \u003cpath d=\"M33.76 34.26c2.75-2.56 4.49-6.37 4.49-11.26 0-.89-.08-1.84-.29-3H24.01v5.99h8.03c-.4 2.02-1.5 3.56-3.07 4.56v.75l3.91 2.97h.88z\" fill=\"#4285F4\"/\u003e\n      \u003cpath d=\"M15.58 25.77A8.845 8.845 0 0 0 24 31.86c1.92 0 3.62-.46 4.97-1.31l4.79 3.71C31.14 36.7 27.65 38 24 38c-5.93 0-11.01-3.4-13.45-8.36l.17-1.01 4.06-2.85h.8z\" fill=\"#34A853\"/\u003e\n      \u003cpath d=\"M15.59 20.21a8.864 8.864 0 0 0 0 5.58l-5.03 3.86c-.98-2-1.53-4.25-1.53-6.64 0-2.39.55-4.64 1.53-6.64l1-.22 3.81 2.98.22 1.08z\" fill=\"#FBBC05\"/\u003e\n      \u003cpath d=\"M24 14.14c2.11 0 4.02.75 5.52 1.98l4.36-4.36C31.22 9.43 27.81 8 24 8c-5.93 0-11.01 3.4-13.45 8.36l5.03 3.85A8.86 8.86 0 0 1 24 14.14z\" fill=\"#EA4335\"/\u003e\n    \u003c/svg\u003e\n    \u003cdiv class=\"gradient-container\"\u003e\u003cdiv class=\"gradient\"\u003e\u003c/div\u003e\u003c/div\u003e\n  \u003c/div\u003e\n  \u003cdiv class=\"carousel\"\u003e\n    \u003ca class=\"chip\" href=\"https://vertexaisearch.cloud.google.com/grounding-api-redirect/AQXblrydXGr2BlSVBjo07bn6znlzvSmowZolyv8HlZpYY9283Kki6lel6GF0u6Xusircm84v9vXRdCbWqJ6xvp-SK772pj-WGuFR6Schb3f1cIjlX_ckti6gochxLxz_fuUg_WmqtmrWoGdAQ5quEgo3tey-j2Q2GonJVSpBXRYosyzIywdwHJBRta3PopirfpIevKZkqDrF4rJs\"\u003estock price of google\u003c/a\u003e\n  \u003c/div\u003e\n\u003c/div\u003e\n"
+        },
+        "groundingChunks": [
+          {
+            "web": {
+              "uri": "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AQXblrzVmdvQ-8RyZbo6knG4xQpbHhzoZtCKui-qEXo7n-Gda_UaV5RNo3GuuAV7OBLY8oRmb0giKvPjP0FXgI8gktbMyJOx9yUkSYbBUJpfbLaHQy13zjpVAC596HzWEfbPjoh1_5EtEinrM1LW0D0_6OwQ_iDClBsm62K-L-I=",
+              "title": "ft.com"
+            }
+          },
+          {
+            "web": {
+              "uri": "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AQXblrwHQTy1lqyXkL_ZTR2yX9LVXL1kmT2lzNGvoK6qvcNy00-sA7cMK0oTJzEQG5qMZqq54lToNR1iMYOeW4Hrn9e88-7oaPqhGy6Kc-DO4pI9r74RSEuDCCziwnaubBY=",
+              "title": "robinhood.com"
+            }
+          },
+          {
+            "web": {
+              "uri": "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AQXblrx3N5KuARTmEGl531BFbrv8RlYoahKjXz2BP4YPnX7GvY8zoNH2Oxua5A51qhaiHSHvEKwZKmT3kWD_C9KCaG45WR4m8geQxOBL0WKKKcyI2ccOAXu0VMSz6zsDSKeoxoEX6dsJtGQW9vVPDA==",
+              "title": "tradingview.com"
+            }
+          },
+          {
+            "web": {
+              "uri": "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AQXblrwBgQeuk_b623DGXbFEvu-uS5q6DYjUulBGw26jPfp-iCDsoAUip1KcyGVC3kV8OYa4nYfm7qpZKPZ0a6rzHhZ1wCl8M3iFwn8F70ZRSf5LYJ_D6WBL7ENN8ENja2y2Wqu0AxUfCEch84to-scf",
+              "title": "nasdaq.com"
+            }
+          }
+        ],
+        "groundingSupports": [
+          {
+            "segment": {
+              "startIndex": 78,
+              "endIndex": 101,
+              "text": "(GOOG:NSQ) was $167.62."
+            },
+            "groundingChunkIndices": [
+              0
+            ],
+            "confidenceScores": [
+              0.817279
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 169,
+              "endIndex": 249,
+              "text": "*   **Robinhood:** Indicates a high today of $167.11 and a low today of $162.11."
+            },
+            "groundingChunkIndices": [
+              1
+            ],
+            "confidenceScores": [
+              0.9855012
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 250,
+              "endIndex": 358,
+              "text": "*   **TradingView:** Shows the current price of GOOGL as $162.76, a decrease of -2.30% in the past 24 hours."
+            },
+            "groundingChunkIndices": [
+              2
+            ],
+            "confidenceScores": [
+              0.9488426
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 359,
+              "endIndex": 453,
+              "text": "*   **Nasdaq:** Reports today's high/low as $166.13/$162.11 and the previous close as $167.11."
+            },
+            "groundingChunkIndices": [
+              3
+            ],
+            "confidenceScores": [
+              0.9807108
+            ]
+          }
+        ],
+        "retrievalMetadata": {},
+        "webSearchQueries": [
+          "stock price of google"
+        ]
+      }
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 10,
+    "candidatesTokenCount": 175,
+    "totalTokenCount": 185,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 10
+      }
+    ],
+    "candidatesTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 175
+      }
+    ]
+  },
+  "modelVersion": "gemini-2.0-flash"
+}

--- a/tests/Providers/Gemini/GeminiTextTest.php
+++ b/tests/Providers/Gemini/GeminiTextTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Prism;
 use Prism\Prism\Tool;
 use Prism\Prism\ValueObjects\Messages\Support\Document;
@@ -311,5 +312,58 @@ describe('Document support for Gemini', function (): void {
 
             return true;
         });
+    });
+});
+
+describe('search grounding', function (): void {
+    it('adds the google_search empty tool if searchGrounding is set to true', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-search-grounding');
+
+        Prism::text()
+            ->using(Provider::Gemini, 'gemini-2.0-flash')
+            ->withPrompt('What is the stock price of Google right now?')
+            ->withProviderMeta(Provider::Gemini, ['searchGrounding' => true])
+            ->generate();
+
+        Http::assertSent(function (Request $request): true {
+            $data = $request->data();
+
+            expect($data['tools'][0])->toHaveKey('google_search');
+            expect($data['tools'][0]['google_search'])->toBeObject();
+
+            return true;
+        });
+    });
+
+    it('throws an exception of searchGrounding is enabled with other tools', function (): void {
+        Http::fake()->preventStrayRequests();
+
+        $tools = [
+            (new Tool)
+                ->as('search_games')
+                ->for('useful for searching current games times in the city')
+                ->withStringParameter('city', 'The city that you want the game times for')
+                ->using(fn (string $city): string => 'The tigers game is at 3pm in detroit'),
+        ];
+
+        Prism::text()
+            ->using(Provider::Gemini, 'gemini-2.0-flash')
+            ->withMaxSteps(3)
+            ->withTools($tools)
+            ->withPrompt('What sport fixtures are on today, and will I need a coat based on today\'s weather forecast?')
+            ->withProviderMeta(Provider::Gemini, ['searchGrounding' => true])
+            ->generate();
+    })->throws(PrismException::class, 'Use of search grounding with custom tools is not currently supported by Prism.');
+
+    it('uses search grounding where searchGrounding is true on provider meta', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-search-grounding');
+
+        $response = Prism::text()
+            ->using(Provider::Gemini, 'gemini-2.0-flash')
+            ->withPrompt('What is the stock price of Google right now?')
+            ->withProviderMeta(Provider::Gemini, ['searchGrounding' => true])
+            ->generate();
+
+        expect($response->text)->toContain('Alphabet Inc.');
     });
 });

--- a/tests/Providers/Gemini/ValueObjects/MessagePartWithSearchGroundingsTest.php
+++ b/tests/Providers/Gemini/ValueObjects/MessagePartWithSearchGroundingsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Providers\Gemini\ValueObjects\MessagePartWithSearchGroundings;
+use Prism\Prism\Providers\Gemini\ValueObjects\SearchGrounding;
+
+it('correctly casts to array', function (): void {
+    $valueObject = new MessagePartWithSearchGroundings(
+        text: 'text',
+        startIndex: 0,
+        endIndex: 1,
+        groundings: [
+            new SearchGrounding(
+                title: 'title',
+                uri: 'uri',
+                confidence: 0.5
+            ),
+            new SearchGrounding(
+                title: 'title2',
+                uri: 'uri2',
+                confidence: 0.6
+            ),
+        ]
+    );
+
+    expect($valueObject->toArray())->toBe([
+        'text' => 'text',
+        'startIndex' => 0,
+        'endIndex' => 1,
+        'groundings' => [
+            [
+                'title' => 'title',
+                'uri' => 'uri',
+                'confidence' => 0.5,
+            ],
+            [
+                'title' => 'title2',
+                'uri' => 'uri2',
+                'confidence' => 0.6,
+            ],
+        ],
+    ]);
+});

--- a/tests/Providers/Gemini/ValueObjects/SearchGroundingTest.php
+++ b/tests/Providers/Gemini/ValueObjects/SearchGroundingTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Providers\Gemini\ValueObjects\SearchGrounding;
+
+it('correctly casts to array', function (): void {
+    $valueObject = new SearchGrounding(
+        title: 'title',
+        uri: 'uri',
+        confidence: 0.5
+    );
+
+    expect($valueObject->toArray())->toBe([
+        'title' => 'title',
+        'uri' => 'uri',
+        'confidence' => 0.5,
+    ]);
+});


### PR DESCRIPTION
## Description

This PR:
- allows you to enable [Google search grounding](https://ai.google.dev/gemini-api/docs/grounding?lang=rest) on text requests
- returns the data you need to build up footnotes and comply with Google's display requirements in `additionalContent`.

Gemini does not support:
- use of search grounding with other tools, without using the "Live" (websocket) API (so Prism will throw an exception if you try).
- search grounding for structured.