### PR TITLE
docs(openai): `ToolChoice::Any` now supported

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -46,11 +46,6 @@ $response = Prism::structured()
     ]) // [!code focus]
 ```
 
-## Limitations
-### Tool Choice
-
-OpenAI does not support `ToolChoice::Any` when using `withToolChoice()`.
-
 ### Caching
 
 Automatic caching does not currently work with JsonMode. Please ensure you use StructuredMode if you wish to utilise automatic caching.


### PR DESCRIPTION
Updating the docs to remove OpenAI limitation now that `ToolChoice::Any` is supported.