### PR TITLE
feat(anthropic): add tool calling mode for improved structured output reliability

### DIFF
--- a/docs/core-concepts/structured-output.md
+++ b/docs/core-concepts/structured-output.md
@@ -51,7 +51,10 @@ Different AI providers handle structured output in two main ways:
 
 ## Provider-Specific Options
 
-Providers may offer additional options for structured output. For example, OpenAI supports a "strict mode" for even tighter schema validation:
+Providers may offer additional options for structured output:
+
+### OpenAI: Strict Mode
+OpenAI supports a "strict mode" for even tighter schema validation:
 
 ```php
 use Prism\Prism\Prism;
@@ -65,6 +68,29 @@ $response = Prism::structured()
     ])
     // ... rest of your configuration
 ```
+
+### Anthropic: Tool Calling Mode
+Anthropic doesn't have native structured output, but Prism provides two approaches. For more reliable JSON parsing, especially with complex content or non-English text, use tool calling mode:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+
+$response = Prism::structured()
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
+    ->withSchema($schema)
+    ->withPrompt('天氣怎麼樣？應該穿什麼？') // Chinese text with potential quotes
+    ->withProviderOptions(['useToolCalling' => true])
+    ->asStructured();
+```
+
+**When to use tool calling mode with Anthropic:**
+- Working with non-English content that may contain quotes
+- Complex JSON structures that might confuse prompt-based parsing
+- When you need the most reliable structured output possible
+
+> [!NOTE]
+> Tool calling mode cannot be used with Anthropic's citations feature.
 
 > [!TIP]
 > Check the provider-specific documentation pages for additional options and features that might be available for structured output.

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -293,10 +293,47 @@ Note that when using streaming, Anthropic does not stream citations in the same 
 
 ### Structured Output
 
-While Anthropic models don't have native JSON mode or structured output like some providers, Prism implements a robust workaround for structured output:
+While Anthropic models don't have native JSON mode or structured output like some providers, Prism implements two approaches for structured output:
 
+#### Default JSON Mode (Prompt-based)
 - We automatically append instructions to your prompt that guide the model to output valid JSON matching your schema
 - If the response isn't valid JSON, Prism will raise a PrismException
+- This method can sometimes struggle with complex JSON containing quotes, especially in non-English languages
+
+#### Tool Calling Mode (Recommended)
+For more reliable structured output, especially when dealing with complex content or non-English text that may contain quotes, you can enable tool calling mode:
+
+```php
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+
+$response = Prism::structured()
+    ->withSchema(new ObjectSchema(
+        'weather_report',
+        'Weather forecast with recommendations',
+        [
+            new StringSchema('forecast', 'The weather forecast'),
+            new StringSchema('recommendation', 'Clothing recommendation')
+        ],
+        ['forecast', 'recommendation']
+    ))
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
+    ->withPrompt('What\'s the weather like and what should I wear?')
+    ->withProviderOptions(['useToolCalling' => true])
+    ->asStructured();
+```
+
+**Benefits of tool calling mode:**
+- More reliable JSON parsing, especially with quotes and special characters
+- Better handling of non-English content (Chinese, Japanese, etc.)
+- Reduced risk of malformed JSON responses
+- Compatible with thinking mode
+
+**Limitations:**
+- Cannot be used with citations (citations are not supported in tool calling mode)
+- Slightly more complex under the hood but identical API usage
 
 ## Limitations
 ### Messages

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\Anthropic\Handlers;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Prism\Prism\Contracts\PrismRequest;
 use Prism\Prism\Providers\Anthropic\Maps\FinishReasonMap;
 use Prism\Prism\Providers\Anthropic\Maps\MessageMap;
@@ -38,7 +39,16 @@ class Structured extends AnthropicHandlerAbstract
 
     public function handle(): Response
     {
-        $this->appendMessageForJsonMode();
+        $this->validateProviderOptions();
+
+        if ($this->shouldUseToolCalling()) {
+            if ($this->request->providerOptions('thinking.enabled') === true) {
+                // In thinking mode with tools, add guidance for JSON output
+                $this->appendThinkingModeGuidance();
+            }
+        } else {
+            $this->appendMessageForJsonMode();
+        }
 
         $this->sendRequest();
 
@@ -63,6 +73,22 @@ class Structured extends AnthropicHandlerAbstract
             additionalContent: $this->tempResponse->additionalContent,
         ));
 
+        // Override the structured data if using tool calling
+        if ($this->shouldUseToolCalling()) {
+            $response = $this->responseBuilder->toResponse();
+
+            return new Response(
+                steps: $response->steps,
+                responseMessages: $response->responseMessages,
+                text: $response->text,
+                structured: $this->tempResponse->structured,
+                finishReason: $response->finishReason,
+                usage: $response->usage,
+                meta: $response->meta,
+                additionalContent: $response->additionalContent
+            );
+        }
+
         return $this->responseBuilder->toResponse();
     }
 
@@ -74,7 +100,19 @@ class Structured extends AnthropicHandlerAbstract
     public static function buildHttpRequestPayload(PrismRequest $request): array
     {
         if (! $request->is(StructuredRequest::class)) {
-            throw new \InvalidArgumentException('Request must be an instance of '.StructuredRequest::class);
+            throw new InvalidArgumentException('Request must be an instance of '.StructuredRequest::class);
+        }
+
+        // Validate options
+        if ($request->providerOptions('citations') === true && $request->providerOptions('useToolCalling') === true) {
+            throw new InvalidArgumentException(
+                'Citations are not supported with tool calling mode. '.
+                'Please set useToolCalling to false in provider options to use citations.'
+            );
+        }
+
+        if ($request->providerOptions('useToolCalling') === true) {
+            return static::buildToolCallingPayload($request);
         }
 
         return Arr::whereNotNull([
@@ -95,32 +133,147 @@ class Structured extends AnthropicHandlerAbstract
         ]);
     }
 
+    protected static function buildToolCallingPayload(StructuredRequest $request): array
+    {
+        // Use the schema directly for tool input_schema instead of converting to Tool parameters
+        $schemaArray = $request->schema()->toArray();
+        $isThinkingEnabled = $request->providerOptions('thinking.enabled') === true;
+
+        $properties = $schemaArray['properties'];
+        $required = $schemaArray['required'] ?? [];
+
+        // Prepend thinking fields when thinking mode is enabled (using special characters to avoid conflicts)
+        if ($isThinkingEnabled) {
+            $thinkingProperties = [
+                '__thinking' => [
+                    'type' => 'string',
+                    'description' => 'Your step-by-step thinking process and reasoning before the final answer',
+                ],
+            ];
+
+            // Prepend thinking fields to the beginning of properties
+            $properties = $thinkingProperties + $properties;
+
+            // Prepend thinking fields to required array
+            $required = array_merge(['__thinking'], $required);
+        }
+
+        $toolDefinition = [
+            'name' => 'output_structured_data',
+            'description' => 'Output data in the requested structure',
+            'input_schema' => [
+                'type' => 'object',
+                'properties' => $properties,
+                'required' => $required,
+                'additionalProperties' => false,
+            ],
+        ];
+
+        return Arr::whereNotNull([
+            'model' => $request->model(),
+            'messages' => MessageMap::map($request->messages(), $request->providerOptions()),
+            'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
+            'thinking' => $isThinkingEnabled
+            ? [
+                'type' => 'enabled',
+                'budget_tokens' => is_int($request->providerOptions('thinking.budgetTokens'))
+                    ? $request->providerOptions('thinking.budgetTokens')
+                    : config('prism.anthropic.default_thinking_budget', 1024),
+            ]
+            : null,
+            'tools' => [$toolDefinition],
+            // Don't force tool choice when thinking is enabled
+            'tool_choice' => $isThinkingEnabled ? null : ['type' => 'tool', 'name' => 'output_structured_data'],
+            'max_tokens' => $request->maxTokens(),
+            'temperature' => $request->temperature(),
+            'top_p' => $request->topP(),
+        ]);
+    }
+
     protected function prepareTempResponse(): void
     {
         $data = $this->httpResponse->json();
 
-        $this->tempResponse = new Response(
-            steps: new Collection,
-            responseMessages: new Collection,
-            text: $this->extractText($data),
-            structured: [],
-            finishReason: FinishReasonMap::map(data_get($data, 'stop_reason', '')),
-            usage: new Usage(
-                promptTokens: data_get($data, 'usage.input_tokens'),
-                completionTokens: data_get($data, 'usage.output_tokens'),
-                cacheWriteInputTokens: data_get($data, 'usage.cache_creation_input_tokens', null),
-                cacheReadInputTokens: data_get($data, 'usage.cache_read_input_tokens', null)
-            ),
-            meta: new Meta(
-                id: data_get($data, 'id'),
-                model: data_get($data, 'model'),
-                rateLimits: $this->processRateLimits($this->httpResponse)
-            ),
-            additionalContent: Arr::whereNotNull([
-                'messagePartsWithCitations' => $this->extractCitations($data),
+        if ($this->shouldUseToolCalling()) {
+            // Extract structured data from tool calls
+            $structuredData = [];
+            $toolCalls = collect(data_get($data, 'content', []))
+                ->filter(fn ($content): bool => data_get($content, 'type') === 'tool_use')
+                ->filter(fn ($toolUse): bool => data_get($toolUse, 'name') === 'output_structured_data');
+
+            if ($toolCalls->isNotEmpty()) {
+                $structuredData = data_get($toolCalls->first(), 'input', []);
+            } else {
+                // Fallback: if no tool was used (e.g., in thinking mode), try to parse JSON from text
+                $text = $this->extractText($data);
+                try {
+                    $parsedJson = json_decode($text, true, flags: JSON_THROW_ON_ERROR);
+                    if (is_array($parsedJson)) {
+                        $structuredData = $parsedJson;
+                    }
+                } catch (\JsonException) {
+                    // If JSON parsing fails, leave structured data empty
+                }
+            }
+
+            // Citations isn't available in tool calling mode
+            $additionalContent = Arr::whereNotNull([
                 ...$this->extractThinking($data),
-            ])
-        );
+            ]);
+
+            // If thinking mode was enabled and we have __thinking in structured data,
+            // also add it to additionalContent for backward compatibility
+            if ($this->request->providerOptions('thinking.enabled') === true &&
+                isset($structuredData['__thinking'])) {
+                $additionalContent['thinking'] = $structuredData['__thinking'];
+
+                // Remove thinking fields from structured data
+                unset($structuredData['__thinking']);
+            }
+
+            $this->tempResponse = new Response(
+                steps: new Collection,
+                responseMessages: new Collection,
+                text: $this->extractText($data),
+                structured: $structuredData,
+                finishReason: FinishReasonMap::map(data_get($data, 'stop_reason', '')),
+                usage: new Usage(
+                    promptTokens: data_get($data, 'usage.input_tokens'),
+                    completionTokens: data_get($data, 'usage.output_tokens'),
+                    cacheWriteInputTokens: data_get($data, 'usage.cache_creation_input_tokens', null),
+                    cacheReadInputTokens: data_get($data, 'usage.cache_read_input_tokens', null)
+                ),
+                meta: new Meta(
+                    id: data_get($data, 'id'),
+                    model: data_get($data, 'model'),
+                    rateLimits: $this->processRateLimits($this->httpResponse)
+                ),
+                additionalContent: $additionalContent
+            );
+        } else {
+            $this->tempResponse = new Response(
+                steps: new Collection,
+                responseMessages: new Collection,
+                text: $this->extractText($data),
+                structured: [],
+                finishReason: FinishReasonMap::map(data_get($data, 'stop_reason', '')),
+                usage: new Usage(
+                    promptTokens: data_get($data, 'usage.input_tokens'),
+                    completionTokens: data_get($data, 'usage.output_tokens'),
+                    cacheWriteInputTokens: data_get($data, 'usage.cache_creation_input_tokens', null),
+                    cacheReadInputTokens: data_get($data, 'usage.cache_read_input_tokens', null)
+                ),
+                meta: new Meta(
+                    id: data_get($data, 'id'),
+                    model: data_get($data, 'model'),
+                    rateLimits: $this->processRateLimits($this->httpResponse)
+                ),
+                additionalContent: Arr::whereNotNull([
+                    'messagePartsWithCitations' => $this->extractCitations($data),
+                    ...$this->extractThinking($data),
+                ])
+            );
+        }
     }
 
     protected function appendMessageForJsonMode(): void
@@ -131,6 +284,29 @@ class Structured extends AnthropicHandlerAbstract
             ($this->request->providerOptions()['citations'] ?? false)
                 ? "\n\n Return the JSON as a single text block with a single set of citations."
                 : ''
+        )));
+    }
+
+    protected function shouldUseToolCalling(): bool
+    {
+        return $this->request->providerOptions('useToolCalling') === true;
+    }
+
+    protected function validateProviderOptions(): void
+    {
+        if ($this->request->providerOptions('citations') === true && $this->shouldUseToolCalling()) {
+            throw new InvalidArgumentException(
+                'Citations are not supported with tool calling mode. '.
+                'Please set useToolCalling to false in provider options to use citations.'
+            );
+        }
+    }
+
+    protected function appendThinkingModeGuidance(): void
+    {
+        $this->request->addMessage(new UserMessage(sprintf(
+            "Please use the output_structured_data tool to provide your response. If for any reason you cannot use the tool, respond with ONLY JSON that matches this schema: \n %s",
+            json_encode($this->request->schema()->toArray(), JSON_PRETTY_PRINT)
         )));
     }
 }

--- a/tests/Fixtures/anthropic/structured-chinese-tool-calling-1.json
+++ b/tests/Fixtures/anthropic/structured-chinese-tool-calling-1.json
@@ -1,0 +1,28 @@
+{
+  "id": "msg_01ChineseWeatherToolCall",
+  "type": "message", 
+  "role": "assistant",
+  "model": "claude-3-5-sonnet-20241022",
+  "content": [
+    {
+      "type": "text",
+      "text": "我來為您提供今天的天氣預報和穿衣建議。"
+    },
+    {
+      "type": "tool_use",
+      "id": "toolu_chinese_weather_001",
+      "name": "output_structured_data",
+      "input": {
+        "weather": "今天天氣：\"15°C\"，多雲轉晴，微風。適合戶外活動，\"溫度\"比較適中。",
+        "recommendation": "建議穿著：\"長袖襯衫\"配\"薄外套\"，下身可穿\"長褲\"。由於\"溫度\"適中，不需要厚重衣物。",
+        "coat_required": true
+      }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 156,
+    "output_tokens": 98
+  }
+}

--- a/tests/Providers/Anthropic/StructuredTest.php
+++ b/tests/Providers/Anthropic/StructuredTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Providers\Anthropic;
 
 use Illuminate\Support\Carbon;
+use InvalidArgumentException;
 use Prism\Prism\Enums\Provider;
 use Prism\Prism\Prism;
 use Prism\Prism\Providers\Anthropic\Handlers\Structured;
@@ -207,3 +208,132 @@ it('can use extending thinking', function (): void {
         ->additionalContent->thinking->toBe($expected_thinking)
         ->additionalContent->thinking_signature->toBe($expected_signature);
 });
+
+it('throws error when citations and tool calling are used together', function (): void {
+    $schema = new ObjectSchema('output', 'the output object', [
+        new StringSchema('answer', 'The answer'),
+    ], ['answer']);
+
+    expect(fn (): \Prism\Prism\Structured\Response => Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
+        ->withPrompt('What is the answer?')
+        ->withProviderOptions(['citations' => true, 'useToolCalling' => true])
+        ->asStructured()
+    )->toThrow(InvalidArgumentException::class, 'Citations are not supported with tool calling mode');
+});
+
+it('returns structured output with default JSON mode', function (): void {
+    $schema = new ObjectSchema('output', 'the output object', [
+        new StringSchema('answer', 'A simple answer'),
+    ], ['answer']);
+
+    $response = Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
+        ->withPrompt('What is 2+2?')
+        ->asStructured();
+
+    expect($response->structured)->toBeArray();
+    expect($response->structured)->toHaveKey('answer');
+    expect($response->structured['answer'])->toBeString();
+})->skip(fn (): bool => ! env('ANTHROPIC_API_KEY'), 'Skipping live test - ANTHROPIC_API_KEY environment variable is not configured. Set your API key to run this test.');
+
+it('works with thinking mode when useToolCalling is true', function (): void {
+    $schema = new ObjectSchema('output', 'the output object', [
+        new StringSchema('answer', 'The answer about life, universe and everything'),
+    ], ['answer']);
+
+    $response = Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::Anthropic, 'claude-3-7-sonnet-latest')
+        ->withSystemPrompt('You are a helpful assistant.')
+        ->withPrompt('What is the meaning of life, the universe and everything in popular fiction?')
+        ->withProviderOptions(['thinking' => ['enabled' => true], 'useToolCalling' => true])
+        ->asStructured();
+
+    expect($response->structured)->toBeArray();
+    expect($response->structured)->toHaveKey('answer');
+    expect($response->structured['answer'])->toBeString();
+
+    // Check that thinking data is available in additionalContent for backward compatibility
+    expect($response->additionalContent)->toHaveKey('thinking');
+    expect($response->additionalContent['thinking'])->toBeString();
+
+    // Check that __thinking is not in structured data (it should be moved to additionalContent)
+    expect($response->structured)->not->toHaveKey('__thinking');
+})->skip(fn (): bool => ! env('ANTHROPIC_API_KEY'), 'Skipping live test - ANTHROPIC_API_KEY environment variable is not configured. Set your API key to run this test.');
+
+it('handles Chinese output with double quotes using tool calling', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/messages', 'anthropic/structured-chinese-tool-calling');
+
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('weather', 'The weather forecast in Chinese with double quotes for temperature'),
+            new StringSchema('recommendation', 'Clothing recommendation in Chinese with quoted items'),
+            new BooleanSchema('coat_required', 'whether a coat is required'),
+        ],
+        ['weather', 'recommendation', 'coat_required']
+    );
+
+    $response = Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
+        ->withSystemPrompt('Respond in Chinese. Use double quotes around temperature values and clothing items.')
+        ->withPrompt('What is the weather like today and what should I wear? The temperature is 15°C.')
+        ->withProviderOptions(['useToolCalling' => true])
+        ->asStructured();
+
+    expect($response->structured)->toBeArray();
+    expect($response->structured)->toHaveKeys([
+        'weather',
+        'recommendation',
+        'coat_required',
+    ]);
+    expect($response->structured['weather'])->toBeString();
+    expect($response->structured['recommendation'])->toBeString();
+    expect($response->structured['coat_required'])->toBeBool();
+
+    // Verify that Chinese text with quotes is properly handled
+    expect($response->structured['weather'])->toContain('今天天氣');
+    expect($response->structured['weather'])->toContain('15°C');
+    expect($response->structured['recommendation'])->toContain('建議');
+    expect($response->structured['coat_required'])->toBe(true);
+});
+
+it('handles Chinese output with double quotes using tool calling (live test)', function (): void {
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('weather', 'The weather forecast in Chinese with double quotes for temperature'),
+            new StringSchema('recommendation', 'Clothing recommendation in Chinese with quoted items'),
+            new BooleanSchema('coat_required', 'whether a coat is required'),
+        ],
+        ['weather', 'recommendation', 'coat_required']
+    );
+
+    $response = Prism::structured()
+        ->withSchema($schema)
+        ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
+        ->withSystemPrompt('Respond in Chinese. Use double quotes around temperature values and clothing items.')
+        ->withPrompt('What is the weather like today and what should I wear? The temperature is 15°C.')
+        ->withProviderOptions(['useToolCalling' => true])
+        ->asStructured();
+
+    expect($response->structured)->toBeArray();
+    expect($response->structured)->toHaveKeys([
+        'weather',
+        'recommendation',
+        'coat_required',
+    ]);
+    expect($response->structured['weather'])->toBeString();
+    expect($response->structured['recommendation'])->toBeString();
+    expect($response->structured['coat_required'])->toBeBool();
+
+    // Verify that Chinese text with quotes is properly handled
+    expect($response->structured['weather'])->toContain('°C');
+    expect($response->structured['recommendation'])->toBeString();
+})->skip(fn (): bool => ! env('ANTHROPIC_API_KEY'), 'Skipping live test - ANTHROPIC_API_KEY environment variable is not configured. Set your API key to run this test.');


### PR DESCRIPTION
This PR adds an optional tool calling mode for Anthropic's structured output to address JSON parsing issues with complex content, particularly non-English text containing quotes.

### Problem

The current prompt-based approach for Anthropic structured output frequently produces malformed JSON when handling:
- Non-English content (Chinese, Japanese, etc.) with quoted strings
- Complex nested structures with special characters
- Content where the model needs to include literal quotes in the output

Example: Descriptions like `{"description": "今天天氣："15°C""}` often break JSON parsing.

### Solution

Implemented an opt-in `useToolCalling` provider option that leverages Anthropic's function calling capabilities for more reliable structured output generation.

## Changes

- **feat(anthropic)**: Add `useToolCalling` provider option for structured output
  - Uses dedicated `output_structured_data` tool to enforce proper JSON structure
  - Maintains backward compatibility - default behavior unchanged
  - Throws clear exception when used with citations (incompatible features)

- **feat(anthropic)**: Support thinking mode with tool calling
  - Extracts `__thinking` field from structured data
  - Moves thinking content to `additionalContent` for consistency
  
- **test**: Add comprehensive test coverage
  - Fixture-based test with Chinese traditional text
  - Live test that skips when `ANTHROPIC_API_KEY` not configured
  - Validation for incompatible option combinations

- **docs**: Update documentation
  - Added usage examples to Anthropic provider docs
  - Updated structured output concept docs with provider-specific options
  - Clear guidance on when to use tool calling mode

## Usage

```php
// Enable tool calling for better reliability with complex content
$response = Prism::structured()
    ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
    ->withSchema($schema)
    ->withPrompt('天氣怎麼樣？應該穿什麼？')
    ->withProviderOptions(['useToolCalling' => true])
    ->asStructured();
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings