### PR TITLE
fix: providerMeta returns null if valuePath is not set

### DIFF
--- a/src/Concerns/HasProviderMeta.php
+++ b/src/Concerns/HasProviderMeta.php
@@ -27,6 +27,10 @@ trait HasProviderMeta
             []
         );
 
-        return data_get($providerMeta, $valuePath, $providerMeta);
+        if ($valuePath === null) {
+            return $providerMeta;
+        }
+
+        return data_get($providerMeta, $valuePath, null);
     }
 }

--- a/src/Providers/Anthropic/Maps/MessageMap.php
+++ b/src/Providers/Anthropic/Maps/MessageMap.php
@@ -69,7 +69,7 @@ class MessageMap
      */
     protected static function mapSystemMessage(SystemMessage $systemMessage): array
     {
-        $cacheType = data_get($systemMessage->providerMeta(Provider::Anthropic), 'cacheType', null);
+        $cacheType = $systemMessage->providerMeta(Provider::Anthropic, 'cacheType');
 
         return array_filter([
             'type' => 'text',
@@ -99,7 +99,8 @@ class MessageMap
      */
     protected static function mapUserMessage(UserMessage $message, array $requestProviderMeta = []): array
     {
-        $cacheType = data_get($message->providerMeta(Provider::Anthropic), 'cacheType', null);
+        $cacheType = $message->providerMeta(Provider::Anthropic, 'cacheType');
+
         $cache_control = $cacheType ? ['type' => $cacheType instanceof BackedEnum ? $cacheType->value : $cacheType] : null;
 
         return [
@@ -121,7 +122,7 @@ class MessageMap
      */
     protected static function mapAssistantMessage(AssistantMessage $message): array
     {
-        $cacheType = data_get($message->providerMeta(Provider::Anthropic), 'cacheType', null);
+        $cacheType = $message->providerMeta(Provider::Anthropic, 'cacheType');
 
         $content = [];
 
@@ -216,7 +217,7 @@ class MessageMap
                 'title' => $document->documentTitle,
                 'context' => $document->documentContext,
                 'cache_control' => $cache_control,
-                'citations' => data_get($requestProviderMeta, 'citations', data_get($document->providerMeta(Provider::Anthropic), 'citations', false))
+                'citations' => data_get($requestProviderMeta, 'citations', $document->providerMeta(Provider::Anthropic, 'citations'))
                     ? ['enabled' => true]
                     : null,
             ]);

--- a/src/Providers/Anthropic/Maps/ToolMap.php
+++ b/src/Providers/Anthropic/Maps/ToolMap.php
@@ -17,7 +17,7 @@ class ToolMap
     public static function map(array $tools): array
     {
         return array_map(function (PrismTool $tool): array {
-            $cacheType = data_get($tool->providerMeta(Provider::Anthropic), 'cacheType', null);
+            $cacheType = $tool->providerMeta(Provider::Anthropic, 'cacheType');
 
             return array_filter([
                 'name' => $tool->name(),

--- a/src/Providers/DeepSeek/Maps/ToolMap.php
+++ b/src/Providers/DeepSeek/Maps/ToolMap.php
@@ -26,7 +26,7 @@ class ToolMap
                     'required' => $tool->requiredParameters(),
                 ],
             ],
-            'strict' => data_get($tool->providerMeta(Provider::DeepSeek), 'strict', null),
+            'strict' => $tool->providerMeta(Provider::DeepSeek, 'strict'),
         ]), $tools);
     }
 }

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -96,8 +96,6 @@ class Text
                 ]
                 : ($request->tools() !== [] ? ['function_declarations' => ToolMap::map($request->tools())] : []);
 
-            $providerMeta = $request->providerMeta(Provider::Gemini);
-
             return $this->client->post(
                 "{$request->model()}:generateContent",
                 array_filter([

--- a/src/Providers/OpenAI/Maps/ToolMap.php
+++ b/src/Providers/OpenAI/Maps/ToolMap.php
@@ -28,7 +28,7 @@ class ToolMap
                     ],
                 ] : [],
             ],
-            'strict' => data_get($tool->providerMeta(Provider::OpenAI), 'strict', null),
+            'strict' => (bool) $tool->providerMeta(Provider::OpenAI, 'strict'),
         ]), $tools);
     }
 }

