### PR TITLE
feat: add providerConfig argument to using

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -67,3 +67,29 @@ PROVIDER_URL=https://custom-endpoint.com
 ```
 > [!NOTE]
 > Remember to always refer to your chosen provider's documentation pages for the most up-to-date configuration options and requirements specific to that provider.
+
+## Overriding config in your code
+
+You can override config in your code in two ways:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+
+// Via the third parameter of `using()`
+$response = Prism::text()
+    ->using(Provider::OpenAI, 'claude-3-5-sonnet-20241022', [
+        'url' => 'new-base-url'
+    ])
+    ->withPrompt('Explain quantum computing.')
+    ->asText();
+
+// Or via `usingProviderConfig()` (note that this will re-resolve the provider).
+$response = Prism::text()
+    ->using(Provider::OpenAI, 'claude-3-5-sonnet-20241022')
+    ->usingProviderConfig([
+        'url' => 'new-base-url'
+    ])
+    ->withPrompt('Explain quantum computing.')
+    ->asText();
+```

--- a/src/Concerns/ConfiguresProviders.php
+++ b/src/Concerns/ConfiguresProviders.php
@@ -16,15 +16,16 @@ trait ConfiguresProviders
 
     protected string $model;
 
-    public function using(string|ProviderEnum $provider, string $model): self
+    /**
+     * @param  array<string, mixed>  $providerConfig
+     */
+    public function using(string|ProviderEnum $provider, string $model, array $providerConfig = []): self
     {
         $this->providerKey = is_string($provider) ? $provider : $provider->value;
 
-        $this->provider = resolve(PrismManager::class)->resolve($this->providerKey);
-
         $this->model = $model;
 
-        return $this;
+        return $this->usingProviderConfig($providerConfig);
     }
 
     public function provider(): Provider

--- a/tests/Text/PendingRequestTest.php
+++ b/tests/Text/PendingRequestTest.php
@@ -28,6 +28,21 @@ test('it can configure the provider and model', function (): void {
     expect($generated->model())->toBe('gpt-4');
 });
 
+test('it can configure the provider and model with custom config via using', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4', ['url' => 'value']);
+
+    expect($request->provider()->url)->toBe('value');
+});
+
+test('it can configure the provider and model with custom config via withProviderConfig', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->usingProviderConfig(['url' => 'value']);
+
+    expect($request->provider()->url)->toBe('value');
+});
+
 test('it sets provider meta with enum', function (): void {
     $request = $this->pendingRequest
         ->using(Provider::OpenAI, 'gpt-4')


### PR DESCRIPTION
## Description

Adds a providerConfig argument to `using()`, e.g.:

```php
Prism::text()
    ->using(Provider::OpenAI, 'gpt-4', [
        'url' => 'new url'
    ]);
```
You can do this already with `usingProviderConfig()`, but this is slightly nicer DX and avoids re-resolving the provider.

