### PR TITLE
feat: add FireworksAI provider support

### DIFF
--- a/config/prism.php
+++ b/config/prism.php
@@ -47,5 +47,11 @@ return [
             'api_key' => env('VOYAGEAI_API_KEY', ''),
             'url' => env('VOYAGEAI_URL', 'https://api.voyageai.com/v1'),
         ],
+        'fireworksai' => [
+            'url' => env('FIREWORKS_URL', 'https://api.fireworks.ai/inference/v1'),
+            'api_key' => env('FIREWORKS_API_KEY', ''),
+            'organization' => env('FIREWORKS_ORGANIZATION', null),
+            'project' => env('FIREWORKS_PROJECT', null),
+        ],
     ],
 ];

--- a/docs/providers/fireworksai.md
+++ b/docs/providers/fireworksai.md
@@ -1,0 +1,90 @@
+# Fireworks AI
+
+## Configuration
+
+```php
+'fireworksai' => [
+    'api_key' => env('FIREWORKS_API_KEY', ''),
+    'url' => env('FIREWORKS_URL', 'https://api.fireworks.ai/inference/v1'),
+],
+```
+
+## Provider-specific Settings
+
+The primary provider-specific settings are configured during the initial setup (see Configuration above).
+* **Model Naming**: Remember that model names for Fireworks AI typically include account prefixes, for example: `accounts/fireworks/models/llama-v3-8b-instruct`.
+
+## Considerations
+
+* **Structured Output Approach**: When using `Prism::structured()`, you must explicitly choose between Fireworks AI's three structured output approaches: JSON mode, grammar mode, or function calling. Each method requires specific configuration:
+    * **JSON mode**: Set `response_format: ['type' => 'json_object']`. If a schema is provided to Prism, it will be included in the `response_format` sent to Fireworks AI.
+    * **Grammar mode**: Provide a `grammar` parameter within `withProviderOptions()` containing your GBNF string.
+    * **Function calling**: Define tools/functions in your request and structure your prompt to guide the model towards using them.
+    * **Note**: Fireworks AI does not automatically fall back between these structured output methods; explicit configuration for the desired approach is required.
+* **Image and Document Handling**: The provider supports the inlining of image data (both Base64 encoded strings and URLs) and document text directly within user messages. This enables multimodal interactions with compatible Fireworks AI models.
+    * **Note**: Document inlining with Fireworks AI is a feature that may be in public preview and its terms of use (e.g., pricing) could change. Always refer to the official Fireworks AI documentation for the latest status.
+* **Rate Limits**: The client is designed to automatically process `x-ratelimit-*` headers returned by the Fireworks AI API. This information is used to populate rate limit details, which can be particularly useful for handling `PrismRateLimitedException`.
+
+## Provider-specific options
+
+### Grammar-Constrained Output
+
+You can enforce output structure using a GBNF (Grammar-Based BNF) grammar. This is applicable for text generation, streaming, and structured requests to ensure the model's output conforms to a predefined format.
+
+```php
+$response = Prism::structured() // Also applicable to text() or stream()
+    ->using(Provider::FireworksAI, 'accounts/fireworks/models/llama-v3-8b-instruct')
+    ->withPrompt("Generate a JSON list of three fruits.")
+    ->withProviderOptions([ // [!code focus]
+        'grammar' => 'root ::= "fruit_list" "\\n" ("- " [a-zA-Z]+ "\\n")*' // Replace with your actual GBNF grammar string [!code focus]
+    ]) // [!code focus]
+    ->asStructured();
+```
+
+### "Any" Tool Choice
+
+Fireworks AI accommodates a specific `tool_choice` option of `'any'`. When this is set, the model is compelled to select and use one of the tools you have provided in the request. This option works particularly well with Fireworks AI's FireFunction series of models.
+
+```php
+$response = Prism::text()
+    ->using(Provider::FireworksAI, 'accounts/fireworks/models/firefunction-v1') // Example FireFunction model
+    ->withTools([/* ...your defined tools... */])
+    ->withProviderOptions([ // [!code focus]
+        'tool_choice' => 'any' // [!code focus]
+    ]) // [!code focus]
+    ->asText();
+```
+This is an extension to standard behaviors like `'auto'` (model decides), `'none'` (no tools called), or specifying a particular tool's name.
+
+### Additional Generation Controls
+
+Fireworks AI offers several other parameters to fine-tune the generation process. These can be passed using the `withProviderOptions()` method:
+
+```php
+$response = Prism::text()
+    ->using(Provider::FireworksAI, 'accounts/fireworks/models/llama-v3-8b-instruct')
+    ->withPrompt('Tell me an interesting fact.')
+    ->withProviderOptions([ // [!code focus]
+        'repetition_penalty' => 1.15, // [!code focus]
+        'context_length_exceeded_behavior' => 'truncate', // Example: 'truncate' or other supported values [!code focus]
+        // Other available options include: mirostat_lr, mirostat_target, raw_output, echo [!code focus]
+    ]) // [!code focus]
+    ->asText();
+```
+Common parameters such as `temperature`, `top_p`, and `max_tokens` are also configurable via `withProviderOptions` or their respective dedicated helper methods.
+
+### Embedding Dimensions
+
+When requesting embeddings, you can specify the desired `dimensions` for the output vectors, provided the selected Fireworks AI embedding model supports this customization.
+
+```php
+$response = Prism::embeddings()
+    ->using(Provider::FireworksAI, 'accounts/fireworks/models/nomic-embed-text-v1.5') // Example embedding model
+    ->fromInput('Text to be embedded.')
+    ->withProviderOptions(['dimensions' => 768]) // [!code focus]
+    ->asEmbeddings();
+```
+
+## Limitations
+
+* At present, no specific limitations unique to the Fireworks AI provider (beyond general API usage patterns or those inherent to the underlying models) are explicitly noted within the Prism integration. The provider aims to expose core Fireworks AI functionalities like tool use, streaming, and structured output.

--- a/src/Enums/Provider.php
+++ b/src/Enums/Provider.php
@@ -15,4 +15,5 @@ enum Provider: string
     case XAI = 'xai';
     case Gemini = 'gemini';
     case VoyageAI = 'voyageai';
+    case FireworksAI = 'fireworksai';
 }

--- a/src/PrismManager.php
+++ b/src/PrismManager.php
@@ -11,6 +11,7 @@ use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Enums\Provider as ProviderEnum;
 use Prism\Prism\Providers\Anthropic\Anthropic;
 use Prism\Prism\Providers\DeepSeek\DeepSeek;
+use Prism\Prism\Providers\FireworksAI\FireworksAI;
 use Prism\Prism\Providers\Gemini\Gemini;
 use Prism\Prism\Providers\Groq\Groq;
 use Prism\Prism\Providers\Mistral\Mistral;
@@ -193,6 +194,19 @@ class PrismManager
         return new Gemini(
             url: $config['url'],
             apiKey: $config['api_key'],
+        );
+    }
+
+    /**
+     * @param  array<string, string>  $config
+     */
+    protected function createFireworksaiProvider(array $config): FireworksAI
+    {
+        return new FireworksAI(
+            apiKey: $config['api_key'] ?? '',
+            url: $config['url'],
+            organization: $config['organization'] ?? null,
+            project: $config['project'] ?? null,
         );
     }
 }

