### PR TITLE
feat(model-options): add HasModelOptions trait and integrate model op…

### DIFF
--- a/src/Concerns/HasModelOptions.php
+++ b/src/Concerns/HasModelOptions.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Prism\Prism\Concerns;
+
+use Prism\Prism\Text\PendingRequest;
+
+trait HasModelOptions
+{
+    /** @var array<string, array<string, mixed>> */
+    protected array $modelOptions = [];
+
+    /**
+     * @return HasModelOptions|\Prism\Prism\Structured\PendingRequest|PendingRequest
+     */
+    public function withOptions(array $options): self
+    {
+        $this->modelOptions = array_merge($this->modelOptions, $options);
+
+        return $this;
+    }
+}

--- a/src/Concerns/HasModelOptions.php
+++ b/src/Concerns/HasModelOptions.php
@@ -2,15 +2,13 @@
 
 namespace Prism\Prism\Concerns;
 
-use Prism\Prism\Text\PendingRequest;
-
 trait HasModelOptions
 {
-    /** @var array<string, array<string, mixed>> */
+    /** @var array<string, mixed> */
     protected array $modelOptions = [];
 
     /**
-     * @return HasModelOptions|\Prism\Prism\Structured\PendingRequest|PendingRequest
+     * @param  array<string, mixed>  $options
      */
     public function withOptions(array $options): self
     {

--- a/src/Embeddings/PendingRequest.php
+++ b/src/Embeddings/PendingRequest.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Embeddings;
 
 use Prism\Prism\Concerns\ConfiguresClient;
 use Prism\Prism\Concerns\ConfiguresProviders;
+use Prism\Prism\Concerns\HasModelOptions;
 use Prism\Prism\Concerns\HasProviderMeta;
 use Prism\Prism\Exceptions\PrismException;
 
@@ -13,6 +14,7 @@ class PendingRequest
 {
     use ConfiguresClient;
     use ConfiguresProviders;
+    use HasModelOptions;
     use HasProviderMeta;
 
     /** @var array<string> */
@@ -76,7 +78,8 @@ class PendingRequest
             inputs: $this->inputs,
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
-            providerMeta: $this->providerMeta
+            providerMeta: $this->providerMeta,
+            modelOptions: $this->modelOptions,
         );
     }
 }

--- a/src/Embeddings/Request.php
+++ b/src/Embeddings/Request.php
@@ -18,6 +18,7 @@ class Request implements PrismRequest
      * @param  array<string, mixed>  $clientOptions
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry
      * @param  array<string, mixed>  $providerMeta
+     * @param  array<string, mixed>  $modelOptions
      */
     public function __construct(
         protected string $model,
@@ -25,6 +26,7 @@ class Request implements PrismRequest
         protected array $clientOptions,
         protected array $clientRetry,
         array $providerMeta = [],
+        protected array $modelOptions = [],
     ) {
         $this->providerMeta = $providerMeta;
     }
@@ -57,5 +59,13 @@ class Request implements PrismRequest
     public function model(): string
     {
         return $this->model;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function options(): array
+    {
+        return array_filter($this->modelOptions);
     }
 }

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -92,6 +92,7 @@ class Structured extends AnthropicHandlerAbstract
             'max_tokens' => $request->maxTokens(),
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
+            ...$request->options(),
         ]);
     }
 

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -99,6 +99,7 @@ class Text extends AnthropicHandlerAbstract
             'top_p' => $request->topP(),
             'tools' => ToolMap::map($request->tools()),
             'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+            ...$request->options(),
         ]);
     }
 

--- a/src/Providers/DeepSeek/Handlers/Structured.php
+++ b/src/Providers/DeepSeek/Handlers/Structured.php
@@ -60,6 +60,7 @@ class Structured
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
                 'response_format' => ['type' => 'json_object'],
+                ...$request->options(),
             ]))
         );
 

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -114,6 +114,7 @@ class Text
                     'top_p' => $request->topP(),
                     'tools' => ToolMap::map($request->tools()),
                     'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                    ...$request->options(),
                 ]))
             );
 

