### PR TITLE
feat: fake streaming text responses

### DIFF
--- a/docs/core-concepts/testing.md
+++ b/docs/core-concepts/testing.md
@@ -68,7 +68,8 @@ it('can handle tool calls', function () {
 
 ## Using the ResponseBuilder
 
-If you need to test a richer response object, e.g. with Steps, you may find it easier to use the `ResponseBuilder` together with the fake Step helpers:
+If you need to test a richer response object, e.g. with Steps, you may find it easier to use the `ResponseBuilder` together with the fake Step helpers.
+This is especially useful when you want to test complex streaming responses.
 
 ```php
 use Prism\Prism\Text\ResponseBuilder;
@@ -204,6 +205,113 @@ it('can use weather tool', function () {
 });
 ```
 
+## Testing Streamed Responses
+
+To test streamed responses, you can use any text response for a fake. The fake Provider will turn the text response into a fake stream of text chunks.
+It will always finish with an empty chunk including your given finish reason.
+
+```php
+Prism::fake([
+    TextResponseFake::make()
+        ->withText('fake response text') // text to be streamed
+        ->withFinishReason(FinishReason::Stop), // finish reason for final chunk
+]);
+
+$text = Prism::text()
+    ->using('anthropic', 'claude-3-sonnet')
+    ->withPrompt('What is the meaning of life?')
+    ->asStream();
+
+$outputText = '';
+foreach ($text as $chunk) {
+    $outputText .= $chunk->text; // will be ['fake ', 'respo', 'nse t', 'ext', '']; 
+}
+
+expect($outputText)->toBe('fake response text');
+```
+
+You can adjust the chunk size by using `withFakeChunkSize` on the fake.
+
+```php
+Prism::fake([
+    TextResponseFake::make()->withText('fake response text'),
+])->withFakeChunkSize(1);
+```
+
+Now, the text will be streamed in chunks of one character (`['f', 'a', 'k', ...]`).
+
+### Testing Tool Calling while Streaming
+
+When testing streamed responses with tool calls, you can use the `ResponseBuilder` to create a more complex response.
+Given a text response with steps, the fake provider will not only generate text chunks, but also include chunks for tool calls and results.
+
+```php
+Prism::fake([
+    (new ResponseBuilder)
+        ->addStep(
+            TextStepFake::make()
+                ->withToolCalls(
+                    [
+                        new ToolCall('id-123', 'tool', ['input' => 'value']),
+                    ]
+                )
+        )
+        ->addStep(
+            TextStepFake::make()
+                ->withToolResults(
+                    [
+                        new ToolResult('id-123', 'tool', ['input' => 'value'], 'result'),
+                    ]
+                )
+        )
+        ->addStep(
+            TextStepFake::make()
+                ->withText('fake response text')
+        )
+        ->toResponse(),
+]);
+
+$text = Prism::text()
+    ->using('anthropic', 'claude-3-sonnet')
+    ->withPrompt('What is the meaning of life?')
+    ->asStream();
+
+$outputText = '';
+$toolCalls = [];
+$toolResults = [];
+
+foreach ($text as $chunk) {
+    $outputText .= $chunk->text;
+
+    // Accumulate tool calls
+    if ($chunk->toolCalls) {
+        foreach ($chunk->toolCalls as $call) {
+            $toolCalls[] = $call;
+        }
+    }
+
+    // Accumulate tool results
+    if ($chunk->toolResults) {
+        foreach ($chunk->toolResults as $result) {
+            $toolResults[] = $result;
+        }
+    }
+}
+
+expect($outputText)->toBe('fake response text')
+    ->and($toolCalls)->toHaveCount(1)
+    ->and($toolCalls[0])->toBeInstanceOf(ToolCall::class)
+    ->and($toolCalls[0]->id)->toBe('id-123')
+    ->and($toolCalls[0]->name)->toBe('tool')
+    ->and($toolCalls[0]->arguments())->toBe(['input' => 'value'])
+    ->and($toolResults)->toHaveCount(1)
+    ->and($toolResults[0])->toBeInstanceOf(ToolResult::class)
+    ->and($toolResults[0]->toolCallId)->toBe('id-123')
+    ->and($toolResults[0]->toolName)->toBe('tool')
+    ->and($toolResults[0]->args)->toBe(['input' => 'value'])
+    ->and($toolResults[0]->result)->toBe('result');
+```
+
 ## Testing Structured Output
 
 ```php
@@ -304,8 +412,6 @@ $fake->assertRequest(function ($requests) {
 // Assert provider configuration
 $fake->assertProviderConfig(['api_key' => 'sk-1234']);
 ```
-
----
 
 ## Using the real response classes
 

--- a/docs/core-concepts/testing.md
+++ b/docs/core-concepts/testing.md
@@ -69,7 +69,7 @@ it('can handle tool calls', function () {
 ## Using the ResponseBuilder
 
 If you need to test a richer response object, e.g. with Steps, you may find it easier to use the `ResponseBuilder` together with the fake Step helpers.
-This is especially useful when you want to test complex streaming responses.
+This is especially useful when you want to test complex streamed responses.
 
 ```php
 use Prism\Prism\Text\ResponseBuilder;

--- a/src/Testing/Concerns/CanGenerateFakeChunksFromTextResponses.php
+++ b/src/Testing/Concerns/CanGenerateFakeChunksFromTextResponses.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Prism\Prism\Testing\Concerns;
+
+use Generator;
+use Prism\Prism\Text\Chunk;
+use Prism\Prism\Text\Response as TextResponse;
+
+trait CanGenerateFakeChunksFromTextResponses
+{
+    /** Default byte length used when chunking strings for the fake stream. */
+    protected int $defaultChunkBytes = 5;
+
+    /** Override the default chunk size used when splitting text. */
+    public function withChunkSize(int $bytes): self
+    {
+        $this->defaultChunkBytes = max(1, $bytes);
+
+        return $this;
+    }
+
+    /**
+     * Convert a {@link TextResponse} into a generator of {@link Chunk}s.
+     *
+     * The algorithm walks through the steps (if any) and yields:
+     *  • text split into fixed-byte chunks,
+     *  • an empty chunk carrying tool-calls / results when present,
+     *  • finally an empty chunk with the original finish-reason.
+     *
+     * @return Generator<Chunk>
+     */
+    protected function chunksFromTextResponse(TextResponse $response): Generator
+    {
+        $chunkBytes = $this->defaultChunkBytes;
+
+        if ($response->steps->isNotEmpty()) {
+            foreach ($response->steps as $step) {
+                // Stream out the textual part of the step.
+                yield from $this->splitTextToTextChunkGenerator($step->text, $chunkBytes);
+
+                // Forward tool calls / results as separate chunks (empty text).
+                if ($step->toolCalls) {
+                    yield new Chunk(text: '', toolCalls: $step->toolCalls);
+                }
+                if ($step->toolResults) {
+                    yield new Chunk(text: '', toolResults: $step->toolResults);
+                }
+            }
+        } else {
+            yield from $this->splitTextToTextChunkGenerator($response->text, $chunkBytes);
+        }
+
+        // Signal the end of the stream with the original finish reason.
+        yield new Chunk(text: '', finishReason: $response->finishReason);
+    }
+
+    /**
+     * Split a string into a sequence of {@link Chunk}s of roughly <$size> bytes.
+     *
+     * @return Generator<Chunk>
+     */
+    protected function splitTextToTextChunkGenerator(string $text, int $size): Generator
+    {
+        $length = strlen($text);
+
+        for ($offset = 0; $offset < $length; $offset += $size) {
+            $piece = substr($text, $offset, $size);
+            if ($piece === '') {
+                continue;
+            }
+
+            yield new Chunk(text: $piece);
+        }
+    }
+}

--- a/tests/Testing/PrismFakeTest.php
+++ b/tests/Testing/PrismFakeTest.php
@@ -173,13 +173,15 @@ it('can consume the fake text stream responses', function (): void {
 
 it('can consume the fake text response builder responses when streaming', function (): void {
     Prism::fake([
-        (new ResponseBuilder)->addStep(
-            TextStepFake::make()
-                ->withToolCalls(
-                    [
-                        new ToolCall('id-123', 'tool', ['input' => 'value']),
-                    ]
-                ))
+        (new ResponseBuilder)
+            ->addStep(
+                TextStepFake::make()
+                    ->withToolCalls(
+                        [
+                            new ToolCall('id-123', 'tool', ['input' => 'value']),
+                        ]
+                    )
+            )
             ->addStep(
                 TextStepFake::make()
                     ->withToolResults(
@@ -188,8 +190,9 @@ it('can consume the fake text response builder responses when streaming', functi
                         ]
                     )
             )
-            ->addStep(TextStepFake::make()
-                ->withText('fake response text')
+            ->addStep(
+                TextStepFake::make()
+                    ->withText('fake response text')
             )->toResponse(),
     ]);
 

--- a/tests/Testing/PrismFakeTest.php
+++ b/tests/Testing/PrismFakeTest.php
@@ -211,6 +211,28 @@ describe('fake streaming responses', function (): void {
             ->and($toolResults)->toBeEmpty();
     });
 
+    it('has a default chunk size of five', function (): void {
+        Prism::fake([
+            TextResponseFake::make()->withText('fake response text'),
+        ]);
+
+        $text = Prism::text()
+            ->using('anthropic', 'claude-3-sonnet')
+            ->withPrompt('What is the meaning of life?')
+            ->asStream();
+
+        $outputText = '';
+        $chunks = [];
+        foreach ($text as $chunk) {
+            $outputText .= $chunk->text;
+            $chunks[] = $chunk;
+        }
+
+        expect($outputText)->toBe('fake response text')
+            // 19 characters -> 3 chunks of 5 + one with 4 characters + 1 empty chunk with finish reason
+            ->and($chunks)->toHaveCount(5);
+    });
+
     it('can consume the fake text response builder responses when streaming', function (): void {
         Prism::fake([
             (new ResponseBuilder)

--- a/tests/Testing/PrismFakeTest.php
+++ b/tests/Testing/PrismFakeTest.php
@@ -314,6 +314,27 @@ describe('fake streaming responses', function (): void {
             ->and($chunks)->toHaveCount(19);
     });
 
+    it('enforces a chunk size of at least 1', function (): void {
+        Prism::fake([
+            TextResponseFake::make()->withText('fake response text'),
+        ])->withFakeChunkSize(0);
+
+        $text = Prism::text()
+            ->using('anthropic', 'claude-3-sonnet')
+            ->withPrompt('What is the meaning of life?')
+            ->asStream();
+
+        $outputText = '';
+        $chunks = [];
+        foreach ($text as $chunk) {
+            $outputText .= $chunk->text;
+            $chunks[] = $chunk;
+        }
+
+        expect($outputText)->toBe('fake response text')
+            ->and($chunks)->toHaveCount(19);
+    });
+
     it('adds an empty chunk with the finish reason at the end', function (): void {
         Prism::fake([
             TextResponseFake::make()


### PR DESCRIPTION
## Description

I did play around with some approaches and now have a minimal surface area way to fake streaming text responses.

Originally, I thought about giving more control about the Chunks to be faked, but honestly I think there is not a lot of use to that. The way I chose now seems to me clean to use & easy to maintain. I just take a TextResponse and construct a stream of chunks from it:

```php
Prism::fake([
    TextResponseFake::make()
        ->withText('fake response text'),
]);

$text = Prism::text()
    ->using('anthropic', 'claude-3-sonnet')
    ->withPrompt('What is the meaning of life?')
    ->asStream();

$outputText = '';
$toolCalls = [];
$toolResults = [];
foreach ($text as $chunk) {
    $outputText .= $chunk->text;
}

expect($outputText)->toBe('fake response text');
```

If one wants to test tool calls, the steps need to be filled, so we go for the builder:

```php
Prism::fake([
    (new ResponseBuilder)
        ->addStep(
            TextStepFake::make()
                ->withToolCalls(
                    [
                        new ToolCall('id-123', 'tool', ['input' => 'value']),
                    ]
                )
        )
        ->addStep(
            TextStepFake::make()
                ->withToolResults(
                    [
                        new ToolResult('id-123', 'tool', ['result' => 'value'], 'result'),
                    ]
                )
        )
        ->addStep(
            TextStepFake::make()
                ->withText('fake response text')
        )->toResponse(),
]);

$text = Prism::text()
    ->using('anthropic', 'claude-3-sonnet')
    ->withPrompt('What is the meaning of life?')
    ->asStream();

$outputText = '';
$toolCalls = [];
$toolResults = [];
foreach ($text as $chunk) {
    $outputText .= $chunk->text;

    // Check for tool calls
    if ($chunk->toolCalls) {
        foreach ($chunk->toolCalls as $call) {
            $toolCalls[] = $call;
        }
    }

    // Check for tool results
    if ($chunk->toolResults) {
        foreach ($chunk->toolResults as $result) {
            $toolResults[] = $result;
        }
    }
}

expect($outputText)->toBe('fake response text')
    ->and($toolCalls)->toHaveCount(1)
    ->and($toolCalls[0])->toBeInstanceOf(ToolCall::class)
    ->and($toolCalls[0]->id)->toBe('id-123')
    ->and($toolCalls[0]->name)->toBe('tool')
    ->and($toolResults)->toHaveCount(1)
    ->and($toolResults[0])->toBeInstanceOf(ToolResult::class)
    ->and($toolResults[0]->toolCallId)->toBe('id-123')
    ->and($toolResults[0]->toolName)->toBe('tool')
    ->and($toolResults[0]->args)->toBe(['result' => 'value'])
    ->and($toolResults[0]->result)->toBe('result');
```

That would be enough to cover all my streaming testing needs. Similar to the other tests, I usually only want to see if it works generally.

Let me know what you guys think about that & if I've missed something. 

## Breaking Changes
None