### PR TITLE
feat(deepseek): support api url configuration

### DIFF
--- a/config/prism.php
+++ b/config/prism.php
@@ -41,6 +41,7 @@ return [
         ],
         'deepseek' => [
             'api_key' => env('DEEPSEEK_API_KEY', ''),
+            'url' => env('DEEPSEEK_URL', 'https://api.deepseek.com/v1'),
         ],
         'voyageai' => [
             'api_key' => env('VOYAGEAI_API_KEY', ''),

--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -4,6 +4,7 @@
 ```php
 'deepseek' => [
     'api_key' => env('DEEPSEEK_API_KEY', ''),
+    'url' => env('DEEPSEEK_URL', 'https://api.deepseek.com/v1')
 ]
 ```
 

--- a/src/PrismManager.php
+++ b/src/PrismManager.php
@@ -132,6 +132,7 @@ class PrismManager
     {
         return new DeepSeek(
             apiKey: $config['api_key'] ?? '',
+            url: $config['url'] ?? '',
         );
     }
 

--- a/src/Providers/DeepSeek/DeepSeek.php
+++ b/src/Providers/DeepSeek/DeepSeek.php
@@ -23,6 +23,7 @@ readonly class DeepSeek implements Provider
 {
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
+        public string $url,
     ) {}
 
     #[\Override]
@@ -63,13 +64,15 @@ readonly class DeepSeek implements Provider
      * @param  array<string, mixed>  $options
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $retry
      */
-    protected function client(array $options, array $retry): PendingRequest
+    protected function client(array $options, array $retry, ?string $baseUrl = null): PendingRequest
     {
+        $baseUrl ??= $this->url;
+
         return Http::withHeaders(array_filter([
             'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
         ]))
             ->withOptions($options)
             ->retry(...$retry)
-            ->baseUrl('https://api.deepseek.com/v1');
+            ->baseUrl($baseUrl);
     }
 }


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
The deepseek API URL in the current project is fixed and official. Currently, there are many transfer platforms, such as openrouter, which also support it. So you need to change the deepseek API URL to a configurable file.
