### PR TITLE
refactor(providers): use trait to initialize Http client

### DIFF
--- a/src/Concerns/InitializesClient.php
+++ b/src/Concerns/InitializesClient.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Concerns;
+
+use Closure;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+
+trait InitializesClient
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function getHeaders(): array
+    {
+        return [];
+    }
+
+    protected function getToken(): string
+    {
+        return '';
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @param  array{}|array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $retry
+     */
+    protected function client(array $options = [], array $retry = [], ?string $baseUrl = null): PendingRequest
+    {
+        $baseUrl ??= $this->url;
+        $headers = $this->getHeaders();
+        $token = $this->getToken();
+
+        return Http::when($token !== '', fn ($client) => $client->withToken($token))
+            ->when($headers !== [], fn ($client) => $client->withHeaders($headers))
+            ->withOptions($options)
+            ->when($retry !== [], fn ($client) => $client->retry(...$retry))
+            ->baseUrl($baseUrl);
+    }
+}

--- a/src/Providers/DeepSeek/DeepSeek.php
+++ b/src/Providers/DeepSeek/DeepSeek.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\DeepSeek;
 
-use Closure;
 use Generator;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
@@ -21,6 +19,8 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class DeepSeek implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -60,19 +60,8 @@ readonly class DeepSeek implements Provider
         throw PrismException::unsupportedProviderAction(__METHOD__, class_basename($this));
     }
 
-    /**
-     * @param  array<string, mixed>  $options
-     * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $retry
-     */
-    protected function client(array $options, array $retry, ?string $baseUrl = null): PendingRequest
+    protected function getToken(): string
     {
-        $baseUrl ??= $this->url;
-
-        return Http::withHeaders(array_filter([
-            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
-        ]))
-            ->withOptions($options)
-            ->retry(...$retry)
-            ->baseUrl($baseUrl);
+        return $this->apiKey;
     }
 }

--- a/src/Providers/Gemini/Gemini.php
+++ b/src/Providers/Gemini/Gemini.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\Gemini;
 
 use Generator;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Message;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
@@ -26,6 +25,8 @@ use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 readonly class Gemini implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -104,23 +105,12 @@ readonly class Gemini implements Provider
     }
 
     /**
-     * @param  array<string, mixed>  $options
-     * @param  array<mixed>  $retry
+     * @return array<string, string>
      */
-    protected function client(array $options = [], array $retry = [], ?string $baseUrl = null): PendingRequest
+    protected function getHeaders(): array
     {
-        $baseUrl ??= $this->url;
-
-        $client = Http::withOptions($options)
-            ->withHeaders([
-                'x-goog-api-key' => $this->apiKey,
-            ])
-            ->baseUrl($baseUrl);
-
-        if ($retry !== []) {
-            return $client->retry(...$retry);
-        }
-
-        return $client;
+        return [
+            'x-goog-api-key' => $this->apiKey,
+        ];
     }
 }

--- a/src/Providers/Groq/Groq.php
+++ b/src/Providers/Groq/Groq.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\Groq;
 
 use Generator;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
@@ -20,6 +19,8 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class Groq implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -53,17 +54,8 @@ readonly class Groq implements Provider
         throw PrismException::unsupportedProviderAction(__METHOD__, class_basename($this));
     }
 
-    /**
-     * @param  array<string, mixed>  $options
-     * @param  array<mixed>  $retry
-     */
-    protected function client(array $options = [], array $retry = []): PendingRequest
+    protected function getToken(): string
     {
-        return Http::withHeaders(array_filter([
-            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
-        ]))
-            ->withOptions($options)
-            ->retry(...$retry)
-            ->baseUrl($this->url);
+        return $this->apiKey;
     }
 }

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\Mistral;
 
 use Generator;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
@@ -26,6 +25,8 @@ use Prism\Prism\ValueObjects\Messages\Support\Document;
 
 readonly class Mistral implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -99,22 +100,8 @@ readonly class Mistral implements Provider
         return $handler->handle($request);
     }
 
-    /**
-     * @param  array<string, mixed>  $options
-     * @param  array<mixed>  $retry
-     */
-    protected function client(array $options = [], array $retry = []): PendingRequest
+    protected function getToken(): string
     {
-        $client = Http::withHeaders(array_filter([
-            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
-        ]))
-            ->withOptions($options)
-            ->baseUrl($this->url);
-
-        if ($retry !== []) {
-            return $client->retry(...$retry);
-        }
-
-        return $client;
+        return $this->apiKey;
     }
 }

