### PR TITLE
chore(docs): add missing language specification on embedding testing

### DIFF
--- a/docs/core-concepts/testing.md
+++ b/docs/core-concepts/testing.md
@@ -283,7 +283,7 @@ it('can generate structured response', function () {
 
 ## Testing Embeddings
 
-```
+```php
 use Prism\Prism\Prism;
 use Prism\Prism\Enums\Provider;
 use Prism\Prism\ValueObjects\Embedding;


### PR DESCRIPTION
## Description
Language specification on embedding testing was missing

## Breaking Changes
none, docs
