### PR TITLE
Fixed Gemini stream finish reason always null

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -81,7 +81,7 @@ class Stream
             $content = data_get($data, 'candidates.0.content.parts.0.text') ?? '';
             $text .= $content;
 
-            $finishReason = data_get($data, 'done', false) ? FinishReason::Stop : FinishReason::Unknown;
+            $finishReason = $this->mapFinishReason($data);
 
             yield new Chunk(
                 text: $content,


### PR DESCRIPTION
## Description
The variable `$finishReason` is always `null` when using Gemini because it checks on a "done" value instead of using the appropriate function. This way is harder to determine when the chunks end

## Changes
Changed to use the `mapFinishReason` function when proecessing the stream

I tested using `gemini-2.0-flash`, so it may be different with the 2.5 version