### PR TITLE
Expand OpenAI tool choice mapping to support 'Any' and 'None' options

### DIFF
--- a/src/Providers/OpenAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/OpenAI/Maps/ToolChoiceMap.php
@@ -25,6 +25,8 @@ class ToolChoiceMap
 
         return match ($toolChoice) {
             ToolChoice::Auto => 'auto',
+            ToolChoice::Any => 'required',
+            ToolChoice::None => 'none',
             null => $toolChoice,
             default => throw new InvalidArgumentException('Invalid tool choice')
         };

--- a/src/Providers/OpenAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/OpenAI/Maps/ToolChoiceMap.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\OpenAI\Maps;
 
-use InvalidArgumentException;
 use Prism\Prism\Enums\ToolChoice;
 
 class ToolChoiceMap
@@ -28,7 +27,6 @@ class ToolChoiceMap
             ToolChoice::Any => 'required',
             ToolChoice::None => 'none',
             null => $toolChoice,
-            default => throw new InvalidArgumentException('Invalid tool choice')
         };
     }
 }

--- a/tests/Providers/OpenAI/TextTest.php
+++ b/tests/Providers/OpenAI/TextTest.php
@@ -7,8 +7,6 @@ namespace Tests\Providers\OpenAI;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
-use Prism\Prism\Enums\ToolChoice;
-use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Facades\Tool;
 use Prism\Prism\Prism;
 use Tests\Fixtures\FixtureResponse;
@@ -215,17 +213,6 @@ it('handles specific tool choice', function (): void {
         ->asText();
 
     expect($response->toolCalls[0]->name)->toBe('weather');
-});
-
-it('throws an exception for ToolChoice::Any', function (): void {
-    $this->expectException(PrismException::class);
-    $this->expectExceptionMessage('Invalid tool choice');
-
-    Prism::text()
-        ->using('openai', 'gpt-4o')
-        ->withPrompt('Who are you?')
-        ->withToolChoice(ToolChoice::Any)
-        ->asText();
 });
 
 it('sets the rate limits on meta', function (): void {


### PR DESCRIPTION
Added mappings for ToolChoice::Any ('required') and ToolChoice::None ('none'). Keeps existing behavior for Auto, null, and invalid values.

<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

## Breaking Changes
<!-- Put any breaking changes here. Remove this section if there are no breaking changes -->
