### PR TITLE
fix(gemini): handle null values in thinkingConfig array

### DIFF
--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -67,7 +67,7 @@ class Structured
                         'maxOutputTokens' => $request->maxTokens(),
                         'thinkingConfig' => Arr::whereNotNull([
                             'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-                        ]),
+                        ]) ?: null,
                     ]),
                     'safetySettings' => $providerOptions['safetySettings'] ?? null,
                 ])


### PR DESCRIPTION

## Description

Related issue https://github.com/prism-php/prism/issues/391

`thinkingConfig` field is being sent as a list (an empty array [], when thinkingBudget is null), but the Gemini API expects it to be an object or absent if not applicable.

## Breaking Changes
N/a