--- a/src/Providers/Gemini/Handlers/Embeddings.php
+++ b/src/Providers/Gemini/Handlers/Embeddings.php
@@ -63,6 +63,7 @@ class Embeddings
                     'parts' => [
                         ['text' => $request->inputs()[0]],
                     ],
+                    ...$request->options(),
                 ],
             ]
         );

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -65,6 +65,7 @@ class Structured
                         'temperature' => $request->temperature(),
                         'topP' => $request->topP(),
                         'maxOutputTokens' => $request->maxTokens(),
+                        ...$request->options(),
                     ]),
                     'safetySettings' => $providerMeta['safetySettings'] ?? null,
                 ])

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -78,12 +78,6 @@ class Text
         try {
             $providerMeta = $request->providerMeta(Provider::Gemini);
 
-            $generationConfig = array_filter([
-                'temperature' => $request->temperature(),
-                'topP' => $request->topP(),
-                'maxOutputTokens' => $request->maxTokens(),
-            ]);
-
             if ($request->tools() !== [] && ($providerMeta['searchGrounding'] ?? false)) {
                 throw new Exception('Use of search grounding with custom tools is not currently supported by Prism.');
             }
@@ -103,7 +97,12 @@ class Text
                 array_filter([
                     ...(new MessageMap($request->messages(), $request->systemPrompts()))(),
                     'cachedContent' => $providerMeta['cachedContentName'] ?? null,
-                    'generationConfig' => $generationConfig !== [] ? $generationConfig : null,
+                    'generationConfig' => array_filter([
+                        'temperature' => $request->temperature(),
+                        'topP' => $request->topP(),
+                        'maxOutputTokens' => $request->maxTokens(),
+                        ...$request->options(),
+                    ]),
                     'tools' => $tools !== [] ? $tools : null,
                     'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
                     'safetySettings' => $providerMeta['safetySettings'] ?? null,

--- a/src/Providers/Groq/Handlers/Structured.php
+++ b/src/Providers/Groq/Handlers/Structured.php
@@ -53,11 +53,12 @@ class Structured
             array_merge([
                 'model' => $request->model(),
                 'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                'max_tokens' => $request->maxTokens(),
             ], array_filter([
+                'max_tokens' => $request->maxTokens(),
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
                 'response_format' => ['type' => 'json_object'],
+                ...$request->options(),
             ]))
         );
     }

--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -12,8 +12,6 @@ use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\Groq\Concerns\ValidateResponse;
 use Prism\Prism\Providers\Groq\Maps\FinishReasonMap;
 use Prism\Prism\Providers\Groq\Maps\MessageMap;
-use Prism\Prism\Providers\Groq\Maps\ToolChoiceMap;
-use Prism\Prism\Providers\Groq\Maps\ToolMap;
 use Prism\Prism\Text\Request;
 use Prism\Prism\Text\Response as TextResponse;
 use Prism\Prism\Text\ResponseBuilder;
@@ -68,15 +66,16 @@ class Text
         try {
             return $this->client->post(
                 'chat/completions',
-                array_filter([
+                array_merge([
                     'model' => $request->model(),
                     'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                ], array_filter([
                     'max_tokens' => $request->maxTokens(),
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
-                    'tools' => ToolMap::map($request->tools()),
-                    'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
-                ])
+                    'response_format' => ['type' => 'json_object'],
+                    ...$request->options(),
+                ]))
             );
         } catch (Throwable $e) {
             throw PrismException::providerRequestError($request->model(), $e);

--- a/src/Providers/Mistral/Handlers/Structured.php
+++ b/src/Providers/Mistral/Handlers/Structured.php
@@ -57,11 +57,12 @@ class Structured
             array_merge([
                 'model' => $request->model(),
                 'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                'max_tokens' => $request->maxTokens(),
             ], array_filter([
+                'max_tokens' => $request->maxTokens(),
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
                 'response_format' => ['type' => 'json_object'],
+                ...$request->options(),
             ]))
         );
     }

