### PR TITLE
feat(openai): Response meta while streaming

### DIFF
--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -25,6 +25,7 @@ use Prism\Prism\Text\Chunk;
 use Prism\Prism\Text\Request;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
+use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\ToolCall;
 use Psr\Http\Message\StreamInterface;
 use Throwable;
@@ -58,6 +59,20 @@ class Stream
             $data = $this->parseNextDataLine($response->getBody());
 
             if ($data === null) {
+                continue;
+            }
+
+            if ($data['type'] === 'response.created') {
+                yield new Chunk(
+                    text: '',
+                    finishReason: null,
+                    meta: new Meta(
+                        id: $data['response']['id'] ?? null,
+                        model: $data['response']['model'] ?? null,
+                    ),
+                    chunkType: ChunkType::Meta,
+                );
+
                 continue;
             }
 

--- a/tests/Providers/OpenAI/StreamTest.php
+++ b/tests/Providers/OpenAI/StreamTest.php
@@ -27,13 +27,25 @@ it('can generate text with a basic stream', function (): void {
     $text = '';
     $chunks = [];
 
+    $responseId = null;
+    $model = null;
+
     foreach ($response as $chunk) {
+        if ($chunk->chunkType === ChunkType::Meta) {
+            $responseId = $chunk->meta?->id;
+            $model = $chunk->meta?->model;
+        }
+
         $chunks[] = $chunk;
         $text .= $chunk->text;
     }
 
     expect($chunks)->not->toBeEmpty();
     expect($text)->not->toBeEmpty();
+    expect($responseId)
+        ->not->toBeNull()
+        ->toStartWith('resp_');
+    expect($model)->not->toBeNull();
 
     // Verify the HTTP request
     Http::assertSent(function (Request $request): bool {


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Uses the existing `Meta` object and chunk type to expose information about the response ID and model from the API response. Otherwise, it's impossible to infer the `response_id` from the response to use in the next completion (as `previous_response_id`).