--- a/src/Providers/FireworksAI/Concerns/ValidateResponse.php
+++ b/src/Providers/FireworksAI/Concerns/ValidateResponse.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\FireworksAI\Concerns;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
+
+trait ValidateResponse
+{
+    protected function validateResponse(Response $response): void
+    {
+        if ($response->getStatusCode() === 429) {
+            throw PrismRateLimitedException::make(
+                rateLimits: $this->processRateLimits($response),
+                retryAfter: (int) $response->header('retry-after')
+            );
+        }
+
+        $data = $response->json();
+
+        if (! $data || data_get($data, 'error')) {
+            throw PrismException::providerResponseError(vsprintf(
+                'FireworksAI Error: [%s] %s',
+                [
+                    data_get($data, 'error.type', 'unknown'),
+                    data_get($data, 'error.message', 'unknown'),
+                ]
+            ));
+        }
+    }
+
+    /**
+     * @return ProviderRateLimit[]
+     */
+    protected function processRateLimits(Response $response): array
+    {
+        $limitHeaders = array_filter(
+            $response->getHeaders(),
+            fn ($headerName) => Str::startsWith($headerName, 'x-ratelimit-'),
+            ARRAY_FILTER_USE_KEY
+        );
+
+        $rateLimits = [];
+
+        foreach ($limitHeaders as $headerName => $headerValues) {
+            if ($headerName === 'x-ratelimit-over-limit') {
+                $rateLimits['over-limit']['status'] = $headerValues[0];
+
+                continue;
+            }
+
+            $limitName = Str::of($headerName)->afterLast('-')->toString();
+            $fieldName = Str::of($headerName)->after('x-ratelimit-')->beforeLast('-')->toString();
+
+            $rateLimits[$limitName][$fieldName] = $headerValues[0];
+        }
+
+        return array_values(Arr::map($rateLimits, function ($fields, $limitName): ProviderRateLimit {
+            if ($limitName === 'over-limit') {
+                return new ProviderRateLimit(
+                    name: 'over-limit',
+                    limit: null,
+                    remaining: 0,
+                    resetsAt: null
+                );
+            }
+
+            $resetsAt = data_get($fields, 'reset', '');
+
+            if (str_contains($resetsAt, 'ms')) {
+                $resetMilliseconds = Str::of($resetsAt)->before('ms')->toString();
+                $resetMinutes = 0;
+                $resetSeconds = 0;
+            } else {
+                $resetMilliseconds = 0;
+
+                $resetMinutes = str_contains($resetsAt, 'm')
+                    ? Str::of($resetsAt)->before('m')->toString()
+                    : 0;
+
+                $resetSeconds = str_contains($resetsAt, 'm')
+                    ? Str::of($resetsAt)->after('m')->before('s')->toString()
+                    : Str::of($resetsAt)->before('s')->toString();
+            }
+
+            return new ProviderRateLimit(
+                name: $limitName,
+                limit: data_get($fields, 'limit') !== null
+                    ? (int) data_get($fields, 'limit')
+                    : null,
+                remaining: data_get($fields, 'remaining') !== null
+                    ? (int) data_get($fields, 'remaining')
+                    : null,
+                resetsAt: data_get($fields, 'reset') !== null
+                    ? Carbon::now()->addMinutes((int) $resetMinutes)->addSeconds((int) $resetSeconds)->addMilliseconds((int) $resetMilliseconds)
+                    : null
+            );
+        }));
+    }
+}