--- a/src/Providers/Mistral/Handlers/Text.php
+++ b/src/Providers/Mistral/Handlers/Text.php
@@ -132,15 +132,20 @@ class Text
     protected function sendRequest(Request $request): ClientResponse
     {
         try {
-            return $this->client->post('chat/completions', [
-                'model' => $request->model(),
-                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                'tools' => ToolMap::map($request->tools()),
-                'temperature' => $request->temperature(),
-                'max_tokens' => $request->maxTokens(),
-                'top_p' => $request->topP(),
-                'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
-            ]);
+            return $this->client->post(
+                'chat/completions',
+                array_merge([
+                    'model' => $request->model(),
+                    'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                ], array_filter([
+                    'tools' => ToolMap::map($request->tools()),
+                    'temperature' => $request->temperature(),
+                    'max_tokens' => $request->maxTokens(),
+                    'top_p' => $request->topP(),
+                    'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                    ...$request->options(),
+                ])));
+
         } catch (Throwable $e) {
             throw PrismException::providerRequestError($request->model(), $e);
         }

--- a/src/Providers/Ollama/Handlers/Embeddings.php
+++ b/src/Providers/Ollama/Handlers/Embeddings.php
@@ -48,10 +48,13 @@ class Embeddings
     {
         return $this->client->post(
             'api/embed',
-            [
+            array_filter([
                 'model' => $request->model(),
                 'input' => $request->inputs(),
-            ]
+                'options' => [
+                    ...$request->options(),
+                ],
+            ])
         );
     }
 }

--- a/src/Providers/Ollama/Handlers/Stream.php
+++ b/src/Providers/Ollama/Handlers/Stream.php
@@ -185,6 +185,7 @@ class Stream
                         'temperature' => $request->temperature(),
                         'num_predict' => $request->maxTokens() ?? 2048,
                         'top_p' => $request->topP(),
+                        ...$request->options(),
                     ]),
                 ]);
         } catch (Throwable $e) {

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -91,7 +91,9 @@ class Structured
                     'temperature' => $request->temperature(),
                     'num_predict' => $request->maxTokens() ?? 2048,
                     'top_p' => $request->topP(),
-                ])]);
+                    ...$request->options(),
+                ]),
+            ]);
 
             return $response->json();
         } catch (Throwable $e) {

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -82,7 +82,9 @@ class Text
                         'temperature' => $request->temperature(),
                         'num_predict' => $request->maxTokens() ?? 2048,
                         'top_p' => $request->topP(),
-                    ])]);
+                        ...$request->options(),
+                    ]),
+                ]);
 
             return $response->json();
         } catch (Throwable $e) {

--- a/src/Providers/OpenAI/Handlers/Embeddings.php
+++ b/src/Providers/OpenAI/Handlers/Embeddings.php
@@ -52,6 +52,7 @@ class Embeddings
             [
                 'model' => $request->model(),
                 'input' => $request->inputs(),
+                ...$request->options(),
             ]
         );
     }

