### PR TITLE
fix(gemini): stream handler sends empty array for thinkingConfig

### DIFF
--- a/src/Providers/Gemini/Handlers/Stream.php
+++ b/src/Providers/Gemini/Handlers/Stream.php
@@ -245,7 +245,7 @@ class Stream
                             'maxOutputTokens' => $request->maxTokens(),
                             'thinkingConfig' => Arr::whereNotNull([
                                 'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-                            ]),
+                            ]) ?: null,
                         ]),
                         'tools' => $tools !== [] ? $tools : null,
                         'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
Gemini stream handlers sends
```json
"generationConfig": {
  "maxOutputTokens": 2048,
  "thinkingConfig": []
}
```
While it should omit `thinkingConfig` if empty.

Related to #394 that fixed it for gemini structured handler, text handler it's working.

Fixes #419