--- a/src/Providers/FireworksAI/FireworksAI.php
+++ b/src/Providers/FireworksAI/FireworksAI.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\FireworksAI;
+
+use Closure;
+use Generator;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
+use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
+use Prism\Prism\Providers\FireworksAI\Handlers\Embeddings;
+use Prism\Prism\Providers\FireworksAI\Handlers\Stream;
+use Prism\Prism\Providers\FireworksAI\Handlers\Structured;
+use Prism\Prism\Providers\FireworksAI\Handlers\Text;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Structured\Response as StructuredResponse;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
+
+readonly class FireworksAI implements Provider
+{
+    public function __construct(
+        #[\SensitiveParameter] public string $apiKey,
+        public string $url,
+        public ?string $organization,
+        public ?string $project,
+    ) {}
+
+    #[\Override]
+    public function text(TextRequest $request): TextResponse
+    {
+        $handler = new Text($this->client($request->clientOptions(), $request->clientRetry()));
+
+        return $handler->handle($request);
+    }
+
+    #[\Override]
+    public function structured(StructuredRequest $request): StructuredResponse
+    {
+        $handler = new Structured($this->client($request->clientOptions(), $request->clientRetry()));
+
+        return $handler->handle($request);
+    }
+
+    #[\Override]
+    public function embeddings(EmbeddingsRequest $request): EmbeddingsResponse
+    {
+        $handler = new Embeddings($this->client($request->clientOptions(), $request->clientRetry()));
+
+        return $handler->handle($request);
+    }
+
+    #[\Override]
+    public function stream(TextRequest $request): Generator
+    {
+        $handler = new Stream($this->client($request->clientOptions(), $request->clientRetry()));
+
+        return $handler->handle($request);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $retry
+     */
+    protected function client(array $options, array $retry): PendingRequest
+    {
+        return Http::withHeaders(array_filter([
+            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
+        ]))
+            ->withOptions($options)
+            ->retry(...$retry)
+            ->baseUrl($this->url);
+    }
+}

--- a/src/Providers/FireworksAI/Handlers/Embeddings.php
+++ b/src/Providers/FireworksAI/Handlers/Embeddings.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\FireworksAI\Handlers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
+use Prism\Prism\Embeddings\Request;
+use Prism\Prism\Embeddings\Response;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\FireworksAI\Concerns\ValidateResponse;
+use Prism\Prism\ValueObjects\Embedding;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
+use Throwable;
+
+class Embeddings
+{
+    use ValidateResponse;
+
+    public function __construct(protected PendingRequest $client) {}
+
+    public function handle(Request $request): Response
+    {
+        $response = $this->sendRequest($request);
+
+        $this->validateResponse($response);
+
+        $data = $response->json();
+
+        return new Response(
+            embeddings: array_map(fn (array $embedding): Embedding => new Embedding(
+                embedding: data_get($embedding, 'embedding'),
+            ), data_get($data, 'data', [])),
+            usage: new EmbeddingsUsage(
+                tokens: data_get($data, 'usage.total_tokens'),
+            ),
+            meta: new Meta(
+                id: '',
+                model: data_get($data, 'model', ''),
+            ),
+        );
+    }
+
+    protected function sendRequest(Request $request): ClientResponse
+    {
+        try {
+            $body = [
+                'model' => $request->model(),
+                'input' => $request->inputs(),
+                'encoding_format' => 'float',
+            ];
+
+            if ($dimensions = $request->providerOptions('dimensions')) {
+                $body['dimensions'] = $dimensions;
+            }
+
+            return $this->client->post(
+                'embeddings',
+                Arr::whereNotNull($body)
+            );
+        } catch (Throwable $e) {
+            throw PrismException::providerRequestError($request->model(), $e);
+        }
+    }
+}

--- a/src/Providers/FireworksAI/Handlers/Stream.php
+++ b/src/Providers/FireworksAI/Handlers/Stream.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\FireworksAI\Handlers;
+
+use Generator;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismChunkDecodeException;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Providers\FireworksAI\Concerns\ValidateResponse;
+use Prism\Prism\Providers\FireworksAI\Maps\MessageMap;
+use Prism\Prism\Providers\FireworksAI\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\OpenAI\Maps\FinishReasonMap;
+use Prism\Prism\Providers\OpenAI\Maps\ToolMap;
+use Prism\Prism\Text\Chunk;
+use Prism\Prism\Text\Request;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\ToolCall;
+use Psr\Http\Message\StreamInterface;
+use Throwable;
+
+class Stream
+{
+    use CallsTools, ValidateResponse;
+
+    public function __construct(protected PendingRequest $client) {}
+
+    /**
+     * @return Generator<Chunk>
+     */
+    public function handle(Request $request): Generator
+    {
+        $response = $this->sendRequest($request);
+
+        yield from $this->processStream($response, $request);
+    }
+
+    /**
+     * @return Generator<Chunk>
+     */
+    protected function processStream(Response $response, Request $request, int $depth = 0): Generator
+    {
+        if ($depth >= $request->maxSteps()) {
+            throw new PrismException('Maximum tool call chain depth exceeded');
+        }
+
+        $text = '';
+        $toolCalls = [];
+
+        while (! $response->getBody()->eof()) {
+            $data = $this->parseNextDataLine($response->getBody());
+
+            if ($data === null) {
+                continue;
+            }
+
+            if ($this->hasToolCalls($data)) {
+                $toolCalls = $this->extractToolCalls($data, $toolCalls);
+
+                continue;
+            }
+
+            if ($this->mapFinishReason($data) === FinishReason::ToolCalls) {
+                yield from $this->handleToolCalls($request, $text, $toolCalls, $depth);
+
+                return;
+            }
+
+            $content = data_get($data, 'choices.0.delta.content', '') ?? '';
+            $text .= $content;
+
+            $finishReason = $this->mapFinishReason($data);
+
+            yield new Chunk(
+                text: $content,
+                finishReason: $finishReason !== FinishReason::Unknown ? $finishReason : null
+            );
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null Parsed JSON data or null if line should be skipped
+     */
+    protected function parseNextDataLine(StreamInterface $stream): ?array
+    {
+        $line = $this->readLine($stream);
+
+        if (! str_starts_with($line, 'data:')) {
+            return null;
+        }
+
+        $line = trim(substr($line, strlen('data: ')));
+
+        if (Str::contains($line, 'DONE')) {
+            return null;
+        }
+
+        try {
+            return json_decode($line, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable $e) {
+            throw new PrismChunkDecodeException('FireworksAI', $e);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<int, array<string, mixed>>  $toolCalls
+     * @return array<int, array<string, mixed>>
+     */
+    protected function extractToolCalls(array $data, array $toolCalls): array
+    {
+        foreach (data_get($data, 'choices.0.delta.tool_calls', []) as $index => $toolCall) {
+            if ($name = data_get($toolCall, 'function.name')) {
+                $toolCalls[$index]['name'] = $name;
+                $toolCalls[$index]['arguments'] = '';
+                $toolCalls[$index]['id'] = data_get($toolCall, 'id');
+            }
+
+            $arguments = data_get($toolCall, 'function.arguments');
+
+            if (! is_null($arguments)) {
+                $toolCalls[$index]['arguments'] .= $arguments;
+            }
+        }
+
+        return $toolCalls;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $toolCalls
+     * @return Generator<Chunk>
+     */
+    protected function handleToolCalls(
+        Request $request,
+        string $text,
+        array $toolCalls,
+        int $depth
+    ): Generator {
+        $toolCalls = $this->mapToolCalls($toolCalls);
+
+        $toolResults = $this->callTools($request->tools(), $toolCalls);
+
+        $request->addMessage(new AssistantMessage($text, $toolCalls));
+        $request->addMessage(new ToolResultMessage($toolResults));
+
+        yield new Chunk(
+            text: '',
+            toolCalls: $toolCalls,
+            toolResults: $toolResults,
+        );
+
+        $nextResponse = $this->sendRequest($request);
+        yield from $this->processStream($nextResponse, $request, $depth + 1);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $toolCalls
+     * @return array<int, ToolCall>
+     */
+    protected function mapToolCalls(array $toolCalls): array
+    {
+        return collect($toolCalls)
+            ->map(fn ($toolCall): ToolCall => new ToolCall(
+                data_get($toolCall, 'id'),
+                data_get($toolCall, 'name'),
+                data_get($toolCall, 'arguments'),
+            ))
+            ->toArray();
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function hasToolCalls(array $data): bool
+    {
+        return (bool) data_get($data, 'choices.0.delta.tool_calls');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function mapFinishReason(array $data): FinishReason
+    {
+        return FinishReasonMap::map(data_get($data, 'choices.0.finish_reason') ?? '');
+    }
+
+    protected function sendRequest(Request $request): Response
+    {
+        try {
+            $body = array_merge([
+                'stream' => true,
+                'model' => $request->model(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                'max_tokens' => $request->maxTokens(),
+            ], Arr::whereNotNull([
+                'temperature' => $request->temperature(),
+                'top_p' => $request->topP(),
+                'metadata' => $request->providerOptions('metadata'),
+                'tools' => ToolMap::map($request->tools()),
+                'tool_choice' => $this->mapToolChoice($request),
+                // FireworksAI-specific parameters
+                'context_length_exceeded_behavior' => $request->providerOptions('context_length_exceeded_behavior'),
+                'repetition_penalty' => $request->providerOptions('repetition_penalty'),
+                'mirostat_lr' => $request->providerOptions('mirostat_lr'),
+                'mirostat_target' => $request->providerOptions('mirostat_target'),
+                'raw_output' => $request->providerOptions('raw_output'),
+                'echo' => $request->providerOptions('echo'),
+            ]));
+
+            if ($grammar = $request->providerOptions('grammar')) {
+                $body['response_format'] = [
+                    'type' => 'grammar',
+                    'grammar' => $grammar,
+                ];
+            }
+
+            return $this
+                ->client
+                ->withOptions(['stream' => true])
+                ->throw()
+                ->post('chat/completions', $body);
+        } catch (Throwable $e) {
+            if ($e instanceof RequestException && $e->response->getStatusCode() === 429) {
+                throw new PrismRateLimitedException($this->processRateLimits($e->response));
+            }
+
+            throw PrismException::providerRequestError($request->model(), $e);
+        }
+    }
+
+    /**
+     * Map tool choice with support for FireworksAI's "any" option
+     *
+     * @return array<string, mixed>|string|null
+     */
+    protected function mapToolChoice(Request $request): array|string|null
+    {
+        $toolChoice = $request->toolChoice();
+
+        if ($toolChoice === null) {
+            return null;
+        }
+
+        if ($request->providerOptions('tool_choice') === 'any') {
+            return 'any';
+        }
+
+        return ToolChoiceMap::map($toolChoice);
+    }
+
+    protected function readLine(StreamInterface $stream): string
+    {
+        $buffer = '';
+
+        while (! $stream->eof()) {
+            $byte = $stream->read(1);
+
+            if ($byte === '') {
+                return $buffer;
+            }
+
+            $buffer .= $byte;
+
+            if ($byte === "\n") {
+                break;
+            }
+        }
+
+        return $buffer;
+    }
+}

--- a/src/Providers/FireworksAI/Handlers/Structured.php
+++ b/src/Providers/FireworksAI/Handlers/Structured.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\FireworksAI\Handlers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\FireworksAI\Concerns\ValidateResponse;
+use Prism\Prism\Providers\FireworksAI\Maps\MessageMap;
+use Prism\Prism\Providers\FireworksAI\Maps\ToolCallMap;
+use Prism\Prism\Providers\OpenAI\Maps\FinishReasonMap;
+use Prism\Prism\Structured\Request;
+use Prism\Prism\Structured\Response;
+use Prism\Prism\Structured\ResponseBuilder;
+use Prism\Prism\Structured\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
+use Throwable;
+
+class Structured
+{
+    use CallsTools, ValidateResponse;
+
+    protected ResponseBuilder $responseBuilder;
+
+    public function __construct(protected PendingRequest $client)
+    {
+        $this->responseBuilder = new ResponseBuilder;
+    }
+
+    public function handle(Request $request): Response
+    {
+        $response = $this->sendRequest($request);
+
+        $this->validateResponse($response);
+
+        $data = $response->json();
+
+        $this->handleResponse($data, $request, $response);
+
+        return $this->responseBuilder->toResponse();
+    }
+
+    protected function sendRequest(Request $request): ClientResponse
+    {
+        try {
+            $body = array_merge([
+                'model' => $request->model(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                'max_tokens' => $request->maxTokens(),
+            ], Arr::whereNotNull([
+                'temperature' => $request->temperature(),
+                'top_p' => $request->topP(),
+                'metadata' => $request->providerOptions('metadata'),
+                'context_length_exceeded_behavior' => $request->providerOptions('context_length_exceeded_behavior'),
+                'repetition_penalty' => $request->providerOptions('repetition_penalty'),
+                'mirostat_lr' => $request->providerOptions('mirostat_lr'),
+                'mirostat_target' => $request->providerOptions('mirostat_target'),
+                'raw_output' => $request->providerOptions('raw_output'),
+                'echo' => $request->providerOptions('echo'),
+            ]));
+
+            if ($request->mode() === StructuredMode::Json) {
+                $responseFormat = ['type' => 'json_object'];
+
+                if ($request->schema() instanceof \Prism\Prism\Contracts\Schema) {
+                    $responseFormat['schema'] = $request->schema()->toArray();
+                }
+
+                $body['response_format'] = $responseFormat;
+            } elseif ($grammar = $request->providerOptions('grammar')) {
+                $body['response_format'] = [
+                    'type' => 'grammar',
+                    'grammar' => $grammar,
+                ];
+            } else {
+                // Default to tool mode for structured output when not using JSON mode or grammar
+                $tool = [
+                    'type' => 'function',
+                    'function' => [
+                        'name' => 'extract',
+                        'description' => 'Extract structured data',
+                        'parameters' => $request->schema()->toArray(),
+                    ],
+                ];
+
+                $body['tools'] = [$tool];
+                $body['tool_choice'] = $request->providerOptions('tool_choice') === 'any'
+                    ? 'any'
+                    : ['type' => 'function', 'function' => ['name' => 'extract']];
+            }
+
+            return $this->client->post('chat/completions', $body);
+        } catch (Throwable $e) {
+            throw PrismException::providerRequestError($request->model(), $e);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function handleResponse(array $data, Request $request, ClientResponse $clientResponse): void
+    {
+        if (isset($data['choices'][0]['message']['tool_calls'])) {
+            $this->handleToolResponse($data, $request, $clientResponse);
+        } else {
+            $this->handleJsonResponse($data, $request, $clientResponse);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function handleToolResponse(array $data, Request $request, ClientResponse $clientResponse): void
+    {
+        $toolCalls = ToolCallMap::map(data_get($data, 'choices.0.message.tool_calls', []));
+
+        if ($toolCalls !== []) {
+            $toolCall = $toolCalls[0];
+            $content = $toolCall->arguments();
+
+            $extracted = $this->extractReasoningFromData($content);
+
+            $additionalContent = [];
+            if ($extracted['reasoning'] !== null) {
+                $additionalContent['reasoning'] = $extracted['reasoning'];
+            }
+
+            $this->responseBuilder->addStep(new Step(
+                text: json_encode($extracted['data']) ?: '',
+                finishReason: FinishReasonMap::map(data_get($data, 'choices.0.finish_reason', '')),
+                usage: new Usage(
+                    promptTokens: data_get($data, 'usage.prompt_tokens', 0),
+                    completionTokens: data_get($data, 'usage.completion_tokens'),
+                ),
+                meta: new Meta(
+                    id: data_get($data, 'id'),
+                    model: data_get($data, 'model'),
+                    rateLimits: $this->processRateLimits($clientResponse)
+                ),
+                messages: $request->messages(),
+                systemPrompts: $request->systemPrompts(),
+                additionalContent: $additionalContent,
+            ));
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function handleJsonResponse(array $data, Request $request, ClientResponse $clientResponse): void
+    {
+        $content = data_get($data, 'choices.0.message.content') ?? '';
+
+        $extracted = $this->extractReasoning($content);
+
+        $responseMessage = new AssistantMessage($extracted['output'], []);
+
+        $request->addMessage($responseMessage);
+
+        $additionalContent = [];
+        if ($extracted['reasoning'] !== null) {
+            $additionalContent['reasoning'] = $extracted['reasoning'];
+        }
+
+        $this->responseBuilder->addStep(new Step(
+            text: $extracted['output'],
+            finishReason: FinishReasonMap::map(data_get($data, 'choices.0.finish_reason', '')),
+            usage: new Usage(
+                promptTokens: data_get($data, 'usage.prompt_tokens', 0),
+                completionTokens: data_get($data, 'usage.completion_tokens'),
+            ),
+            meta: new Meta(
+                id: data_get($data, 'id'),
+                model: data_get($data, 'model'),
+                rateLimits: $this->processRateLimits($clientResponse)
+            ),
+            messages: $request->messages(),
+            systemPrompts: [],
+            additionalContent: $additionalContent,
+        ));
+    }
+
+    /**
+     * @return array{reasoning: ?string, output: string}
+     */
+    protected function extractReasoning(string $content): array
+    {
+        if (preg_match('/<think>(.*?)<\/think>/s', $content, $matches)) {
+            $reasoning = trim($matches[1]);
+            $output = trim((string) preg_replace('/<think>.*?<\/think>/s', '', $content));
+
+            return [
+                'reasoning' => $reasoning,
+                'output' => $output,
+            ];
+        }
+
+        return [
+            'reasoning' => null,
+            'output' => $content,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array{reasoning: ?string, data: array<string, mixed>}
+     */
+    protected function extractReasoningFromData(array $data): array
+    {
+        if (isset($data['reasoning'])) {
+            $reasoning = $data['reasoning'];
+            unset($data['reasoning']);
+
+            return [
+                'reasoning' => $reasoning,
+                'data' => $data,
+            ];
+        }
+
+        return [
+            'reasoning' => null,
+            'data' => $data,
+        ];
+    }
+}

--- a/src/Providers/FireworksAI/Handlers/Text.php
+++ b/src/Providers/FireworksAI/Handlers/Text.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\FireworksAI\Handlers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\FireworksAI\Concerns\ValidateResponse;
+use Prism\Prism\Providers\FireworksAI\Maps\MessageMap;
+use Prism\Prism\Providers\FireworksAI\Maps\ToolCallMap;
+use Prism\Prism\Providers\FireworksAI\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\OpenAI\Maps\FinishReasonMap;
+use Prism\Prism\Providers\OpenAI\Maps\ToolMap;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Response;
+use Prism\Prism\Text\ResponseBuilder;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
+use Throwable;
+
+class Text
+{
+    use CallsTools, ValidateResponse;
+
+    protected ResponseBuilder $responseBuilder;
+
+    public function __construct(protected PendingRequest $client)
+    {
+        $this->responseBuilder = new ResponseBuilder;
+    }
+
+    public function handle(Request $request): Response
+    {
+        $response = $this->sendRequest($request);
+
+        $this->validateResponse($response);
+
+        $data = $response->json();
+
+        $content = data_get($data, 'choices.0.message.content') ?? '';
+        $extracted = $this->extractReasoning($content);
+
+        $responseMessage = new AssistantMessage(
+            $extracted['output'],
+            ToolCallMap::map(data_get($data, 'choices.0.message.tool_calls', [])),
+        );
+
+        $this->responseBuilder->addResponseMessage($responseMessage);
+
+        $request->addMessage($responseMessage);
+
+        $finishReason = FinishReasonMap::map(data_get($data, 'choices.0.finish_reason', ''));
+
+        return match ($finishReason) {
+            FinishReason::ToolCalls => $this->handleToolCalls($data, $request, $response, $extracted),
+            FinishReason::Stop => $this->handleStop($data, $request, $response, $extracted),
+            FinishReason::Length => $this->handleStop($data, $request, $response, $extracted),
+            default => throw new PrismException('FireworksAI: unknown finish reason: '.$finishReason->value),
+        };
+    }
+
+    protected function sendRequest(Request $request): ClientResponse
+    {
+        try {
+            $body = array_merge([
+                'model' => $request->model(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                'max_tokens' => $request->maxTokens(),
+            ], Arr::whereNotNull([
+                'temperature' => $request->temperature(),
+                'top_p' => $request->topP(),
+                'metadata' => $request->providerOptions('metadata'),
+                'tools' => ToolMap::map($request->tools()),
+                'tool_choice' => $this->mapToolChoice($request),
+                'context_length_exceeded_behavior' => $request->providerOptions('context_length_exceeded_behavior'),
+                'repetition_penalty' => $request->providerOptions('repetition_penalty'),
+                'mirostat_lr' => $request->providerOptions('mirostat_lr'),
+                'mirostat_target' => $request->providerOptions('mirostat_target'),
+                'raw_output' => $request->providerOptions('raw_output'),
+                'echo' => $request->providerOptions('echo'),
+            ]));
+
+            if ($grammar = $request->providerOptions('grammar')) {
+                $body['response_format'] = [
+                    'type' => 'grammar',
+                    'grammar' => $grammar,
+                ];
+            }
+
+            return $this->client->post('chat/completions', $body);
+        } catch (Throwable $e) {
+            throw PrismException::providerRequestError($request->model(), $e);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|string|null
+     */
+    protected function mapToolChoice(Request $request): array|string|null
+    {
+        $toolChoice = $request->toolChoice();
+
+        if ($toolChoice === null) {
+            return null;
+        }
+
+        if ($request->providerOptions('tool_choice') === 'any') {
+            return 'any';
+        }
+
+        return ToolChoiceMap::map($toolChoice);
+    }
+
+    /**
+     * @return array{reasoning: ?string, output: string}
+     */
+    protected function extractReasoning(string $content): array
+    {
+        if (preg_match('/<think>(.*?)<\/think>/s', $content, $matches)) {
+            $reasoning = trim($matches[1]);
+            $output = trim((string) preg_replace('/<think>.*?<\/think>/s', '', $content));
+
+            return [
+                'reasoning' => $reasoning,
+                'output' => $output,
+            ];
+        }
+
+        return [
+            'reasoning' => null,
+            'output' => $content,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array{reasoning: ?string, output: string}  $extracted
+     */
+    protected function handleToolCalls(array $data, Request $request, ClientResponse $clientResponse, array $extracted): Response
+    {
+        $toolResults = $this->callTools(
+            $request->tools(),
+            ToolCallMap::map(data_get($data, 'choices.0.message.tool_calls', [])),
+        );
+
+        $request->addMessage(new ToolResultMessage($toolResults));
+
+        $this->addStep($data, $request, $clientResponse, FinishReason::ToolCalls, $toolResults, ['reasoning' => null, 'output' => data_get($data, 'choices.0.message.content') ?? '']);
+
+        if ($this->shouldContinue($request)) {
+            return $this->handle($request);
+        }
+
+        return $this->responseBuilder->toResponse();
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array{reasoning: ?string, output: string}  $extracted
+     */
+    protected function handleStop(array $data, Request $request, ClientResponse $clientResponse, array $extracted): Response
+    {
+        $this->addStep($data, $request, $clientResponse, FinishReason::Stop, [], $extracted);
+
+        return $this->responseBuilder->toResponse();
+    }
+
+    protected function shouldContinue(Request $request): bool
+    {
+        return $this->responseBuilder->steps->count() < $request->maxSteps();
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  ToolResult[]  $toolResults
+     * @param  array{reasoning: ?string, output: string}  $extracted
+     */
+    protected function addStep(
+        array $data,
+        Request $request,
+        ClientResponse $clientResponse,
+        FinishReason $finishReason,
+        array $toolResults = [],
+        array $extracted = ['reasoning' => null, 'output' => '']
+    ): void {
+        $additionalContent = [];
+        if ($extracted['reasoning'] !== null) {
+            $additionalContent['reasoning'] = $extracted['reasoning'];
+        }
+
+        $this->responseBuilder->addStep(new Step(
+            text: $extracted['output'],
+            finishReason: $finishReason,
+            toolCalls: ToolCallMap::map(data_get($data, 'choices.0.message.tool_calls', [])),
+            toolResults: $toolResults,
+            usage: new Usage(
+                promptTokens: data_get($data, 'usage.prompt_tokens', 0),
+                completionTokens: data_get($data, 'usage.completion_tokens'),
+            ),
+            meta: new Meta(
+                id: data_get($data, 'id'),
+                model: data_get($data, 'model'),
+                rateLimits: $this->processRateLimits($clientResponse)
+            ),
+            messages: $request->messages(),
+            additionalContent: $additionalContent,
+            systemPrompts: $request->systemPrompts(),
+        ));
+    }
+}

--- a/src/Providers/FireworksAI/Maps/MessageMap.php
+++ b/src/Providers/FireworksAI/Maps/MessageMap.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\FireworksAI\Maps;
+
+use Prism\Prism\Providers\OpenAI\Maps\MessageMap as OpenAIMessageMap;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+
+class MessageMap extends OpenAIMessageMap
+{
+    /**
+     * Override to handle FireworksAI's document inlining feature
+     */
+    #[\Override]
+    protected function mapUserMessage(UserMessage $message): void
+    {
+        $imageParts = array_map(fn (Image $image): array => [
+            'type' => 'image_url',
+            'image_url' => [
+                'url' => $this->processImageUrl($image),
+            ],
+        ], $message->images());
+
+        $documentParts = array_map(fn ($document): array => [
+            'type' => 'text',
+            'text' => is_array($document->document) ? implode("\n", $document->document) : $document->document,
+        ], $message->documents());
+
+        $this->mappedMessages[] = [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => $message->text()],
+                ...$imageParts,
+                ...$documentParts,
+            ],
+        ];
+    }
+
+    /**
+     * Process image URL to preserve FireworksAI's #transform=inline feature
+     */
+    protected function processImageUrl(Image $image): string
+    {
+        if ($image->isUrl()) {
+            return $image->image;
+        }
+
+        return sprintf('data:%s;base64,%s', $image->mimeType, $image->image);
+    }
+}

--- a/src/Providers/FireworksAI/Maps/ToolCallMap.php
+++ b/src/Providers/FireworksAI/Maps/ToolCallMap.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\FireworksAI\Maps;
+
+use Prism\Prism\ValueObjects\ToolCall;
+
+class ToolCallMap
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $toolCalls
+     * @return array<int, ToolCall>
+     */
+    public static function map(array $toolCalls): array
+    {
+        return array_map(fn (array $toolCall): ToolCall => new ToolCall(
+            id: data_get($toolCall, 'id'),
+            name: data_get($toolCall, 'function.name'),
+            arguments: data_get($toolCall, 'function.arguments'),
+        ), $toolCalls);
+    }
+}

--- a/src/Providers/FireworksAI/Maps/ToolChoiceMap.php
+++ b/src/Providers/FireworksAI/Maps/ToolChoiceMap.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\FireworksAI\Maps;
+
+use Prism\Prism\Enums\ToolChoice;
+
+class ToolChoiceMap
+{
+    /**
+     * @return array<string, mixed>|string|null
+     */
+    public static function map(string|ToolChoice|null $toolChoice): string|array|null
+    {
+        if (is_string($toolChoice)) {
+            return [
+                'type' => 'function',
+                'function' => [
+                    'name' => $toolChoice,
+                ],
+            ];
+        }
+
+        return match ($toolChoice) {
+            ToolChoice::Auto => 'auto',
+            ToolChoice::Any => 'any',
+            ToolChoice::None => 'none',
+            null => $toolChoice,
+        };
+    }
+}

--- a/tests/PrismManagerTest.php
+++ b/tests/PrismManagerTest.php
@@ -66,6 +66,13 @@ it('can resolve DeepSeek', function (): void {
     expect($manager->resolve('deepseek'))->toBeInstanceOf(DeepSeek::class);
 });
 
+it('can resolve FireworksAI', function (): void {
+    $manager = new PrismManager($this->app);
+
+    expect($manager->resolve(Provider::FireworksAI))->toBeInstanceOf(\Prism\Prism\Providers\FireworksAI\FireworksAI::class);
+    expect($manager->resolve('fireworksai'))->toBeInstanceOf(\Prism\Prism\Providers\FireworksAI\FireworksAI::class);
+});
+
 it('allows for custom provider configuration', function (): void {
     $manager = new PrismManager($this->app);
 

--- a/tests/Providers/FireworksAI/FireworksAIEmbeddingsTest.php
+++ b/tests/Providers/FireworksAI/FireworksAIEmbeddingsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\FireworksAI;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+
+beforeEach(function (): void {
+    config()->set('prism.providers.fireworksai.api_key', env('FIREWORKS_API_KEY', 'fw-1234'));
+    config()->set('prism.providers.fireworksai.url', 'https://api.fireworks.ai/inference/v1');
+});
+
+describe('Embeddings for FireworksAI', function (): void {
+    it('can generate embeddings', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/embeddings' => Http::response([
+                'object' => 'list',
+                'data' => [[
+                    'object' => 'embedding',
+                    'embedding' => [0.1, 0.2, 0.3, 0.4, 0.5],
+                    'index' => 0,
+                ]],
+                'model' => 'nomic-ai/nomic-embed-text-v1.5',
+                'usage' => [
+                    'prompt_tokens' => 5,
+                    'total_tokens' => 5,
+                ],
+            ]),
+        ]);
+
+        $response = Prism::embeddings()
+            ->using(Provider::FireworksAI, 'nomic-ai/nomic-embed-text-v1.5')
+            ->fromInput('Hello world')
+            ->asEmbeddings();
+
+        expect($response->embeddings)->toHaveCount(1)
+            ->and($response->embeddings[0]->embedding)->toBe([0.1, 0.2, 0.3, 0.4, 0.5])
+            ->and($response->usage->tokens)->toBe(5)
+            ->and($response->meta->model)->toBe('nomic-ai/nomic-embed-text-v1.5');
+
+        Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.fireworks.ai/inference/v1/embeddings'
+            && $request['model'] === 'nomic-ai/nomic-embed-text-v1.5'
+            && $request['input'] === ['Hello world']
+            && $request['encoding_format'] === 'float');
+    });
+
+    it('can use dimensions parameter', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/embeddings' => Http::response([
+                'object' => 'list',
+                'data' => [[
+                    'object' => 'embedding',
+                    'embedding' => array_fill(0, 256, 0.1),
+                    'index' => 0,
+                ]],
+                'model' => 'nomic-ai/nomic-embed-text-v1.5',
+                'usage' => [
+                    'prompt_tokens' => 5,
+                    'total_tokens' => 5,
+                ],
+            ]),
+        ]);
+
+        $response = Prism::embeddings()
+            ->using(Provider::FireworksAI, 'nomic-ai/nomic-embed-text-v1.5')
+            ->fromInput('Hello world')
+            ->withProviderOptions(['dimensions' => 256])
+            ->asEmbeddings();
+
+        expect($response->embeddings[0]->embedding)->toHaveCount(256);
+
+        Http::assertSent(fn (Request $request): bool => $request['dimensions'] === 256);
+    });
+});

--- a/tests/Providers/FireworksAI/FireworksAIStreamTest.php
+++ b/tests/Providers/FireworksAI/FireworksAIStreamTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\FireworksAI;
+
+use Illuminate\Support\Facades\Http;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+
+beforeEach(function (): void {
+    config()->set('prism.providers.fireworksai.api_key', env('FIREWORKS_API_KEY', 'fw-1234'));
+    config()->set('prism.providers.fireworksai.url', 'https://api.fireworks.ai/inference/v1');
+});
+
+describe('Streaming for FireworksAI', function (): void {
+    it('can stream text responses', function (): void {
+        $streamData = [
+            'data: {"id":"chatcmpl-fw-stream-1","object":"chat.completion.chunk","created":1234567890,"model":"accounts/fireworks/models/llama-v3p3-70b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}',
+            '',
+            'data: {"id":"chatcmpl-fw-stream-1","object":"chat.completion.chunk","created":1234567890,"model":"accounts/fireworks/models/llama-v3p3-70b-instruct","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}',
+            '',
+            'data: {"id":"chatcmpl-fw-stream-1","object":"chat.completion.chunk","created":1234567890,"model":"accounts/fireworks/models/llama-v3p3-70b-instruct","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}',
+            '',
+            'data: {"id":"chatcmpl-fw-stream-1","object":"chat.completion.chunk","created":1234567890,"model":"accounts/fireworks/models/llama-v3p3-70b-instruct","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":3,"total_tokens":13}}',
+            '',
+            'data: [DONE]',
+            '',
+        ];
+
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/chat/completions' => Http::response(
+                implode("\n", $streamData),
+                200,
+                ['Content-Type' => 'text/event-stream']
+            ),
+        ]);
+
+        $stream = Prism::text()
+            ->using(Provider::FireworksAI, 'accounts/fireworks/models/llama-v3p3-70b-instruct')
+            ->withPrompt('Say hello')
+            ->asStream();
+
+        $chunks = [];
+        $lastChunk = null;
+
+        foreach ($stream as $chunk) {
+            if ($chunk->text !== '') {
+                $chunks[] = $chunk->text;
+            }
+            $lastChunk = $chunk;
+        }
+
+        expect($chunks)->toBe(['Hello', ' world', '!'])
+            ->and($lastChunk->finishReason->name)->toBe('Stop');
+
+        // Note: Usage stats in streaming are captured but not exposed in chunks directly
+        // This is a limitation in the current Prism architecture
+    });
+});

--- a/tests/Providers/FireworksAI/FireworksAITextTest.php
+++ b/tests/Providers/FireworksAI/FireworksAITextTest.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\FireworksAI;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Facades\Tool;
+use Prism\Prism\Prism;
+use Prism\Prism\Schema\NumberSchema;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+
+beforeEach(function (): void {
+    config()->set('prism.providers.fireworksai.api_key', env('FIREWORKS_API_KEY', 'fw-1234'));
+    config()->set('prism.providers.fireworksai.url', 'https://api.fireworks.ai/inference/v1');
+});
+
+describe('Text generation for FireworksAI', function (): void {
+    it('can resolve the provider', function (): void {
+        $manager = app(\Prism\Prism\PrismManager::class);
+        $provider = $manager->resolve(\Prism\Prism\Enums\Provider::FireworksAI);
+
+        expect($provider)->toBeInstanceOf(\Prism\Prism\Providers\FireworksAI\FireworksAI::class);
+    });
+
+    it('can generate text with a prompt', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/chat/completions' => Http::response([
+                'id' => 'chatcmpl-fireworks-123',
+                'object' => 'chat.completion',
+                'created' => 1234567890,
+                'model' => 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'I am an AI assistant created by Fireworks.ai.',
+                    ],
+                    'finish_reason' => 'stop',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 10,
+                    'completion_tokens' => 15,
+                    'total_tokens' => 25,
+                ],
+            ]),
+        ]);
+
+        $response = Prism::text()
+            ->using(Provider::FireworksAI, 'accounts/fireworks/models/llama-v3p3-70b-instruct')
+            ->withPrompt('Who are you?')
+            ->asText();
+
+        expect($response->usage->promptTokens)->toBe(10)
+            ->and($response->usage->completionTokens)->toBe(15)
+            ->and($response->text)->toBe('I am an AI assistant created by Fireworks.ai.')
+            ->and($response->meta->id)->toBe('chatcmpl-fireworks-123')
+            ->and($response->meta->model)->toBe('accounts/fireworks/models/llama-v3p3-70b-instruct');
+
+        Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.fireworks.ai/inference/v1/chat/completions'
+            && $request->hasHeader('Authorization', 'Bearer fw-1234')
+            && $request['model'] === 'accounts/fireworks/models/llama-v3p3-70b-instruct'
+            && $request['messages'][0]['role'] === 'user'
+            && $request['messages'][0]['content'][0]['text'] === 'Who are you?');
+    });
+
+    it('can use FireworksAI-specific parameters', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/chat/completions' => Http::response([
+                'id' => 'chatcmpl-fireworks-456',
+                'object' => 'chat.completion',
+                'created' => 1234567890,
+                'model' => 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Response with custom parameters.',
+                    ],
+                    'finish_reason' => 'stop',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 10,
+                    'completion_tokens' => 5,
+                    'total_tokens' => 15,
+                ],
+            ]),
+        ]);
+
+        $response = Prism::text()
+            ->using(Provider::FireworksAI, 'accounts/fireworks/models/llama-v3p3-70b-instruct')
+            ->withPrompt('Test prompt')
+            ->withProviderOptions([
+                'context_length_exceeded_behavior' => 'truncate',
+                'repetition_penalty' => 1.1,
+                'mirostat_lr' => 0.1,
+                'mirostat_target' => 5.0,
+                'raw_output' => false,
+                'echo' => false,
+            ])
+            ->asText();
+
+        expect($response->text)->toBe('Response with custom parameters.');
+
+        Http::assertSent(fn (Request $request): bool => $request['context_length_exceeded_behavior'] === 'truncate'
+            && $request['repetition_penalty'] === 1.1
+            && $request['mirostat_lr'] === 0.1
+            && $request['mirostat_target'] === 5.0
+            && $request['raw_output'] === false
+            && $request['echo'] === false);
+    });
+
+    it('can use grammar mode', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/chat/completions' => Http::response([
+                'id' => 'chatcmpl-fireworks-789',
+                'object' => 'chat.completion',
+                'created' => 1234567890,
+                'model' => 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => '{"name": "John", "age": 30}',
+                    ],
+                    'finish_reason' => 'stop',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 10,
+                    'completion_tokens' => 10,
+                    'total_tokens' => 20,
+                ],
+            ]),
+        ]);
+
+        $gbnfGrammar = 'root ::= "{" ws "\"name\":" ws string ws "," ws "\"age\":" ws number ws "}"';
+
+        $response = Prism::text()
+            ->using(Provider::FireworksAI, 'accounts/fireworks/models/llama-v3p3-70b-instruct')
+            ->withPrompt('Generate a person object')
+            ->withProviderOptions(['grammar' => $gbnfGrammar])
+            ->asText();
+
+        expect($response->text)->toBe('{"name": "John", "age": 30}');
+
+        Http::assertSent(fn (Request $request): bool => $request['response_format']['type'] === 'grammar'
+            && $request['response_format']['grammar'] === $gbnfGrammar);
+    });
+
+    it('can use tool_choice any', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/chat/completions' => Http::sequence()
+                ->push([
+                    'id' => 'chatcmpl-fireworks-tool-any',
+                    'object' => 'chat.completion',
+                    'created' => 1234567890,
+                    'model' => 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+                    'choices' => [[
+                        'index' => 0,
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => null,
+                            'tool_calls' => [[
+                                'id' => 'call_1',
+                                'type' => 'function',
+                                'function' => [
+                                    'name' => 'get_weather',
+                                    'arguments' => '{"location":"San Francisco"}',
+                                ],
+                            ]],
+                        ],
+                        'finish_reason' => 'tool_calls',
+                    ]],
+                    'usage' => [
+                        'prompt_tokens' => 20,
+                        'completion_tokens' => 10,
+                        'total_tokens' => 30,
+                    ],
+                ])
+                ->push([
+                    'id' => 'chatcmpl-fireworks-tool-any-2',
+                    'object' => 'chat.completion',
+                    'created' => 1234567891,
+                    'model' => 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+                    'choices' => [[
+                        'index' => 0,
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => 'The weather in San Francisco is sunny.',
+                        ],
+                        'finish_reason' => 'stop',
+                    ]],
+                    'usage' => [
+                        'prompt_tokens' => 40,
+                        'completion_tokens' => 10,
+                        'total_tokens' => 50,
+                    ],
+                ]),
+        ]);
+
+        $response = Prism::text()
+            ->using(Provider::FireworksAI, 'accounts/fireworks/models/llama-v3p3-70b-instruct')
+            ->withPrompt('Get the weather')
+            ->withProviderOptions(['tool_choice' => 'any'])
+            ->withTools([
+                Tool::as('get_weather')
+                    ->for('Get weather information')
+                    ->withStringParameter('location', 'The location to get weather for')
+                    ->using(fn (string $location): string => "Sunny in $location"),
+            ])
+            ->asText();
+
+        expect($response->steps)->toHaveCount(1)
+            ->and($response->steps[0]->toolCalls)->toHaveCount(1)
+            ->and($response->steps[0]->toolCalls[0]->name)->toBe('get_weather')
+            ->and($response->steps[0]->toolResults[0]->result)->toBe('Sunny in San Francisco')
+            ->and($response->steps[0]->finishReason->name)->toBe('ToolCalls');
+    });
+
+    it('handles reasoning model output with think tags', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/chat/completions' => Http::response([
+                'id' => 'chatcmpl-fireworks-reason',
+                'object' => 'chat.completion',
+                'created' => 1234567890,
+                'model' => 'accounts/fireworks/models/deepthink-v1',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => '<think>Let me think about this step by step...</think>The answer is 42.',
+                    ],
+                    'finish_reason' => 'stop',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 10,
+                    'completion_tokens' => 20,
+                    'total_tokens' => 30,
+                ],
+            ]),
+        ]);
+
+        $response = Prism::text()
+            ->using(Provider::FireworksAI, 'accounts/fireworks/models/deepthink-v1')
+            ->withPrompt('What is the meaning of life?')
+            ->asText();
+
+        expect($response->text)->toBe('The answer is 42.')
+            ->and($response->steps->first()->additionalContent['reasoning'] ?? null)
+            ->toBe('Let me think about this step by step...');
+    });
+
+    it('can use JSON mode with schema in structured output', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/chat/completions' => Http::response([
+                'id' => 'chatcmpl-fireworks-json-schema',
+                'object' => 'chat.completion',
+                'created' => 1234567890,
+                'model' => 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => '{"name": "John Doe", "age": 30}',
+                    ],
+                    'finish_reason' => 'stop',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 20,
+                    'completion_tokens' => 10,
+                    'total_tokens' => 30,
+                ],
+            ]),
+        ]);
+
+        $schema = new ObjectSchema(
+            'user',
+            'User information',
+            [
+                new StringSchema('name', 'User name'),
+                new NumberSchema('age', 'User age'),
+            ],
+            ['name', 'age']
+        );
+
+        $response = Prism::structured()
+            ->using(Provider::FireworksAI, 'accounts/fireworks/models/llama-v3p3-70b-instruct')
+            ->withPrompt('Extract user information')
+            ->withSchema($schema)
+            ->usingStructuredMode(StructuredMode::Json)
+            ->asStructured();
+
+        expect($response->structured)->toBeArray()
+            ->and($response->structured['name'])->toBe('John Doe')
+            ->and($response->structured['age'])->toBe(30);
+
+        Http::assertSent(fn (Request $request): bool => isset($request['response_format'])
+            && $request['response_format']['type'] === 'json_object'
+            && isset($request['response_format']['schema']));
+    });
+
+    it('can use context_length_exceeded_behavior', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/chat/completions' => Http::response([
+                'id' => 'chatcmpl-fireworks-truncate',
+                'object' => 'chat.completion',
+                'created' => 1234567890,
+                'model' => 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Response with truncation.',
+                    ],
+                    'finish_reason' => 'stop',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 100,
+                    'completion_tokens' => 5,
+                    'total_tokens' => 105,
+                ],
+            ]),
+        ]);
+
+        $response = Prism::text()
+            ->using(Provider::FireworksAI, 'accounts/fireworks/models/llama-v3p3-70b-instruct')
+            ->withPrompt('Very long prompt that might exceed context length...')
+            ->withProviderOptions(['context_length_exceeded_behavior' => 'truncate'])
+            ->asText();
+
+        expect($response->text)->toBe('Response with truncation.');
+
+        Http::assertSent(fn (Request $request): bool => $request['context_length_exceeded_behavior'] === 'truncate');
+    });
+
+    it('handles API errors correctly', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/chat/completions' => Http::response([
+                'error' => [
+                    'type' => 'invalid_request_error',
+                    'message' => 'Invalid model name',
+                ],
+            ], 400),
+        ]);
+
+        expect(fn (): \Prism\Prism\Text\Response => Prism::text()
+            ->using(Provider::FireworksAI, 'invalid-model')
+            ->withPrompt('Hello')
+            ->asText()
+        )->toThrow(\Prism\Prism\Exceptions\PrismException::class, 'FireworksAI Error: [invalid_request_error] Invalid model name');
+    });
+
+    it('handles rate limiting correctly', function (): void {
+        Http::fake([
+            'https://api.fireworks.ai/inference/v1/chat/completions' => Http::response(
+                ['error' => ['type' => 'rate_limit_error', 'message' => 'Rate limit exceeded']],
+                429,
+                [
+                    'retry-after' => '60',
+                    'x-ratelimit-limit-requests' => '100',
+                    'x-ratelimit-remaining-requests' => '0',
+                    'x-ratelimit-reset-requests' => '60s',
+                    'x-ratelimit-over-limit' => 'true',
+                ]
+            ),
+        ]);
+
+        expect(fn (): \Prism\Prism\Text\Response => Prism::text()
+            ->using(Provider::FireworksAI, 'accounts/fireworks/models/llama-v3p3-70b-instruct')
+            ->withPrompt('Hello')
+            ->asText()
+        )->toThrow(\Prism\Prism\Exceptions\PrismRateLimitedException::class);
+    });
+});


