### PR TITLE
docs: Update links and add Bedrock/Relay docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -149,7 +149,7 @@ export default defineConfig({
               },
               {
                 text: "Bedrock",
-                link: "https://github.com/prism-php/bedrock",
+                link: "/providers/bedrock",
               },
               {
                 text: "DeepSeek",
@@ -207,11 +207,11 @@ export default defineConfig({
             items: [
               {
                 text: "Relay",
-                link: "https://github.com/prism-php/relay",
+                link: "/packages/relay",
               },
               {
                 text: "Bedrock",
-                link: "https://github.com/prism-php/bedrock",
+                link: "/packages/bedrock",
               },
             ],
           },

--- a/docs/packages/bedrock.md
+++ b/docs/packages/bedrock.md
@@ -1,0 +1,155 @@
+# Prism Bedrock
+
+Unlock the power of AWS Bedrock services in your Laravel applications with Prism Bedrock. This package provides a standalone Bedrock provider for the Prism PHP framework.
+
+## Installation
+
+```bash
+composer require prism-php/bedrock
+```
+
+## Configuration
+
+Add the following to your Prism configuration (`config/prism.php`):
+
+```php
+'bedrock' => [ // Key should match Bedrock::KEY
+    'api_key' => env('AWS_ACCESS_KEY_ID'),
+    'api_secret' => env('AWS_SECRET_ACCESS_KEY'),
+    'region' => env('AWS_REGION', 'us-east-1')
+],
+```
+
+## Usage
+
+### Text Generation
+
+```php
+use Prism\Prism\Prism;
+use Prism\Bedrock\Bedrock;
+
+$response = Prism::text()
+    ->using(Bedrock::KEY, 'anthropic.claude-3-sonnet-20240229-v1:0')
+    ->withPrompt('Explain quantum computing in simple terms')
+    ->asText();
+
+echo $response->text;
+```
+
+### Structured Output (JSON)
+
+```php
+use Prism\Prism\Prism;
+use Prism\Bedrock\Bedrock;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Schema\ArraySchema;
+
+$schema = new ObjectSchema(
+    name: 'languages',
+    description: 'Top programming languages',
+    properties: [
+        new ArraySchema(
+            'languages',
+            'List of programming languages',
+            items: new ObjectSchema(
+                name: 'language',
+                description: 'Programming language details',
+                properties: [
+                    new StringSchema('name', 'The language name'),
+                    new StringSchema('popularity', 'Popularity description'),
+                ]
+            )
+        )
+    ]
+);
+
+$response = Prism::structured()
+    ->using(Bedrock::KEY, 'anthropic.claude-3-sonnet-20240229-v1:0')
+    ->withSchema($schema)
+    ->withPrompt('List the top 3 programming languages')
+    ->asStructured();
+
+// Access your structured data
+$data = $response->structured;
+```
+
+### Embeddings (with Cohere models)
+
+```php
+use Prism\Prism\Prism;
+use Prism\Bedrock\Bedrock;
+
+$response = Prism::embeddings()
+    ->using(Bedrock::KEY, 'cohere.embed-english-v3')
+    ->fromArray(['The sky is blue', 'Water is wet'])
+    ->asEmbeddings();
+
+// Access the embeddings
+$embeddings = $response->embeddings;
+```
+
+## Supported API Schemas
+
+AWS Bedrock supports several API schemas - some LLM vendor specific, some generic.
+
+Prism Bedrock supports three of those API schemas:
+
+- **Converse**: AWS's native interface for chat (default)*
+- **Anthropic**: For Claude models**
+- **Cohere**: For Cohere embeddings models
+
+Each schema supports different capabilities:
+
+| Schema | Text | Structured | Embeddings |
+|--------|:----:|:----------:|:----------:|
+| Converse | ✅ | ✅ | ❌ |
+| Anthropic | ✅ | ✅ | ❌ |
+| Cohere | ❌ | ❌ | ✅ |
+
+\* A unified interface for multiple providers. See [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html) for a list of supported models.
+
+\*\* The Converse schema does not support Anthropic specific features. This schema uses Anthropic's native schema and therefore allows use of Anthropic features. Please note however that AWS does not yet have feature parity with Anthropic. Notably Bedrock does not support documents or citations, and only supports prompt caching for Claude Sonnet 3.7 and Claude Haiku 3.5.
+
+## Auto-resolution of API schemas
+
+Prism Bedrock resolves the most appropriate API schema from the model string. If it is unable to resolve a specific schema (e.g. anthropic for Anthropic), it will default to Converse.
+
+Therefore if you use a model that is not supported by AWS Bedrock Converse, and does not have a specific Prism Bedrock implementation, your request will fail.
+
+If you wish to force Prism Bedrock to use Converse instead of a vendor specific interface, you can do so with `withProviderMeta()`:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Bedrock\Bedrock;
+use Prism\Bedrock\Enums\BedrockSchema;
+
+$response = Prism::text()
+    ->using(Bedrock::KEY, 'anthropic.claude-3-sonnet-20240229-v1:0')
+    ->withProviderMeta(Bedrock::KEY, ['apiSchema' => BedrockSchema::Converse])
+    ->withPrompt('Explain quantum computing in simple terms')
+    ->asText();
+
+```
+
+## Cache-Optimized Prompts
+
+For [supported models](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html), you can enable prompt caching to reduce latency and costs:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Bedrock\Bedrock;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+
+$response = Prism::text()
+    ->using(Bedrock::KEY, 'anthropic.claude-3-sonnet-20240229-v1:0')
+    ->withMessages([
+        (new UserMessage('Message with cache breakpoint'))->withProviderMeta('bedrock', ['cacheType' => 'ephemeral']),
+        (new UserMessage('Message with another cache breakpoint'))->withProviderMeta('bedrock', ['cacheType' => 'ephemeral']),
+        new UserMessage('Compare the last two messages.')
+    ])
+    ->asText();
+```
+
+> [!TIP]
+> Anthropic currently supports a cacheType of "ephemeral". Converse currently supports a cacheType of "default". It is possible that Anthropic and/or AWS may add additional types in the future.

--- a/docs/packages/relay.md
+++ b/docs/packages/relay.md
@@ -1,0 +1,210 @@
+# Relay
+
+A seamless integration between Prism and Model Context Protocol (MCP) servers that empowers your AI applications with powerful, external tool capabilities.
+
+## Installation
+
+You can install the package via Composer:
+
+```bash
+composer require prism-php/relay
+```
+
+After installation, publish the configuration file:
+
+```bash
+php artisan vendor:publish --tag="relay-config"
+```
+
+## Configuration
+
+The published config file (`config/relay.php`) is where you'll define your MCP server connections.
+
+### Configuring Servers
+
+You must define each MCP server explicitly in the config file. Each server needs a unique name and the appropriate configuration parameters:
+
+```php
+return [
+    'servers' => [
+        'puppeteer' => [
+            'command' => ['npx', '-y', '@modelcontextprotocol/server-puppeteer'],
+            'timeout' => 30,
+            'env' => [],
+            'transport' => \Prism\Relay\Enums\Transport::Stdio,
+        ],
+        'github' => [
+            'url' => env('RELAY_GITHUB_SERVER_URL', 'http://localhost:8001/api'),
+            'timeout' => 30,
+            'transport' => \Prism\Relay\Enums\Transport::Http,
+        ],
+    ],
+    'cache_duration' => env('RELAY_TOOLS_CACHE_DURATION', 60), // in minutes (0 to disable)
+];
+```
+
+## Basic Usage
+
+Here's how you can integrate MCP tools into your Prism agent:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Relay\Facades\Relay;
+use Prism\Prism\Enums\Provider;
+
+$response = Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-7-sonnet-latest')
+    ->withPrompt('Find information about Laravel on the web')
+    ->withTools(Relay::tools('puppeteer'))
+    ->asText();
+
+return $response->text;
+```
+
+The agent can now use any tools provided by the Puppeteer MCP server, such as navigating to webpages, taking screenshots, clicking buttons, and more.
+
+## Real-World Example
+
+Here's a practical example of creating a Laravel command that uses MCP tools with Prism:
+
+```php
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Prism\Relay\Facades\Relay;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Text\PendingRequest;
+
+use function Laravel\Prompts\note;
+use function Laravel\Prompts\textarea;
+
+class MCP extends Command
+{
+    protected $signature = 'prism:mcp';
+
+    public function handle()
+    {
+        $response = $this->agent(textarea('Prompt'))->asText();
+
+        note($response->text);
+    }
+
+    protected function agent(string $prompt): PendingRequest
+    {
+        return Prism::text()
+            ->using(Provider::Anthropic, 'claude-3-7-sonnet-latest')
+            ->withSystemPrompt(view('prompts.nova-v2'))
+            ->withPrompt($prompt)
+            ->withTools([
+                ...Relay::tools('puppeteer'),
+            ])
+            ->usingTopP(1)
+            ->withMaxSteps(99)
+            ->withMaxTokens(8192);
+    }
+}
+```
+
+This command creates an interactive CLI that lets you input prompts that will be sent to Claude. The agent can use Puppeteer tools to browse the web, complete tasks, and return the results.
+
+## Transport Types
+
+Arc supports multiple transport mechanisms:
+
+### HTTP Transport
+
+For MCP servers that communicate over HTTP:
+
+```php
+'github' => [
+    'url' => env('RELAY_GITHUB_SERVER_URL', 'http://localhost:8000/api'),
+    'api_key' => env('RELAY_GITHUB_SERVER_API_KEY'),
+    'timeout' => 30,
+    'transport' => Transport::Http,
+],
+```
+
+### STDIO Transport
+
+For locally running MCP servers that communicate via standard I/O:
+
+```php
+'puppeteer' => [
+    'command' => [
+      'npx',
+      '-y',
+      '@modelcontextprotocol/server-puppeteer',
+      '--options',
+      // Array values are passed as JSON encoded strings
+      [
+        'debug' => env('MCP_PUPPETEER_DEBUG', false)
+      ]
+    ],
+    'timeout' => 30,
+    'transport' => Transport::Stdio,
+    'env' => [
+        'NODE_ENV' => 'production',  // Set Node environment
+        'MCP_SERVER_PORT' => '3001',  // Set a custom port for the server
+    ],
+],
+```
+
+> [!NOTE]
+> The STDIO transport launches a subprocess and communicates with it through standard input/output. This is perfect for running tools directly on your application server.
+
+> [!TIP]
+> The `env` option allows you to pass environment variables to the MCP server process. This is useful for configuring server behavior, enabling debugging, or setting authentication details.
+
+## Advanced Usage
+
+### Using Multiple MCP Servers
+
+You can combine tools from multiple MCP servers in a single Prism agent:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Relay\Facades\Relay;
+use Prism\Prism\Enums\Provider;
+
+$response = Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-7-sonnet-latest')
+    ->withTools([
+        ...Relay::tools('github'),
+        ...Relay::tools('puppeteer')
+    ])
+    ->withPrompt('Find and take screenshots of Laravel repositories')
+    ->asText();
+```
+
+### Error Handling
+
+The package uses specific exception types for better error handling:
+
+```php
+use Prism\Relay\Exceptions\RelayException;
+use Prism\Relay\Exceptions\ServerConfigurationException;
+use Prism\Relay\Exceptions\ToolCallException;
+use Prism\Relay\Exceptions\ToolDefinitionException;
+use Prism\Relay\Exceptions\TransportException;
+
+try {
+    $tools = Relay::tools('puppeteer');
+    // Use the tools...
+} catch (ServerConfigurationException $e) {
+    // Handle configuration errors (missing server, invalid settings)
+    Log::error('MCP Server configuration error: ' . $e->getMessage());
+} catch (ToolDefinitionException $e) {
+    // Handle issues with tool definitions from the MCP server
+    Log::error('MCP Tool definition error: ' . $e->getMessage());
+} catch (TransportException $e) {
+    // Handle communication errors with the MCP server
+    Log::error('MCP Transport error: ' . $e->getMessage());
+} catch (ToolCallException $e) {
+    // Handle errors when calling a specific tool
+    Log::error('MCP Tool call error: ' . $e->getMessage());
+} catch (RelayException $e) {
+    // Handle any other MCP-related errors
+    Log::error('Relay general error: ' . $e->getMessage());
+}
+```


### PR DESCRIPTION
This pull request updates the documentation and configuration for two Prism PHP packages (`Bedrock` and `Relay`) and adjusts related links in the navigation menu. Key changes include adding comprehensive usage guides for the packages and updating internal links to point to the new documentation pages.

### Documentation Enhancements

* **Bedrock Documentation**: Added a detailed guide for the `Bedrock` package, including installation, configuration, usage examples for text generation, structured output, embeddings, and advanced features like API schema resolution and prompt caching.
* **Relay Documentation**: Introduced a comprehensive guide for the `Relay` package, covering installation, configuration for MCP servers, basic and advanced usage, transport types, and error handling.

### Navigation Updates

* **Updated Links**: Changed external GitHub links for `Bedrock` and `Relay` in the navigation menu to point to their respective internal documentation pages (`/providers/bedrock` and `/packages/relay`). [[1]](diffhunk://#diff-e3dd2227e911b905c0de197c1154f07c408373635ac0434607068133835e88deL152-R152) [[2]](diffhunk://#diff-e3dd2227e911b905c0de197c1154f07c408373635ac0434607068133835e88deL210-R214)