--- a/tests/Concerns/HasProviderMetaTest.php
+++ b/tests/Concerns/HasProviderMetaTest.php
@@ -19,3 +19,11 @@ test('providerMeta returns a string with the exact providerMeta if valuePath is 
 
     expect($class->providerMeta('openai', 'key'))->toBe('value');
 });
+
+test('providerMeta returns null if the value path is not set', function (): void {
+    $class = new PendingRequest;
+
+    $class->withProviderMeta('openai', ['key' => 'value']);
+
+    expect($class->providerMeta('openai', 'foo'))->toBeNull();
+});

--- a/tests/Providers/Anthropic/AnthropicTextTest.php
+++ b/tests/Providers/Anthropic/AnthropicTextTest.php
@@ -31,7 +31,7 @@ it('can generate text with a prompt', function (): void {
     $response = Prism::text()
         ->using('anthropic', 'claude-3-5-sonnet-20240620')
         ->withPrompt('Who are you?')
-        ->generate();
+        ->asText();
 
     expect($response->usage->promptTokens)->toBe(11);
     expect($response->usage->completionTokens)->toBe(55);
@@ -51,7 +51,7 @@ it('can generate text with a system prompt', function (): void {
         ->using('anthropic', 'claude-3-5-sonnet-20240620')
         ->withSystemPrompt('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]!')
         ->withPrompt('Who are you?')
-        ->generate();
+        ->asText();
 
     expect($response->usage->promptTokens)->toBe(33);
     expect($response->usage->completionTokens)->toBe(98);
@@ -81,7 +81,7 @@ it('can generate text using multiple tools and multiple steps', function (): voi
         ->withTools($tools)
         ->withMaxSteps(3)
         ->withPrompt('What time is the tigers game today and should I wear a coat?')
-        ->generate();
+        ->asText();
 
     // Assert tool calls in the first step
     $firstStep = $response->steps[0];
@@ -126,7 +126,7 @@ it('can send images from file', function (): void {
                 ],
             ),
         ])
-        ->generate();
+        ->asText();
 
     Http::assertSent(function (Request $request): true {
         $message = $request->data()['messages'][0]['content'];
@@ -165,7 +165,7 @@ it('handles specific tool choice', function (): void {
         ->withPrompt('Do something')
         ->withTools($tools)
         ->withToolChoice('weather')
-        ->generate();
+        ->asText();
 
     expect($response->toolCalls[0]->name)->toBe('weather');
 });
@@ -178,7 +178,7 @@ it('can calculate cache usage correctly', function (): void {
         ->withMessages([
             (new UserMessage('New context'))->withProviderMeta(Provider::Anthropic, ['cacheType' => 'ephemeral']),
         ])
-        ->generate();
+        ->asText();
 
     expect($response->usage->cacheWriteInputTokens)->toBe(200);
     expect($response->usage->cacheReadInputTokens)->ToBe(100);
@@ -209,7 +209,7 @@ it('adds rate limit data to the responseMeta', function (): void {
     $response = Prism::text()
         ->using('anthropic', 'claude-3-5-sonnet-20240620')
         ->withPrompt('Who are you?')
-        ->generate();
+        ->asText();
 
     expect($response->meta->rateLimits)->toHaveCount(4);
     expect($response->meta->rateLimits[0])->toBeInstanceOf(ProviderRateLimit::class);
@@ -271,7 +271,7 @@ describe('Anthropic citations', function (): void {
                 )),
             ])
             ->withProviderMeta(Provider::Anthropic, ['citations' => true])
-            ->generate();
+            ->asText();
 
         expect($response->text)->toEqual('According to the text, the grass is green and the sky is blue.');
 
@@ -311,7 +311,7 @@ describe('Anthropic citations', function (): void {
                 )),
             ])
             ->withProviderMeta(Provider::Anthropic, ['citations' => true])
-            ->generate();
+            ->asText();
 
         expect($response->text)->toBe("According to the documents:\nThe grass is green and the sky is blue.");
 
@@ -351,7 +351,7 @@ describe('Anthropic citations', function (): void {
                 )),
             ])
             ->withProviderMeta(Provider::Anthropic, ['citations' => true])
-            ->generate();
+            ->asText();
 
         expect($response->text)->toBe('According to the documents, the grass is green and the sky is blue.');
 
@@ -384,7 +384,7 @@ describe('Anthropic extended thinking', function (): void {
             ->using('anthropic', 'claude-3-7-sonnet-latest')
             ->withPrompt('What is the meaning of life, the universe and everything in popular fiction?')
             ->withProviderMeta(Provider::Anthropic, ['thinking' => ['enabled' => true]])
-            ->generate();
+            ->asText();
 
         $expected_thinking = "This is a reference to Douglas Adams' popular science fiction series \"The Hitchhiker's Guide to the Galaxy\" where the supercomputer Deep Thought was built to calculate \"the Answer to the Ultimate Question of Life, the Universe, and Everything.\" After 7.5 million years of computation, it famously determined the answer to be \"42\" - a deliberately anticlimactic and absurd response that has become a significant pop culture reference.\n\nBeyond the Hitchhiker's reference, the question of life's meaning appears in many works of fiction across different media, with various philosophical approaches.\n\nI should note this humorous 42 reference while also mentioning how other fictional works have approached this philosophical question.";
         $expected_signature = 'EuYBCkQYAiJAQ7ZOmBu5pa8U03x/RN5+Gs3tyKXFYcruUfnC8X/4AKBpJmB8qX+nQQ9atvYOXLD/mUAClCRZEaxt2fyEvdxnhRIMfFi6CLULECysli0mGgy5JRaOXL06fVJndm8iMD2T+D8dSIFJuctCnVeFKZme2TfIPIH+UMFO33a0ojzUq2VYy8+RzKkH7WYK9+580ipQ4yDVegd/67LKRtfb574HOHqwlPcfEbeiJuFuHrayoqK8KS2ltGYRckVGH6lNH46zUyjGaD2z3nZeti8UjmgnfMWRpjUmv0TWWGtrCKRoHGQ=';
@@ -434,7 +434,7 @@ describe('Anthropic extended thinking', function (): void {
             ->withMaxSteps(3)
             ->withPrompt('What time is the tigers game today and should I wear a coat?')
             ->withProviderMeta(Provider::Anthropic, ['thinking' => ['enabled' => true]])
-            ->generate();
+            ->asText();
 
         $expected_thinking = "The user is asking about:\n1. The time of the Tigers game today (likely referring to a sports team, probably Detroit Tigers baseball)\n2. Whether they should wear a coat (which relates to weather conditions)\n\nFor the first question, I need to search for the Tigers game schedule for today. For the second question, I need to check the weather in the relevant location.\n\nHowever, I'm missing some information:\n- The user hasn't specified which Tigers team they're referring to (though Detroit Tigers is most likely)\n- The user hasn't specified their location, which I need for the weather check\n\nI'll need to search for the Tigers game information first, and then check the weather in the appropriate location (likely Detroit if it's a home game).";
         $expected_signature = 'EuYBCkQYAiJAY1corUurDaKsURSV32GUvrp4ZySJDYJXGHIBx2aPaphiKr+Kcenv2gTcLxAvkU5zUxek2mX3GGkrp8XlN2qJAhIM7v4WGU9Wwfpn8qu1Ggzd9cK0sZX2z6qEbaciMKAfMsaYMc9zVHF1Y2qY+iC35WGiXAnEAZk+KBNGCo0V+t/U1bzJGhAigvTRKkDKpipQDXkfw+XdPzHh+VGFXut2TIPatMN5UrE1CvR+GtQT1cscbxBnuiXFwgs3B/QPlC2/l2VloajCHeYVaHqY3MIXiTyqe4HAyt51Go1Xt1ydVaY=';
@@ -460,7 +460,7 @@ it('includes anthropic beta header if set in config', function (): void {
         ->using('anthropic', 'claude-3-7-sonnet-latest')
         ->withPrompt('What is the meaning of life, the universe and everything in popular fiction?')
         ->withProviderMeta(Provider::Anthropic, ['thinking' => ['enabled' => true]])
-        ->generate();
+        ->asText();
 
     Http::assertSent(fn (Request $request) => $request->hasHeader('anthropic-beta', 'beta1,beta2'));
 });


### PR DESCRIPTION
## Description
I have been meaning to do this for a while, but in my head it was a bigger change than it actually was...!

`->providerMeta()` currently returns the full providerMeta for the specified provider (or an empty array) if the valuePath is not set. This is clunky and requires workarounds to handle null values.

This PR changes `->providerMeta()`  to:
- Return early if the valuePath is null (therefore not affecting behaviour if your intent is to grab the whole array).
- Return null if the valuePath is not set.

I've also been through and cleaned up where we have worked around this internally.

## Breaking Changes
- `->providerMeta()` now returns null if the valuePath is not set, instead of returning the full providerMeta array for the provider. This _should_ only affect custom providers.