--- a/src/Providers/Ollama/Ollama.php
+++ b/src/Providers/Ollama/Ollama.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\Ollama;
 
 use Generator;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
@@ -21,6 +20,8 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class Ollama implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -70,17 +71,8 @@ readonly class Ollama implements Provider
         return $handler->handle($request);
     }
 
-    /**
-     * @param  array<string, mixed>  $options
-     * @param  array<mixed>  $retry
-     */
-    protected function client(array $options = [], array $retry = []): PendingRequest
+    protected function getToken(): string
     {
-        return Http::withHeaders(array_filter([
-            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
-        ]))
-            ->withOptions($options)
-            ->retry(...$retry)
-            ->baseUrl($this->url);
+        return $this->apiKey;
     }
 }

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\OpenAI;
 
-use Closure;
 use Generator;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
@@ -22,6 +20,8 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class OpenAI implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -74,18 +74,18 @@ readonly class OpenAI implements Provider
     }
 
     /**
-     * @param  array<string, mixed>  $options
-     * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $retry
+     * @return array<string, string>
      */
-    protected function client(array $options, array $retry): PendingRequest
+    protected function getHeaders(): array
     {
-        return Http::withHeaders(array_filter([
-            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
+        return array_filter([
             'OpenAI-Organization' => $this->organization,
             'OpenAI-Project' => $this->project,
-        ]))
-            ->withOptions($options)
-            ->retry(...$retry)
-            ->baseUrl($this->url);
+        ]);
+    }
+
+    protected function getToken(): string
+    {
+        return $this->apiKey;
     }
 }

--- a/src/Providers/VoyageAI/VoyageAI.php
+++ b/src/Providers/VoyageAI/VoyageAI.php
@@ -3,8 +3,7 @@
 namespace Prism\Prism\Providers\VoyageAI;
 
 use Generator;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
@@ -16,10 +15,16 @@ use Prism\Prism\Text\Response as TextResponse;
 
 class VoyageAI implements Provider
 {
+    use InitializesClient;
+
+    protected string $url;
+
     public function __construct(
         #[\SensitiveParameter] protected string $apiKey,
         protected string $baseUrl
-    ) {}
+    ) {
+        $this->url = $baseUrl;
+    }
 
     #[\Override]
     public function text(TextRequest $request): TextResponse
@@ -50,15 +55,8 @@ class VoyageAI implements Provider
         throw PrismException::unsupportedProviderAction(__METHOD__, class_basename($this));
     }
 
-    /**
-     * @param  array<string, mixed>  $options
-     * @param  array<mixed>  $retry
-     */
-    protected function client(array $options = [], array $retry = []): PendingRequest
+    protected function getToken(): string
     {
-        return Http::withToken($this->apiKey)
-            ->withOptions($options)
-            ->retry(...$retry)
-            ->baseUrl($this->baseUrl);
+        return $this->apiKey;
     }
 }

--- a/src/Providers/XAI/XAI.php
+++ b/src/Providers/XAI/XAI.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\XAI;
 
 use Generator;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
@@ -19,6 +18,8 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class XAI implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -50,17 +51,8 @@ readonly class XAI implements Provider
         throw PrismException::unsupportedProviderAction(__METHOD__, class_basename($this));
     }
 
-    /**
-     * @param  array<string, mixed>  $options
-     * @param  array<mixed>  $retry
-     */
-    protected function client(array $options = [], array $retry = []): PendingRequest
+    protected function getToken(): string
     {
-        return Http::withHeaders(array_filter([
-            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
-        ]))
-            ->withOptions($options)
-            ->retry(...$retry)
-            ->baseUrl($this->url);
+        return $this->apiKey;
     }
 }


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
Use a trait in Provider classes to standarize Http client initialization.
Each provider can customize headers setting them in `getHeaders` or `getToken` for Bearer Token.

Having a single place where Http client is initialized make it easier to trace Http calls with:

```php
return Http::when($token !== '', fn ($client) => $client->withToken($token))
    ->when($headers !== [], fn ($client) => $client->withHeaders($headers))
    // trace request with middleware
    ->withRequestMiddleware(
        function (RequestInterface $request) {
            // fire event
            return $request;
        }
    ))
    // trace response with middleware
    ->withResponseMiddleware(
        function (ResponseInterface $response) {
            // fire event
            return $response;
        }
    ))
    ->withOptions($options)
    ->when($retry !== [], fn ($client) => $client->retry(...$retry))
    ->baseUrl($baseUrl);
```
