### PR TITLE
fix: change input_text to text for user message type

### DIFF
--- a/src/Providers/OpenAI/Maps/MessageMap.php
+++ b/src/Providers/OpenAI/Maps/MessageMap.php
@@ -82,7 +82,7 @@ class MessageMap
         $this->mappedMessages[] = [
             'role' => 'user',
             'content' => [
-                ['type' => 'input_text', 'text' => $message->text()],
+                ['type' => 'text', 'text' => $message->text()],
                 ...self::mapImageParts($message->images()),
                 ...self::mapDocumentParts($message->documents()),
                 ...self::mapFileParts($message->files()),

--- a/tests/Providers/OpenAI/MessageMapTest.php
+++ b/tests/Providers/OpenAI/MessageMapTest.php
@@ -26,7 +26,7 @@ it('maps user messages', function (): void {
     expect($messageMap())->toBe([[
         'role' => 'user',
         'content' => [
-            ['type' => 'input_text', 'text' => 'Who are you?'],
+            ['type' => 'text', 'text' => 'Who are you?'],
         ],
     ]]);
 });
@@ -183,7 +183,7 @@ it('maps system prompt', function (): void {
         [
             'role' => 'user',
             'content' => [
-                ['type' => 'input_text', 'text' => 'Who are you?'],
+                ['type' => 'text', 'text' => 'Who are you?'],
             ],
         ],
     ]);


### PR DESCRIPTION
This fixes streaming responses for openai.

I am not sure if I am crazy. Without this, I get the following error when streaming responses:

```
  "error" => array:4 [▼
    "message" => "Invalid value: 'input_text'. Supported values are: 'text', 'image_url', 'input_audio', 'refusal', 'audio', and 'file'."
    "type" => "invalid_request_error"
    "param" => "messages[1].content[0].type"
    "code" => "invalid_value"
  ]
```

But the docs [state otherwise](https://platform.openai.com/docs/api-reference/responses/list). Normal responses work with `input_text`. With `text`, both works.