### PR TITLE
Avoid sending empty thinkingConfig in Gemini requests to fix 400 error

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -232,6 +232,18 @@ class Stream
                 default => [],
             };
 
+            $generationConfig = Arr::whereNotNull([
+                'temperature'      => $request->temperature(),
+                'topP'             => $request->topP(),
+                'maxOutputTokens'  => $request->maxTokens(),
+            ]);
+
+            if (! empty($providerOptions['thinkingBudget'])) {
+                $generationConfig['thinkingConfig'] = [
+                    'thinkingBudget' => $providerOptions['thinkingBudget'],
+                ];
+            }
+
             return $this->client
                 ->withOptions(['stream' => true])
                 ->post(
@@ -239,14 +251,7 @@ class Stream
                     Arr::whereNotNull([
                         ...(new MessageMap($request->messages(), $request->systemPrompts()))(),
                         'cachedContent' => $providerOptions['cachedContentName'] ?? null,
-                        'generationConfig' => Arr::whereNotNull([
-                            'temperature' => $request->temperature(),
-                            'topP' => $request->topP(),
-                            'maxOutputTokens' => $request->maxTokens(),
-                            'thinkingConfig' => Arr::whereNotNull([
-                                'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-                            ]),
-                        ]),
+                        'generationConfig' => $generationConfig,
                         'tools' => $tools !== [] ? $tools : null,
                         'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
                         'safetySettings' => $providerOptions['safetySettings'] ?? null,


### PR DESCRIPTION
## Description
Builds generationConfig with only the keys that are actually set.

Adds thinkingConfig only when the caller supplied a non-null thinkingBudget.

Why?

Google’s Gemini API returns 400 INVALID_ARGUMENT – Unknown name "thinkingConfig" whenever an empty object ("thinkingConfig": {}) is present. Prism previously sent that empty object by default, so every streaming request without a thinking-budget failed before the SSE stream started.

## Breaking Changes
n/a
