### PR TITLE
feat(gemini): Add support for Gemini 2.5 Thinking Budget

### DIFF
--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -123,3 +123,21 @@ Prism::embeddings()
     ->withProviderOptions(['outputDimensionality' => 768])
     ->asEmbeddings();
 ```
+
+### Thinking Mode
+
+Gemini 2.5 series models use an internal "thinking process" during response generation. Thinking is on by default as these models have the ability to automatically decide when and how much to think based on the prompt. If you would like to customize how many tokens the model may use for thinking, or disable thinking altogether, utilize the `withProviderOptions()` method, and pass through an array with a key value pair with `thinkingBudget` and an integer representing the budget of tokens. Set this value to `0` to disable thinking.
+
+```php
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-2.5-flash-preview')
+    ->withPrompt('Explain the concept of Occam\'s Razor and provide a simple, everyday example.')
+    // Set thinking budget
+    ->withProviderOptions(['thinkingBudget' => 300])
+    ->generate();
+```
+> [!NOTE]
+> Do not specify a `thinkingBudget` on 2.0 or prior series Gemini models as your request will fail.

--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -242,11 +242,11 @@ class Stream
                             'temperature' => $request->temperature(),
                             'topP' => $request->topP(),
                             'maxOutputTokens' => $request->maxTokens(),
-							'thinkingConfig' => array_filter([
-								'thinkingBudget' => array_key_exists('thinkingBudget', $providerOptions)
-									? $providerOptions['thinkingBudget']
-									: null,
-							], fn($v) => $v !== null),
+                            'thinkingConfig' => array_filter([
+                                'thinkingBudget' => array_key_exists('thinkingBudget', $providerOptions)
+                                    ? $providerOptions['thinkingBudget']
+                                    : null,
+                            ], fn ($v) => $v !== null),
                         ]),
                         'tools' => $tools !== [] ? $tools : null,
                         'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,

--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -243,8 +243,10 @@ class Stream
                             'topP' => $request->topP(),
                             'maxOutputTokens' => $request->maxTokens(),
 							'thinkingConfig' => array_filter([
-								'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-							]),
+								'thinkingBudget' => array_key_exists('thinkingBudget', $providerOptions)
+									? $providerOptions['thinkingBudget']
+									: null,
+							], fn($v) => $v !== null),
                         ]),
                         'tools' => $tools !== [] ? $tools : null,
                         'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,

--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -242,6 +242,9 @@ class Stream
                             'temperature' => $request->temperature(),
                             'topP' => $request->topP(),
                             'maxOutputTokens' => $request->maxTokens(),
+							'thinkingConfig' => array_filter([
+								'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
+							]),
                         ]),
                         'tools' => $tools !== [] ? $tools : null,
                         'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -106,8 +106,9 @@ class Structured
                     data_get($data, 'candidates.0.finishReason'),
                 ),
                 usage: new Usage(
-                    data_get($data, 'usageMetadata.promptTokenCount', 0),
-                    data_get($data, 'usageMetadata.candidatesTokenCount', 0)
+                    promptTokens: data_get($data, 'usageMetadata.promptTokenCount', 0),
+					completionTokens: data_get($data, 'usageMetadata.candidatesTokenCount', 0),
+					thoughtTokens: data_get($data, 'usageMetadata.thoughtsTokenCount', null),
                 ),
                 meta: new Meta(
                     id: data_get($data, 'id', ''),

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -64,6 +64,9 @@ class Structured
                         'temperature' => $request->temperature(),
                         'topP' => $request->topP(),
                         'maxOutputTokens' => $request->maxTokens(),
+						'thinkingConfig' => array_filter([
+							'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
+						]),
                     ]),
                     'safetySettings' => $providerOptions['safetySettings'] ?? null,
                 ])

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -65,8 +65,10 @@ class Structured
                         'topP' => $request->topP(),
                         'maxOutputTokens' => $request->maxTokens(),
 						'thinkingConfig' => array_filter([
-							'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-						]),
+							'thinkingBudget' => array_key_exists('thinkingBudget', $providerOptions)
+								? $providerOptions['thinkingBudget']
+								: null,
+						], fn($v) => $v !== null),
                     ]),
                     'safetySettings' => $providerOptions['safetySettings'] ?? null,
                 ])

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -64,11 +64,11 @@ class Structured
                         'temperature' => $request->temperature(),
                         'topP' => $request->topP(),
                         'maxOutputTokens' => $request->maxTokens(),
-						'thinkingConfig' => array_filter([
-							'thinkingBudget' => array_key_exists('thinkingBudget', $providerOptions)
-								? $providerOptions['thinkingBudget']
-								: null,
-						], fn($v) => $v !== null),
+                        'thinkingConfig' => array_filter([
+                            'thinkingBudget' => array_key_exists('thinkingBudget', $providerOptions)
+                                ? $providerOptions['thinkingBudget']
+                                : null,
+                        ], fn ($v) => $v !== null),
                     ]),
                     'safetySettings' => $providerOptions['safetySettings'] ?? null,
                 ])
@@ -109,8 +109,8 @@ class Structured
                 ),
                 usage: new Usage(
                     promptTokens: data_get($data, 'usageMetadata.promptTokenCount', 0),
-					completionTokens: data_get($data, 'usageMetadata.candidatesTokenCount', 0),
-					thoughtTokens: data_get($data, 'usageMetadata.thoughtsTokenCount', null),
+                    completionTokens: data_get($data, 'usageMetadata.candidatesTokenCount', 0),
+                    thoughtTokens: data_get($data, 'usageMetadata.thoughtsTokenCount', null),
                 ),
                 meta: new Meta(
                     id: data_get($data, 'id', ''),

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -82,8 +82,10 @@ class Text
                 'topP' => $request->topP(),
                 'maxOutputTokens' => $request->maxTokens(),
 				'thinkingConfig' => array_filter([
-					'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-				]),
+					'thinkingBudget' => array_key_exists('thinkingBudget', $providerOptions)
+						? $providerOptions['thinkingBudget']
+						: null,
+				], fn($v) => $v !== null),
             ]);
 
             if ($request->tools() !== [] && ($providerOptions['searchGrounding'] ?? false)) {

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -81,11 +81,11 @@ class Text
                 'temperature' => $request->temperature(),
                 'topP' => $request->topP(),
                 'maxOutputTokens' => $request->maxTokens(),
-				'thinkingConfig' => array_filter([
-					'thinkingBudget' => array_key_exists('thinkingBudget', $providerOptions)
-						? $providerOptions['thinkingBudget']
-						: null,
-				], fn($v) => $v !== null),
+                'thinkingConfig' => array_filter([
+                    'thinkingBudget' => array_key_exists('thinkingBudget', $providerOptions)
+                        ? $providerOptions['thinkingBudget']
+                        : null,
+                ], fn ($v) => $v !== null),
             ]);
 
             if ($request->tools() !== [] && ($providerOptions['searchGrounding'] ?? false)) {
@@ -171,7 +171,7 @@ class Text
                     : data_get($data, 'usageMetadata.promptTokenCount', 0),
                 completionTokens: data_get($data, 'usageMetadata.candidatesTokenCount', 0),
                 cacheReadInputTokens: data_get($data, 'usageMetadata.cachedContentTokenCount', null),
-				thoughtTokens: data_get($data, 'usageMetadata.thoughtsTokenCount', null),
+                thoughtTokens: data_get($data, 'usageMetadata.thoughtsTokenCount', null),
             ),
             meta: new Meta(
                 id: data_get($data, 'id', ''),

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -81,6 +81,9 @@ class Text
                 'temperature' => $request->temperature(),
                 'topP' => $request->topP(),
                 'maxOutputTokens' => $request->maxTokens(),
+				'thinkingConfig' => array_filter([
+					'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
+				]),
             ]);
 
             if ($request->tools() !== [] && ($providerOptions['searchGrounding'] ?? false)) {

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -169,6 +169,7 @@ class Text
                     : data_get($data, 'usageMetadata.promptTokenCount', 0),
                 completionTokens: data_get($data, 'usageMetadata.candidatesTokenCount', 0),
                 cacheReadInputTokens: data_get($data, 'usageMetadata.cachedContentTokenCount', null),
+				thoughtTokens: data_get($data, 'usageMetadata.thoughtsTokenCount', null),
             ),
             meta: new Meta(
                 id: data_get($data, 'id', ''),

--- a/src/Structured/ResponseBuilder.php
+++ b/src/Structured/ResponseBuilder.php
@@ -84,6 +84,9 @@ readonly class ResponseBuilder
             cacheReadInputTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->cacheReadInputTokens !== null)
                 ? $this->steps->sum(fn (Step $result): int => $result->usage->cacheReadInputTokens ?? 0)
                 : null,
+			thoughtTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->thoughtTokens !== null)
+				? $this->steps->sum(fn (Step $result): int => $result->usage->thoughtTokens ?? 0)
+				: null,
         );
     }
 }

--- a/src/Structured/ResponseBuilder.php
+++ b/src/Structured/ResponseBuilder.php
@@ -84,9 +84,9 @@ readonly class ResponseBuilder
             cacheReadInputTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->cacheReadInputTokens !== null)
                 ? $this->steps->sum(fn (Step $result): int => $result->usage->cacheReadInputTokens ?? 0)
                 : null,
-			thoughtTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->thoughtTokens !== null)
-				? $this->steps->sum(fn (Step $result): int => $result->usage->thoughtTokens ?? 0)
-				: null,
+            thoughtTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->thoughtTokens !== null)
+                ? $this->steps->sum(fn (Step $result): int => $result->usage->thoughtTokens ?? 0)
+                : null,
         );
     }
 }

--- a/src/Text/ResponseBuilder.php
+++ b/src/Text/ResponseBuilder.php
@@ -70,6 +70,9 @@ readonly class ResponseBuilder
             cacheReadInputTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->cacheReadInputTokens !== null)
                 ? $this->steps->sum(fn (Step $result): int => $result->usage->cacheReadInputTokens ?? 0)
                 : null,
+			thoughtTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->thoughtTokens !== null)
+				? $this->steps->sum(fn (Step $result): int => $result->usage->thoughtTokens ?? 0)
+				: null,
         );
     }
 }

--- a/src/Text/ResponseBuilder.php
+++ b/src/Text/ResponseBuilder.php
@@ -70,9 +70,9 @@ readonly class ResponseBuilder
             cacheReadInputTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->cacheReadInputTokens !== null)
                 ? $this->steps->sum(fn (Step $result): int => $result->usage->cacheReadInputTokens ?? 0)
                 : null,
-			thoughtTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->thoughtTokens !== null)
-				? $this->steps->sum(fn (Step $result): int => $result->usage->thoughtTokens ?? 0)
-				: null,
+            thoughtTokens: $this->steps->contains(fn (Step $result): bool => $result->usage->thoughtTokens !== null)
+                ? $this->steps->sum(fn (Step $result): int => $result->usage->thoughtTokens ?? 0)
+                : null,
         );
     }
 }

--- a/src/ValueObjects/Usage.php
+++ b/src/ValueObjects/Usage.php
@@ -10,6 +10,7 @@ readonly class Usage
         public int $promptTokens,
         public int $completionTokens,
         public ?int $cacheWriteInputTokens = null,
-        public ?int $cacheReadInputTokens = null
+        public ?int $cacheReadInputTokens = null,
+		public ?int $thoughtTokens = null,
     ) {}
 }

--- a/src/ValueObjects/Usage.php
+++ b/src/ValueObjects/Usage.php
@@ -11,6 +11,6 @@ readonly class Usage
         public int $completionTokens,
         public ?int $cacheWriteInputTokens = null,
         public ?int $cacheReadInputTokens = null,
-		public ?int $thoughtTokens = null,
+        public ?int $thoughtTokens = null,
     ) {}
 }

--- a/tests/Fixtures/gemini/generate-text-with-a-prompt-with-no-thinking-budget-1.json
+++ b/tests/Fixtures/gemini/generate-text-with-a-prompt-with-no-thinking-budget-1.json
@@ -1,0 +1,23 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Okay, let's break down Occam's Razor. **Explanation of Occam's Razor:** Occam's Razor (also spelled Ockham's Razor, and known in Latin as *Lex Parsimoniae*, the Law of Parsimony or Stinginess) is a **problem-solving principle**, not ▶ The core idea is: **When presented with competing hypothetical explanations for a phenomenon, you should select the one that makes the fewest assumptions.** In simpler terms: **The simplest explanation is usually the best one.** It doesn't say the simplest explanation is *always* correct, just that it's the most likely to be correct or the one you should investigate first. It encourages ▶ Think of it as being \"stingy\" with adding extra layers or factors that aren't strictly needed to explain something. **Simple, Everyday Example:** Imagine you come home and find a plate broken on the kitchen floor. You weren't home when it happened. *   **Explanation 1 (Complex):** A small earthquake occurred precisely at the moment the plate was sitting precariously on the edge of the counter, vibrating it ▶ *   **Explanation 2 (Simple):** It simply fell off the counter or was knocked off by a pet or someone who left the house just before you arrived. According to Occam's Razor, you would favor **Explanation 2**. Why? *   **Explanation 1** requires several assumptions: the timing of a specific, small earthquake you didn't feel, the plate's exact position, and the specific vibration frequency needed to dislodge *just* that plate. ◀ *   **Explanation 2** requires fewer assumptions: gravity exists, objects fall, things get knocked over, pets are sometimes clumsy, or someone might have been a bit careless. These are common occurrences. ◀ Occam's Razor suggests that the simplest explanation (it fell or was knocked) is the more probable one, as it relies on far fewer unproven or unlikely factors than the earthquake scenario. You'd start by looking for signs of it falling or asking others in the house, rather than checking seismic activity reports."
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "avgLogprobs": -0.12800796408402293
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 17,
+    "candidatesTokenCount": 492,
+    "totalTokenCount": 61,
+    "thoughtsTokenCount": null
+  },
+  "modelVersion": "gemini-2.5-flash-preview"
+}

--- a/tests/Fixtures/gemini/generate-text-with-a-prompt-with-thinking-budget-1.json
+++ b/tests/Fixtures/gemini/generate-text-with-a-prompt-with-thinking-budget-1.json
@@ -1,0 +1,23 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Okay, let's break down Occam's Razor. **Explanation of Occam's Razor:** Occam's Razor (also spelled Ockham's Razor, and known in Latin as *Lex Parsimoniae*, the Law of Parsimony or Stinginess) is a **problem-solving principle**, not ▶ The core idea is: **When presented with competing hypothetical explanations for a phenomenon, you should select the one that makes the fewest assumptions.** In simpler terms: **The simplest explanation is usually the best one.** It doesn't say the simplest explanation is *always* correct, just that it's the most likely to be correct or the one you should investigate first. It encourages ▶ Think of it as being \"stingy\" with adding extra layers or factors that aren't strictly needed to explain something. **Simple, Everyday Example:** Imagine you come home and find a plate broken on the kitchen floor. You weren't home when it happened. *   **Explanation 1 (Complex):** A small earthquake occurred precisely at the moment the plate was sitting precariously on the edge of the counter, vibrating it ▶ *   **Explanation 2 (Simple):** It simply fell off the counter or was knocked off by a pet or someone who left the house just before you arrived. According to Occam's Razor, you would favor **Explanation 2**. Why? *   **Explanation 1** requires several assumptions: the timing of a specific, small earthquake you didn't feel, the plate's exact position, and the specific vibration frequency needed to dislodge *just* that plate. ◀ *   **Explanation 2** requires fewer assumptions: gravity exists, objects fall, things get knocked over, pets are sometimes clumsy, or someone might have been a bit careless. These are common occurrences. ◀ Occam's Razor suggests that the simplest explanation (it fell or was knocked) is the more probable one, as it relies on far fewer unproven or unlikely factors than the earthquake scenario. You'd start by looking for signs of it falling or asking others in the house, rather than checking seismic activity reports."
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "avgLogprobs": -0.12800796408402293
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 17,
+    "candidatesTokenCount": 492,
+    "totalTokenCount": 61,
+    "thoughtsTokenCount": 1209
+  },
+  "modelVersion": "gemini-2.5-flash-preview"
+}

--- a/tests/Providers/Gemini/GeminiTextTest.php
+++ b/tests/Providers/Gemini/GeminiTextTest.php
@@ -12,7 +12,6 @@ use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Prism;
 use Prism\Prism\Providers\Gemini\ValueObjects\MessagePartWithSearchGroundings;
 use Prism\Prism\Providers\Gemini\ValueObjects\SearchGrounding;
-use Prism\Prism\Testing\TextResponseFake;
 use Prism\Prism\Tool;
 use Prism\Prism\ValueObjects\Messages\Support\Document;
 use Prism\Prism\ValueObjects\Messages\Support\Image;
@@ -443,47 +442,47 @@ describe('Cache support for Gemini', function (): void {
 });
 
 describe('Thinking Mode for Gemini', function (): void {
-	it('uses thought tokens on 2.5 series models by default without specifying a budget', function (): void {
-		FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt-with-thinking-budget');
+    it('uses thought tokens on 2.5 series models by default without specifying a budget', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt-with-thinking-budget');
 
-		$response = Prism::text()
-			->using(Provider::Gemini, 'gemini-2.5-flash-preview')
-			->withPrompt('Explain the concept of Occam\'s Razor and provide a simple, everyday example.')
-			->asText();
+        $response = Prism::text()
+            ->using(Provider::Gemini, 'gemini-2.5-flash-preview')
+            ->withPrompt('Explain the concept of Occam\'s Razor and provide a simple, everyday example.')
+            ->asText();
 
-		expect($response->usage->thoughtTokens)->toBe(1209);
+        expect($response->usage->thoughtTokens)->toBe(1209);
 
-		Http::assertSent(function (Request $request) {
-			$data = $request->data();
+        Http::assertSent(function (Request $request) {
+            $data = $request->data();
 
-			expect($data['generationConfig'])->not->toHaveKey('thinkingConfig');
+            expect($data['generationConfig'])->not->toHaveKey('thinkingConfig');
 
-			return true;
-		});
+            return true;
+        });
 
-	});
+    });
 
-	it('sets thinking budget to 0', function (): void {
-		FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt-with-no-thinking-budget');
+    it('sets thinking budget to 0', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-with-a-prompt-with-no-thinking-budget');
 
-		$response = Prism::text()
-			->using(Provider::Gemini, 'gemini-2.5-flash-preview')
-			->withPrompt('Explain the concept of Occam\'s Razor and provide a simple, everyday example.')
-			->withProviderOptions(['thinkingBudget' => 0])
-			->asText();
+        $response = Prism::text()
+            ->using(Provider::Gemini, 'gemini-2.5-flash-preview')
+            ->withPrompt('Explain the concept of Occam\'s Razor and provide a simple, everyday example.')
+            ->withProviderOptions(['thinkingBudget' => 0])
+            ->asText();
 
-		expect($response->usage->thoughtTokens)->toBeNull();
+        expect($response->usage->thoughtTokens)->toBeNull();
 
-		Http::assertSent(function (Request $request) {
-			$data = $request->data();
+        Http::assertSent(function (Request $request) {
+            $data = $request->data();
 
-			expect($data['generationConfig'])->toHaveKey('thinkingConfig')
-				->and($data['generationConfig']['thinkingConfig'])->toMatchArray([
-					'thinkingBudget' => 0,
-				]);
+            expect($data['generationConfig'])->toHaveKey('thinkingConfig')
+                ->and($data['generationConfig']['thinkingConfig'])->toMatchArray([
+                    'thinkingBudget' => 0,
+                ]);
 
-			return true;
-		});
+            return true;
+        });
 
-	});
+    });
 });


### PR DESCRIPTION
## Description
In the preview Gemini 2.5 models, Google introduced "thinking", and is enabled by default on these models. Without this feature, using the new models will always include thinking, which is billed at a higher rate and not always desirable. This PR enables you to configure a `thinkingBudget`, which Gemini views a max amount of tokens that may be used for thinking, or it can be set to 0 to disable it altogether.

This PR:

- Introduces a new `thoughtTokens` to the `Usage` class
- Leverages the `withProviderOptions()` method to inject a `thinkingBudget` when passed as a key, value pair
- Includes two tests that check for `thoughtTokens` in the `Usage` output
- Updates the documentation for Gemini to include this functionality

## Usage

```
$response = Prism::text()
			->using(Provider::Gemini, 'gemini-2.5-flash-preview')
			->withPrompt('Explain the concept of Occam\'s Razor and provide a simple, everyday example.')
			->withProviderOptions(['thinkingBudget' => 500])
			->asText();
```

You can set `thinkingBudget` to `0` to disable thinking altogether. Note this also works with structured.

## Potential Discussion
Gemini has made the choice that thinking is on by default, so this PR follows that convention. As in, if you do not specify a `thinkingBudget` of `0`, then thinking will be enabled. An alternative approach could assume that unless you include a `thinkingBudget`, that Prism can set this value to 0. For this to work effectively you would need to (re)introduce a `ThinkingModeResolver`, at least in the near term, as I expect all models will eventually gravitate towards this thinking convention. 
