### PR TITLE
fix(openai): remove array cast from metadata

### DIFF
--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -220,7 +220,7 @@ class Stream
                     ], Arr::whereNotNull([
                         'temperature' => $request->temperature(),
                         'top_p' => $request->topP(),
-                        'metadata' => (array) $request->providerOptions('metadata'),
+                        'metadata' => $request->providerOptions('metadata'),
                         'tools' => ToolMap::map($request->tools()),
                         'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
                     ]))

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -102,7 +102,7 @@ class Structured
                 ], Arr::whereNotNull([
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
-                    'metadata' => (array) $request->providerOptions('metadata'),
+                    'metadata' => $request->providerOptions('metadata'),
                     'response_format' => $responseFormat,
                 ]))
             );

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -114,7 +114,7 @@ class Text
                 ], Arr::whereNotNull([
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
-                    'metadata' => (array) $request->providerOptions('metadata'),
+                    'metadata' => $request->providerOptions('metadata'),
                     'tools' => ToolMap::map($request->tools()),
                     'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
                 ]))


### PR DESCRIPTION
## Description

#377 (not yet tagged) introduced a regression with openai with the metadata property.

I don't think the array cast is necessary when wrapped with Arr::whereNotNull().

@sixlive this should be tagged along with 377 to avoid releasing the regression. 