### PR TITLE
Update Gemini provider example to use ProviderTool class

### DIFF
--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -15,12 +15,15 @@ You may enable Google search grounding on text requests using withProviderTools:
 ```php
 use Prism\Prism\Prism;
 use Prism\Prism\Enums\Provider;
+use Prism\Prism\ValueObjects\ProviderTool;
 
 $response = Prism::text()
     ->using(Provider::Gemini, 'gemini-2.0-flash')
     ->withPrompt('What is the stock price of Google right now?')
     // Enable search grounding
-    ->withProviderTools(['google_search'])
+    ->withProviderTools([
+            new ProviderTool('google_search')
+        ])
     ->asText();
 ```
 


### PR DESCRIPTION
## Description
The docs have an outdated example for the Gemini::withProviderTools() method.
