### PR TITLE
bug(gemini): fix handler regressions

### DIFF
--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -61,7 +61,7 @@ class Structured
                     'cachedContent' => $providerMeta['cachedContentName'] ?? null,
                     'generationConfig' => array_filter([
                         'response_mime_type' => 'application/json',
-                        'response_schema' => new SchemaMap($request->schema()),
+                        'response_schema' => (new SchemaMap($request->schema()))->toArray(),
                         'temperature' => $request->temperature(),
                         'topP' => $request->topP(),
                         'maxOutputTokens' => $request->maxTokens(),

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -17,6 +17,7 @@ use Prism\Prism\Providers\Gemini\Maps\FinishReasonMap;
 use Prism\Prism\Providers\Gemini\Maps\MessageMap;
 use Prism\Prism\Providers\Gemini\Maps\ToolCallMap;
 use Prism\Prism\Providers\Gemini\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\Gemini\Maps\ToolMap;
 use Prism\Prism\Text\Request;
 use Prism\Prism\Text\Response as TextResponse;
 use Prism\Prism\Text\ResponseBuilder;
@@ -93,7 +94,7 @@ class Text
                         'google_search' => (object) [],
                     ],
                 ]
-                : ($request->tools() !== [] ? ['function_declarations' => $request->tools()] : []);
+                : ($request->tools() !== [] ? ['function_declarations' => ToolMap::map($request->tools())] : []);
 
             $providerMeta = $request->providerMeta(Provider::Gemini);
 

--- a/tests/Fixtures/FixtureResponse.php
+++ b/tests/Fixtures/FixtureResponse.php
@@ -35,7 +35,7 @@ class FixtureResponse
             $iterator = 0;
 
             Http::fake(function ($request) use ($requestPath, $name, &$iterator, $headers) {
-                if (Str::contains($request->url(), $requestPath)) {
+                if ($requestPath === '*' || Str::contains($request->url(), $requestPath)) {
                     $iterator++;
 
                     // Prepare path for recording


### PR DESCRIPTION
## Description

This fixes a side issue highlighted in #269, caused by a regression in #219 that was stopped schemas from working. It also fixes another regression with Tools, but I believe unrelated to #269.

@sixlive I also noticed that `FixtureResponse` no longer took a wildcard route when recording. I assumed that was unintentionally so re-added but do shout if it was intentional.
