### PR TITLE
refactor: UserMessage public properties

### DIFF
--- a/src/ValueObjects/Messages/UserMessage.php
+++ b/src/ValueObjects/Messages/UserMessage.php
@@ -19,8 +19,8 @@ class UserMessage implements Message
      * @param  array<int, Text|Image|Document|OpenAIFile>  $additionalContent
      */
     public function __construct(
-        protected readonly string $content,
-        protected array $additionalContent = []
+        public readonly string $content,
+        public array $additionalContent = []
     ) {
         $this->additionalContent[] = new Text($content);
     }


### PR DESCRIPTION
Currently, [`SystemMessage`](https://github.com/prism-php/prism/blob/main/src/ValueObjects/Messages/SystemMessage.php), [`AssistantMessage`](https://github.com/prism-php/prism/blob/main/src/ValueObjects/Messages/AssistantMessage.php) both have a public property, `$content`.

I was writing a quick test script, and was trying to just log the output a list of all the messages. Surprisingly, it get's a little funky because of the [`UserMessage`](https://github.com/prism-php/prism/blob/main/src/ValueObjects/Messages/UserMessage.php#L22).

```
/** @var  $message Messages\SystemMessage|Messages\UserMessage|Messages\AssistantMessage|Messages\ToolResultMessage */
foreach ($response->messages as $message) {
    if ($message instanceof Messages\SystemMessage) {
        $this->info('System: '. $message->content);
    }
    if ($message instanceof Messages\AssistantMessage) {
        $this->info('Assistant: '. $message->content);
    }
    if ($message instanceof Messages\UserMessage) {
        $this->info('User: '. $message->text());
    }
    if ($message instanceof Messages\ToolResultMessage) {
        $this->info('Tool result: ' . $message->toolResults[0]->result);
    }
}
```

This fix is the simplest way possible to clean up that inconsistency in a non breaking way.

In the future, options could be to ensure those properties are consistent in the [`Message`](https://github.com/prism-php/prism/blob/main/src/Contracts/Message.php) contract.