### PR TITLE
refactor(ollama): enhance options handling in handlers

### DIFF
--- a/src/Providers/Ollama/Handlers/Embeddings.php
+++ b/src/Providers/Ollama/Handlers/Embeddings.php
@@ -51,6 +51,7 @@ class Embeddings
             [
                 'model' => $request->model(),
                 'input' => $request->inputs(),
+                'options' => array_filter($request->providerOptions()),
             ]
         );
     }

--- a/src/Providers/Ollama/Handlers/Stream.php
+++ b/src/Providers/Ollama/Handlers/Stream.php
@@ -181,11 +181,11 @@ class Stream
                     'messages' => (new MessageMap($request->messages()))->map(),
                     'tools' => ToolMap::map($request->tools()),
                     'stream' => true,
-                    'options' => array_filter([
+                    'options' => array_filter(array_merge([
                         'temperature' => $request->temperature(),
                         'num_predict' => $request->maxTokens() ?? 2048,
                         'top_p' => $request->topP(),
-                    ]),
+                    ], $request->providerOptions())),
                 ]);
         } catch (Throwable $e) {
             if ($e instanceof RequestException && $e->response->getStatusCode() === 429) {

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -87,11 +87,12 @@ class Structured
                 'messages' => (new MessageMap($request->messages()))->map(),
                 'format' => $request->schema()->toArray(),
                 'stream' => false,
-                'options' => array_filter([
+                'options' => array_filter(array_merge([
                     'temperature' => $request->temperature(),
                     'num_predict' => $request->maxTokens() ?? 2048,
                     'top_p' => $request->topP(),
-                ])]);
+                ], $request->providerOptions())),
+            ]);
 
             return $response->json();
         } catch (Throwable $e) {

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -78,11 +78,12 @@ class Text
                     'messages' => (new MessageMap($request->messages()))->map(),
                     'tools' => ToolMap::map($request->tools()),
                     'stream' => false,
-                    'options' => array_filter([
+                    'options' => array_filter(array_merge([
                         'temperature' => $request->temperature(),
                         'num_predict' => $request->maxTokens() ?? 2048,
                         'top_p' => $request->topP(),
-                    ])]);
+                    ], $request->providerOptions())),
+                ]);
 
             return $response->json();
         } catch (Throwable $e) {


### PR DESCRIPTION
Whats up TJ!

Great work on this package. Finally got around to a new LLM project and decided to give it a go vs rolling my own. 

So far so good. 

I noticed Ollama options were missing, and added those with this PR.

Now users can do something like

```php
$response = Prism::text()
    ->usingTemperature(0.5)
    ->withMaxTokens(1000)
    ->withProviderOptions([
        'stop' => ['<custom_stop_sequence>'],
    ])
```

To create a custom stop sequence. Other [options are available](https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values).

The way it's implemented, `withProviderOptions` will take priority over any of the temperature, top_p, or token configurations, should the user manually define these in the `withProviderOptions`. This would be preferential, so users could use one definition for all their options, if they so choose.

I added options to embeddings, since Ollama does make it available in their API specs.

This would close Issue #110 