### PR TITLE
docs: replace deprecated generate() with asText() in docs

### DIFF
--- a/docs/advanced/custom-providers.md
+++ b/docs/advanced/custom-providers.md
@@ -70,5 +70,5 @@ use Prism\Prism\Facades\Prism;
 $response = Prism::text()
     ->using('my-custom-provider', 'model-name')
     ->withPrompt('Hello, custom AI!')
-    ->generate();
+    ->asText();
 ```

--- a/docs/advanced/rate-limits.md
+++ b/docs/advanced/rate-limits.md
@@ -38,7 +38,7 @@ try {
     Prism::text()
         ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
         ->withPrompt('Hello world!')
-        ->generate();
+        ->asText();
 }
 catch (PrismRateLimitedException $e) {
     /** @var ProviderRateLimit $rate_limit */ 
@@ -110,7 +110,7 @@ use Prism\Prism\ValueObjects\ProviderRateLimit;
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
     ->withPrompt('Hello world!')
-    ->generate();
+    ->asText();
     
 /** @var ProviderRateLimit $rate_limit */ 
 foreach ($response->meta->rateLimits as $rate_limit) {

--- a/docs/input-modalities/images.md
+++ b/docs/input-modalities/images.md
@@ -50,7 +50,7 @@ $message = new UserMessage(
 $response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
     ->withMessages([$message])
-    ->generate();
+    ->asText();
 ```
 
 ## Transfer mediums 

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -21,7 +21,7 @@ $response = Prism::text()
     ->withPrompt('What is the stock price of Google right now?')
     // Enable search grounding
     ->withProviderTools(['google_search'])
-    ->generate();
+    ->asText();
 ```
 
 If you use search groundings, Google require you meet certain [display requirements](https://ai.google.dev/gemini-api/docs/grounding/search-suggestions).
@@ -137,7 +137,7 @@ $response = Prism::text()
     ->withPrompt('Explain the concept of Occam\'s Razor and provide a simple, everyday example.')
     // Set thinking budget
     ->withProviderOptions(['thinkingBudget' => 300])
-    ->generate();
+    ->asText();
 ```
 > [!NOTE]
 > Do not specify a `thinkingBudget` on 2.0 or prior series Gemini models as your request will fail.


### PR DESCRIPTION
Replaced deprecated generate() method with asText() method in docs.

example of the changes
```php
use Prism\Prism\Facades\Prism;

$response = Prism::text()
    ->using('my-custom-provider', 'model-name')
    ->withPrompt('Hello, custom AI!')
    ->generate();
```
changed to:


```php
use Prism\Prism\Facades\Prism;

$response = Prism::text()
    ->using('my-custom-provider', 'model-name')
    ->withPrompt('Hello, custom AI!')
    ->asText();
```