--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -210,15 +210,16 @@ class Stream
                 ->post(
                     'chat/completions',
                     array_merge([
-                        'stream' => true,
                         'model' => $request->model(),
                         'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                        'max_completion_tokens' => $request->maxTokens(),
                     ], array_filter([
+                        'stream' => true,
+                        'max_completion_tokens' => $request->maxTokens(),
                         'temperature' => $request->temperature(),
                         'top_p' => $request->topP(),
                         'tools' => ToolMap::map($request->tools()),
                         'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                        ...$request->options(),
                     ]))
                 );
         } catch (Throwable $e) {

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -97,11 +97,12 @@ class Structured
                 array_merge([
                     'model' => $request->model(),
                     'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                    'max_completion_tokens' => $request->maxTokens(),
                 ], array_filter([
+                    'max_completion_tokens' => $request->maxTokens(),
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'response_format' => $responseFormat,
+                    ...$request->options(),
                 ]))
             );
         } catch (Throwable $e) {

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -109,12 +109,13 @@ class Text
                 array_merge([
                     'model' => $request->model(),
                     'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                    'max_completion_tokens' => $request->maxTokens(),
                 ], array_filter([
+                    'max_completion_tokens' => $request->maxTokens(),
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'tools' => ToolMap::map($request->tools()),
                     'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                    ...$request->options(),
                 ]))
             );
         } catch (Throwable $e) {

--- a/src/Providers/VoyageAI/Handlers/Embeddings.php
+++ b/src/Providers/VoyageAI/Handlers/Embeddings.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Prism\Prism\Providers\VoyageAI;
+namespace EchoLabs\Prism\Providers\VoyageAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
@@ -51,8 +51,9 @@ class Embeddings
             $this->httpResponse = $this->client->post('embeddings', array_filter([
                 'model' => $this->request->model(),
                 'input' => $this->request->inputs(),
-                'input_type' => $providerMeta['inputType'] ?? null,
-                'truncation' => $providerMeta['truncation'] ?? null,
+                'input_type' => data_get($providerMeta, 'input_type'),
+                'truncation' => data_get($providerMeta, 'truncation'),
+                ...$this->request->options(),
             ]));
         } catch (\Exception $e) {
             throw PrismException::providerRequestError($this->request->model(), $e);

--- a/src/Providers/VoyageAI/Handlers/Embeddings.php
+++ b/src/Providers/VoyageAI/Handlers/Embeddings.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EchoLabs\Prism\Providers\VoyageAI\Handlers;
+namespace Prism\Prism\Providers\VoyageAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;

--- a/src/Providers/VoyageAI/VoyageAI.php
+++ b/src/Providers/VoyageAI/VoyageAI.php
@@ -2,7 +2,6 @@
 
 namespace Prism\Prism\Providers\VoyageAI;
 
-use EchoLabs\Prism\Providers\VoyageAI\Handlers\Embeddings;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
@@ -10,6 +9,7 @@ use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
 use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\VoyageAI\Handlers\Embeddings;
 use Prism\Prism\Structured\Request as StructuredRequest;
 use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Text\Request as TextRequest;

--- a/src/Providers/VoyageAI/VoyageAI.php
+++ b/src/Providers/VoyageAI/VoyageAI.php
@@ -2,6 +2,7 @@
 
 namespace Prism\Prism\Providers\VoyageAI;
 
+use EchoLabs\Prism\Providers\VoyageAI\Handlers\Embeddings;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -107,12 +107,13 @@ class Text
                 array_merge([
                     'model' => $request->model(),
                     'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                    'max_tokens' => $request->maxTokens() ?? 2048,
                 ], array_filter([
+                    'max_tokens' => $request->maxTokens() ?? 2048,
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
                     'tools' => ToolMap::map($request->tools()),
                     'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                    ...$request->options(),
                 ]))
             );
         } catch (Throwable $e) {

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -9,6 +9,7 @@ use Prism\Prism\Concerns\ConfiguresModels;
 use Prism\Prism\Concerns\ConfiguresProviders;
 use Prism\Prism\Concerns\ConfiguresStructuredOutput;
 use Prism\Prism\Concerns\HasMessages;
+use Prism\Prism\Concerns\HasModelOptions;
 use Prism\Prism\Concerns\HasPrompts;
 use Prism\Prism\Concerns\HasProviderMeta;
 use Prism\Prism\Concerns\HasSchema;
@@ -22,6 +23,7 @@ class PendingRequest
     use ConfiguresProviders;
     use ConfiguresStructuredOutput;
     use HasMessages;
+    use HasModelOptions;
     use HasPrompts;
     use HasProviderMeta;
     use HasSchema;
@@ -68,6 +70,7 @@ class PendingRequest
             providerMeta: $this->providerMeta,
             schema: $this->schema,
             mode: $this->structuredMode,
+            modelOptions: $this->modelOptions,
         );
     }
 }

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -37,6 +37,7 @@ class Request implements PrismRequest
         protected Schema $schema,
         protected StructuredMode $mode,
         array $providerMeta = [],
+        protected array $modelOptions = [],
     ) {
         $this->providerMeta = $providerMeta;
     }
@@ -114,5 +115,13 @@ class Request implements PrismRequest
         $this->messages = array_merge($this->messages, [$message]);
 
         return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function options(): array
