### PR TITLE
feat(anthropic): Add usage to stream chunk

### DIFF
--- a/docs/core-concepts/streaming-output.md
+++ b/docs/core-concepts/streaming-output.md
@@ -40,9 +40,6 @@ foreach ($response as $chunk) {
     // Check if this is the final chunk
     if ($chunk->finishReason === FinishReason::Stop) {
         echo "Generation complete: " . $chunk->finishReason->name;
-        // Only available for Anthropic in each chunk with finishReason
-        echo "Prompt tokens: " . $chunk->usage->promptTokens;
-        echo "Completion tokens: " . $chunk->usage->completionTokens;
     }
 }
 ```

--- a/docs/core-concepts/streaming-output.md
+++ b/docs/core-concepts/streaming-output.md
@@ -40,6 +40,9 @@ foreach ($response as $chunk) {
     // Check if this is the final chunk
     if ($chunk->finishReason === FinishReason::Stop) {
         echo "Generation complete: " . $chunk->finishReason->name;
+        // Only available for Anthropic in each chunk with finishReason
+        echo "Prompt tokens: " . $chunk->usage->promptTokens;
+        echo "Completion tokens: " . $chunk->usage->completionTokens;
     }
 }
 ```

--- a/src/Providers/Anthropic/ValueObjects/StreamState.php
+++ b/src/Providers/Anthropic/ValueObjects/StreamState.php
@@ -9,6 +9,7 @@ class StreamState
     /**
      * @param  array<int, array<string, mixed>>  $toolCalls
      * @param  array<int, MessagePartWithCitations>  $citations
+     * @param  array<string, int>  $usage
      * @param  array<string, mixed>|null  $tempCitation
      */
     public function __construct(
@@ -20,6 +21,7 @@ class StreamState
         protected string $thinkingSignature = '',
         protected array $citations = [],
         protected string $stopReason = '',
+        protected ?array $usage = [],
         protected ?string $tempContentBlockType = null,
         protected ?int $tempContentBlockIndex = null,
         protected ?array $tempCitation = null,
@@ -149,6 +151,30 @@ class StreamState
         return $this;
     }
 
+    /**
+     * @return array<string, int>|null
+     */
+    public function usage(): ?array
+    {
+        return $this->usage;
+    }
+
+    /**
+     * @param  array<string, int>  $usage
+     */
+    public function setUsage(array $usage): self
+    {
+        if ($this->usage === []) {
+            $this->usage = $usage;
+        } else {
+            foreach ($usage as $key => $value) {
+                $this->usage[$key] = ($this->usage[$key] ?? 0) + $value;
+            }
+        }
+
+        return $this;
+    }
+
     public function tempContentBlockType(): ?string
     {
         return $this->tempContentBlockType;
@@ -211,6 +237,7 @@ class StreamState
         $this->thinkingSignature = '';
         $this->citations = [];
         $this->stopReason = '';
+        $this->usage = [];
         $this->tempContentBlockType = null;
         $this->tempContentBlockIndex = null;
         $this->tempCitation = null;


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
Adds optional `Usage` to text Chunk and implements it for Anthropic.

In Anthropic there are some additional usage details, but we might implement them in a future improvement.

I had to change some things in Stream Handler because the stream was not being read entirely and finish reason was sent only at the end instead of sending all finish reasons.

This is currently generated chunks, no finish reason for tool calls, only last chunk has finish reason.
![Screenshot From 2025-06-17 16-43-33](https://github.com/user-attachments/assets/5603cad5-9c62-496e-a76a-efa76d67ba7f)

This is how it is with this PR
![Screenshot From 2025-06-17 16-26-05](https://github.com/user-attachments/assets/c9cb024e-8bac-4a68-8225-9a10c393e7ba)

### TODO
- [x] Add documentation

Closes #404