### PR DESCRIPTION
## Description

This PR adds comprehensive support for the [FireworksAI](https://fireworks.ai/) provider to Prism, enabling developers to use FireworksAI's models for various AI tasks. FireworksAI is useful for hosting low cost, fine tuned LoRa models and it's largely OpenAI compatible. Implements text generation, structured output, embeddings, and streaming with FireworksAI-specific features like grammar mode and reasoning model support.

### Features Implemented

- **Text Generation**: Full support for FireworksAI's text generation API with all standard Prism features
- **Structured Output**: 
  - JSON mode for structured responses
  - Grammar mode with custom EBNF grammars for precise output control
- **Embeddings**: Support for FireworksAI's embedding models
- **Streaming**: Real-time streaming responses for text generation
- **Tool/Function Calling**: Complete support for tool calling including:
  - Tool definitions and mapping
  - Tool choice options (auto, none, required, specific tool)
  - Multi-step tool conversations
- **Reasoning Models**: Special handling for FireworksAI's reasoning models (e.g., `deepseek-r1-distill-llama-70b`) which use internal reasoning steps

### Implementation Details

- Added proper request/response handling following FireworksAI's API specifications
- Implemented proper message mapping between Prism's format and FireworksAI's expected format
- Added finish reason mapping for proper response handling
- Included validation for API responses to ensure reliability
- Followed existing provider patterns for consistency with the codebase

### Configuration

FireworksAI can be configured in the Prism config file:

```php
'fireworksai' => [
    'api_key' => env('FIREWORKSAI_API_KEY'),
    'url' => env('FIREWORKSAI_URL', 'https://api.fireworks.ai/inference/v1'),
],
```

### Testing

All handlers include appropriate response validation and error handling consistent with other providers in the codebase. I also created integration tests that made actual requests to Fireworks and they all worked. I did not commit these tests though.

## Breaking Changes

None - this is a new provider addition with no impact on existing functionality.