### PR TITLE
feat(docs): add local search to documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -219,6 +219,10 @@ export default defineConfig({
       },
     ],
 
+    search: {
+      provider: 'local',
+    },
+
     socialLinks: [
       { icon: "github", link: "https://github.com/echolabsdev/prism" },
     ],


### PR DESCRIPTION
## Description
This is a tiny change but supper helpful. 
`VitePress` has this [local search](https://vitepress.dev/reference/default-theme-search#local-search) feature, which is in-browser index offline search. It's not that advanced but in our case it's more than enough.
