### PR TITLE
feat(anthropic): tool result caching

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -62,7 +62,7 @@ Note that you must use the `withMessages()` method in order to enable prompt cac
 
 In addition to caching prompts and tool definitions, Prism supports caching tool results. This is particularly useful when making multiple tool calls where results might be referenced repeatedly.
 
-To enable tool result caching, use the `toolResultCacheType` provider option on your request:
+To enable tool result caching, use the `tool_result_cache_type` provider option on your request:
 
 ```php
 use Prism\Prism\Prism;
@@ -72,7 +72,7 @@ $response = Prism::text()
     ->withMaxSteps(30)
     ->withTools([new WeatherTool()])
     ->withProviderOptions([
-        'toolResultCacheType' => 'ephemeral'
+        'tool_result_cache_type' => 'ephemeral'
     ])
     ->withPrompt('Check the weather in New York, London, Tokyo, Paris, and Sydney')
     ->asText();

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -75,7 +75,7 @@ $response = Prism::text()
         'toolResultCacheType' => 'ephemeral'
     ])
     ->withPrompt('Check the weather in New York, London, Tokyo, Paris, and Sydney')
-    ->generate();
+    ->asText();
 ```
 
 When multiple tool results are returned, Prism automatically applies caching to only the last result, which caches all preceding results as well. This avoids Anthropic's 4-cache-breakpoint limitation.

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -58,6 +58,28 @@ use Prism\Prism\ValueObjects\Messages\Support\Document;
 ```
 Note that you must use the `withMessages()` method in order to enable prompt caching, rather than `withPrompt()` or `withSystemPrompt()`.
 
+### Tool result caching
+
+In addition to caching prompts and tool definitions, Prism supports caching tool results. This is particularly useful when making multiple tool calls where results might be referenced repeatedly.
+
+To enable tool result caching, use the `toolResultCacheType` provider option on your request:
+
+```php
+use Prism\Prism\Prism;
+
+$response = Prism::text()
+    ->using('anthropic', 'claude-3-5-sonnet-20241022')
+    ->withMaxSteps(30)
+    ->withTools([new WeatherTool()])
+    ->withProviderOptions([
+        'toolResultCacheType' => 'ephemeral'
+    ])
+    ->withPrompt('Check the weather in New York, London, Tokyo, Paris, and Sydney')
+    ->generate();
+```
+
+When multiple tool results are returned, Prism automatically applies caching to only the last result, which caches all preceding results as well. This avoids Anthropic's 4-cache-breakpoint limitation.
+
 Please ensure you read Anthropic's [prompt caching documentation](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching), which covers some important information on e.g. minimum cacheable tokens and message order consistency.
 
 ## Extended thinking

--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -611,9 +611,9 @@ class Stream
         $message = new ToolResultMessage($toolResults);
 
         // Apply tool result caching if configured
-        $toolResultCacheType = $request->providerOptions('toolResultCacheType');
-        if ($toolResultCacheType) {
-            $message->withProviderOptions(['cacheType' => $toolResultCacheType]);
+        $tool_result_cache_type = $request->providerOptions('tool_result_cache_type');
+        if ($tool_result_cache_type) {
+            $message->withProviderOptions(['cacheType' => $tool_result_cache_type]);
         }
 
         $request->addMessage($message);

--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -608,7 +608,15 @@ class Stream
             $additionalContent ?? []
         ));
 
-        $request->addMessage(new ToolResultMessage($toolResults));
+        $message = new ToolResultMessage($toolResults);
+
+        // Apply tool result caching if configured
+        $toolResultCacheType = $request->providerOptions('toolResultCacheType');
+        if ($toolResultCacheType) {
+            $message->withProviderOptions(['cacheType' => $toolResultCacheType]);
+        }
+
+        $request->addMessage($message);
     }
 
     /**

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -108,6 +108,12 @@ class Text extends AnthropicHandlerAbstract
         $toolResults = $this->callTools($this->request->tools(), $this->tempResponse->toolCalls);
         $message = new ToolResultMessage($toolResults);
 
+        // Apply tool result caching if configured
+        $toolResultCacheType = $this->request->providerOptions('toolResultCacheType');
+        if ($toolResultCacheType) {
+            $message->withProviderOptions(['cacheType' => $toolResultCacheType]);
+        }
+
         $this->request->addMessage($message);
 
         $this->addStep($toolResults);

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -109,9 +109,9 @@ class Text extends AnthropicHandlerAbstract
         $message = new ToolResultMessage($toolResults);
 
         // Apply tool result caching if configured
-        $toolResultCacheType = $this->request->providerOptions('toolResultCacheType');
-        if ($toolResultCacheType) {
-            $message->withProviderOptions(['cacheType' => $toolResultCacheType]);
+        $tool_result_cache_type = $this->request->providerOptions('tool_result_cache_type');
+        if ($tool_result_cache_type) {
+            $message->withProviderOptions(['cacheType' => $tool_result_cache_type]);
         }
 
         $this->request->addMessage($message);

--- a/src/ValueObjects/Messages/ToolResultMessage.php
+++ b/src/ValueObjects/Messages/ToolResultMessage.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Prism\Prism\ValueObjects\Messages;
 
+use Prism\Prism\Concerns\HasProviderOptions;
 use Prism\Prism\Contracts\Message;
 use Prism\Prism\ValueObjects\ToolResult;
 
-readonly class ToolResultMessage implements Message
+class ToolResultMessage implements Message
 {
+    use HasProviderOptions;
+
     /**
      * @param  ToolResult[]  $toolResults
      */
     public function __construct(
-        public array $toolResults
+        public readonly array $toolResults
     ) {}
 }


### PR DESCRIPTION
This PR adds support for caching tool results when using Anthropic's API. This feature reduces token usage and API costs when tool results are referenced multiple times within a conversation.

## Problem

When using tools with Anthropic's Claude models, each tool result consumes input tokens every time it's referenced in subsequent API calls. For scenarios with multiple tool calls (e.g., checking weather in 5 cities), this can significantly increase costs and latency.

## Solution

Added support for caching tool results using Anthropic's prompt caching feature. Tool results can now be cached for 5 minutes, reducing token usage on subsequent references.

## Implementation Details

  1. Added HasProviderOptions trait to ToolResultMessage - Enables provider-specific configuration on tool result messages
  2. Updated Anthropic's MessageMap - Adds cache_control field to tool results when caching is enabled
  3. Smart caching behavior - Only applies cache_control to the last tool result, which automatically caches all preceding results (avoiding
  Anthropic's 4-cache-breakpoint limitation)
  4. Request-level configuration - Added toolResultCacheType provider option

## Usage
```php
  $response = Prism::text()
      ->using('anthropic', 'claude-3-5-sonnet-20241022')
      ->withMaxSteps(30)
      ->withTools([new WeatherTool()])
      ->withProviderOptions([
          'toolResultCacheType' => 'ephemeral'
      ])
      ->withPrompt('Check the weather in New York & London')
      ->asText();
```
## Testing

  - Added comprehensive test coverage for single and multiple tool result caching
  - All existing tests continue to pass
  - Code style compliance verified with Laravel Pint

## Documentation

Updated the Anthropic provider documentation with a new "Tool result caching" section explaining the feature and its benefits.
