### PR TITLE
feat(refactor): update ChunkType enum to be string backed enum for easierr ha…

### DIFF
--- a/src/Enums/ChunkType.php
+++ b/src/Enums/ChunkType.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Enums;
 
-enum ChunkType
+enum ChunkType: string
 {
-    case Text;
-    case Thinking;
-    case Meta;
+    case Text = 'text';
+    case Thinking = 'thinking';
+    case Meta = 'meta';
 }


### PR DESCRIPTION
Making the ChunkType enum a string-backed enum would simplify storing it in the database. Currently, we have to manually map the enum to a string in application logic, which adds unnecessary overhead. If Prism handles this natively, it would be a nice improvement.

This MR is optional and non-breaking, but I wanted to get your thoughts on it. @sixlive 