### PR TITLE
bug(openai): Fixed Text handler response

### DIFF
--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -50,7 +50,7 @@ class Text
         $data = $response->json();
 
         $responseMessage = new AssistantMessage(
-            data_get($data, 'message.content') ?? '',
+            data_get($data, 'choices.0.message.content') ?? '',
             ToolCallMap::map(data_get($data, 'choices.0.message.tool_calls', [])),
         );
 


### PR DESCRIPTION
## Description
I was testing out the `PrismServer` feature and found that OpenAi models were not returning a response.

I forked to debug and found this line that was missed during a refactor.

Updating it fixed my issue and `PrismServer` now returns the correct response.
