### PR TITLE
Fix: openai tool call map fix #397

### DIFF
--- a/src/Providers/OpenAI/Maps/ToolCallMap.php
+++ b/src/Providers/OpenAI/Maps/ToolCallMap.php
@@ -9,11 +9,15 @@ use Prism\Prism\ValueObjects\ToolCall;
 class ToolCallMap
 {
     /**
-     * @param  array<int, array<string, mixed>>  $toolCalls
+     * @param  ?array<int, array<string, mixed>>  $toolCalls
      * @return array<int, ToolCall>
      */
-    public static function map(array $toolCalls): array
+    public static function map(?array $toolCalls): array
     {
+        if ($toolCalls === null) {
+            return [];
+        }
+
         return array_map(fn (array $toolCall): ToolCall => new ToolCall(
             id: data_get($toolCall, 'id'),
             name: data_get($toolCall, 'function.name'),

--- a/tests/Fixtures/openai/generate-text-with-null-tool-call-1.json
+++ b/tests/Fixtures/openai/generate-text-with-null-tool-call-1.json
@@ -1,0 +1,37 @@
+{
+  "id": "chatcmpl-BB7W9oAuHdViPFBso4YNqG5n48hg6",
+  "object": "chat.completion",
+  "created": 1741990205,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": null,
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 95,
+    "completion_tokens": 7,
+    "total_tokens": 102,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_f9f4fb6dbf"
+}

--- a/tests/Providers/OpenAI/TextTest.php
+++ b/tests/Providers/OpenAI/TextTest.php
@@ -215,6 +215,27 @@ it('handles specific tool choice', function (): void {
     expect($response->toolCalls[0]->name)->toBe('weather');
 });
 
+it('handles tool choice when null', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/chat/completions', 'openai/generate-text-with-null-tool-call');
+
+    $tools = [
+        Tool::as('weather')
+            ->for('useful when you need to search for current weather conditions')
+            ->withStringParameter('city', 'The city that you want the weather for')
+            ->using(fn (string $city): string => 'The weather will be 75° and sunny'),
+        Tool::as('search')
+            ->for('useful for searching curret events or data')
+            ->withStringParameter('query', 'The detailed search query')
+            ->using(fn (string $query): string => 'The tigers game is at 3pm in detroit'),
+    ];
+
+    Prism::text()
+        ->using('openai', 'gpt-4o')
+        ->withPrompt('Do something')
+        ->withTools($tools)
+        ->asText();
+})->throwsNoExceptions();
+
 it('sets the rate limits on meta', function (): void {
     $this->freezeTime(function (Carbon $time): void {
         $time = $time->toImmutable();


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
This address the issue in #397. Sometimes, depending on the OpenAI api, `choices.0.message.tool_calls` is actually null instead of an array. 