+    {
+        return $this->modelOptions;
     }
 }

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -23,6 +23,7 @@ class Request implements PrismRequest
      * @param  array<string, mixed>  $clientOptions
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry
      * @param  array<string, mixed>  $providerMeta
+     * @param  array<string, mixed>  $modelOptions
      */
     public function __construct(
         protected array $systemPrompts,

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -11,6 +11,7 @@ use Prism\Prism\Concerns\ConfiguresModels;
 use Prism\Prism\Concerns\ConfiguresProviders;
 use Prism\Prism\Concerns\ConfiguresTools;
 use Prism\Prism\Concerns\HasMessages;
+use Prism\Prism\Concerns\HasModelOptions;
 use Prism\Prism\Concerns\HasPrompts;
 use Prism\Prism\Concerns\HasProviderMeta;
 use Prism\Prism\Concerns\HasTools;
@@ -25,6 +26,7 @@ class PendingRequest
     use ConfiguresProviders;
     use ConfiguresTools;
     use HasMessages;
+    use HasModelOptions;
     use HasPrompts;
     use HasProviderMeta;
     use HasTools;
@@ -76,6 +78,7 @@ class PendingRequest
             clientRetry: $this->clientRetry,
             toolChoice: $this->toolChoice,
             providerMeta: $this->providerMeta,
+            modelOptions: $this->modelOptions,
         );
     }
 }

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -24,6 +24,7 @@ class Request implements PrismRequest
      * @param  array<string, mixed>  $clientOptions
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry
      * @param  array<string, mixed>  $providerMeta
+     * @param  array<string, mixed>  $modelOptions
      */
     public function __construct(
         protected string $model,
@@ -39,6 +40,7 @@ class Request implements PrismRequest
         protected array $clientRetry,
         protected string|ToolChoice|null $toolChoice,
         array $providerMeta = [],
+        protected array $modelOptions = [],
     ) {
         $this->providerMeta = $providerMeta;
     }
@@ -124,5 +126,13 @@ class Request implements PrismRequest
         $this->messages = array_merge($this->messages, [$message]);
 
         return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function options(): array
+    {
+        return array_filter($this->modelOptions);
     }
 }

--- a/tests/Providers/Groq/GroqTextTest.php
+++ b/tests/Providers/Groq/GroqTextTest.php
@@ -133,7 +133,7 @@ describe('Text generation for Groq', function (): void {
 
     it('throws an exception for ToolChoice::Any', function (): void {
         $this->expectException(PrismException::class);
-        $this->expectExceptionMessage('Invalid tool choice');
+        $this->expectExceptionMessage('Groq Error:  [invalid_request_error] Invalid API Key');
 
         Prism::text()
             ->using('groq', 'gpt-4')


### PR DESCRIPTION
## Description
As of now, Prism doesn't provide a way for library users to specify additional options to model providers beyond the standard `temperature, topP, and maxTokens (num_predict)` parameters. Many providers offer a rich set of configuration options that our users currently cannot access.

To make Prism more flexible, I've introduced a new `HasModelOptions` trait to provide custom configuration options to all model providers via a same, fluent API:
```php
 Prism::text()
    ->using(Provider::Anthropic, 'claude-3-sonnet')
    ->withSystemPrompt(view('prompts.system'))
    ->withPrompt('Explain quantum computing to a 5-year-old.')
    ->withClientOptions(['timeout' => 30])
    ->withOptions([ // TODO: Planed to add
	    'temperature' => 0.9,
	    'num_predict' => 1000,
	    'top_p' => 0.9,
            'top_k' => 40,
            'seed': 42
    ])
    ->asText();

```
This implementation allows users to leverage provider-specific options beyond our standard parameters, making Prism more adaptable to various use cases without requiring core changes for each new parameter.

One consideration in the API design is the potential confusion between `Prism::text()->withOptions()` and Laravel's HTTP facade `Http::withOptions()`. Despite the naming similarity, I felt this approach best matches our existing fluent API pattern.

Currently I implemented this feature for the Ollama provider as a proof of concept. If feedback is positive, I'll extend this functionality to other providers in this PR. (PR solves issue: #110 )
Looking forward to your feedback @sixlive 
