### PR TITLE
refactor(providers): use trait to initialize base Http client

### DIFF
--- a/src/Concerns/HandlesRequestExceptions.php
+++ b/src/Concerns/HandlesRequestExceptions.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Concerns;
+
+use Illuminate\Http\Client\RequestException;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Throwable;
+
+trait HandlesRequestExceptions
+{
+    public function handleRequestExceptions(string $model, Throwable $e): never
+    {
+        // Keep already raised PrismException
+        if ($e instanceof PrismException) {
+            throw $e;
+        }
+
+        if (! $e instanceof RequestException) {
+            throw PrismException::providerRequestError($model, $e);
+        }
+
+        match ($e->response->getStatusCode()) {
+            413 => throw PrismRequestTooLargeException::make(self::class),
+            429 => throw PrismRateLimitedException::make([]),
+            529 => throw PrismProviderOverloadedException::make(self::class),
+            default => throw PrismException::providerRequestError($model, $e),
+        };
+    }
+}

--- a/src/Concerns/InitializesClient.php
+++ b/src/Concerns/InitializesClient.php
@@ -14,6 +14,7 @@ trait InitializesClient
     protected function baseClient(): PendingRequest
     {
         return Http::withRequestMiddleware(fn (RequestInterface $request): RequestInterface => $request)
-            ->withResponseMiddleware(fn (ResponseInterface $response): ResponseInterface => $response);
+            ->withResponseMiddleware(fn (ResponseInterface $response): ResponseInterface => $response)
+            ->throw();
     }
 }

--- a/src/Concerns/InitializesClient.php
+++ b/src/Concerns/InitializesClient.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+trait InitializesClient
+{
+    protected function baseClient(): PendingRequest
+    {
+        return Http::withRequestMiddleware(fn (RequestInterface $request): RequestInterface => $request)
+            ->withResponseMiddleware(fn (ResponseInterface $response): ResponseInterface => $response);
+    }
+}

--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -12,6 +12,7 @@ use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Text\Chunk;
 use Prism\Prism\Text\Request as TextRequest;
 use Prism\Prism\Text\Response as TextResponse;
+use Throwable;
 
 interface Provider
 {
@@ -25,4 +26,6 @@ interface Provider
      * @return Generator<Chunk>
      */
     public function stream(TextRequest $request): Generator;
+
+    public function handleRequestExceptions(string $model, Throwable $e): never;
 }

--- a/src/Embeddings/PendingRequest.php
+++ b/src/Embeddings/PendingRequest.php
@@ -8,6 +8,7 @@ use Prism\Prism\Concerns\ConfiguresClient;
 use Prism\Prism\Concerns\ConfiguresProviders;
 use Prism\Prism\Concerns\HasProviderOptions;
 use Prism\Prism\Exceptions\PrismException;
+use Throwable;
 
 class PendingRequest
 {
@@ -60,13 +61,19 @@ class PendingRequest
         return $this->asEmbeddings();
     }
 
-    public function asEmbeddings(): \Prism\Prism\Embeddings\Response
+    public function asEmbeddings(): Response
     {
         if ($this->inputs === []) {
             throw new PrismException('Embeddings input is required');
         }
 
-        return $this->provider->embeddings($this->toRequest());
+        $request = $this->toRequest();
+
+        try {
+            return $this->provider->embeddings($request);
+        } catch (Throwable $e) {
+            $this->provider->handleRequestExceptions($request->model(), $e);
+        }
     }
 
     protected function toRequest(): Request

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -6,21 +6,29 @@ namespace Prism\Prism\Providers\Anthropic;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
 use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Enums\Provider as ProviderName;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Providers\Anthropic\Concerns\ProcessesRateLimits;
 use Prism\Prism\Providers\Anthropic\Handlers\Stream;
 use Prism\Prism\Providers\Anthropic\Handlers\Structured;
 use Prism\Prism\Providers\Anthropic\Handlers\Text;
 use Prism\Prism\Structured\Request as StructuredRequest;
 use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Text\Request as TextRequest;
-use Prism\Prism\Text\Response;
+use Prism\Prism\Text\Response as TextResponse;
+use Throwable;
 
 readonly class Anthropic implements Provider
 {
-    use InitializesClient;
+    use InitializesClient, ProcessesRateLimits;
 
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
@@ -29,7 +37,7 @@ readonly class Anthropic implements Provider
     ) {}
 
     #[\Override]
-    public function text(TextRequest $request): Response
+    public function text(TextRequest $request): TextResponse
     {
         $handler = new Text(
             $this->client(
@@ -71,6 +79,29 @@ readonly class Anthropic implements Provider
     public function embeddings(EmbeddingRequest $request): EmbeddingResponse
     {
         throw new \Exception(sprintf('%s does not support embeddings', class_basename($this)));
+    }
+
+    public function handleRequestExceptions(string $model, Throwable $e): never
+    {
+        if ($e instanceof PrismException) {
+            throw $e;
+        }
+
+        if (! $e instanceof RequestException) {
+            throw PrismException::providerRequestError($model, $e);
+        }
+
+        match ($e->response->getStatusCode()) {
+            429 => throw PrismRateLimitedException::make(
+                rateLimits: $this->processRateLimits($e->response),
+                retryAfter: $e->response->hasHeader('retry-after')
+                    ? (int) $e->response->getHeader('retry-after')[0]
+                    : null
+            ),
+            529 => throw PrismProviderOverloadedException::make(ProviderName::Anthropic),
+            413 => throw PrismRequestTooLargeException::make(ProviderName::Anthropic),
+            default => throw PrismException::providerRequestError($model, $e),
+        };
     }
 
     /**

--- a/src/Providers/Anthropic/Concerns/ProcessesRateLimits.php
+++ b/src/Providers/Anthropic/Concerns/ProcessesRateLimits.php
@@ -8,34 +8,10 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
-use Prism\Prism\Enums\Provider;
-use Prism\Prism\Exceptions\PrismProviderOverloadedException;
-use Prism\Prism\Exceptions\PrismRateLimitedException;
-use Prism\Prism\Exceptions\PrismRequestTooLargeException;
 use Prism\Prism\ValueObjects\ProviderRateLimit;
 
-trait HandlesResponse
+trait ProcessesRateLimits
 {
-    protected function handleResponseExceptions(Response $response): void
-    {
-        if ($response->getStatusCode() === 429) {
-            throw PrismRateLimitedException::make(
-                rateLimits: $this->processRateLimits($response),
-                retryAfter: $response->hasHeader('retry-after')
-                    ? (int) $response->getHeader('retry-after')[0]
-                    : null
-            );
-        }
-
-        if ($response->getStatusCode() === 529) {
-            throw PrismProviderOverloadedException::make(Provider::Anthropic);
-        }
-
-        if ($response->getStatusCode() === 413) {
-            throw PrismRequestTooLargeException::make(Provider::Anthropic);
-        }
-    }
-
     /**
      * @return array<int, ProviderRateLimit>
      */

--- a/src/Providers/DeepSeek/DeepSeek.php
+++ b/src/Providers/DeepSeek/DeepSeek.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\DeepSeek;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
+use Prism\Prism\Concerns\HandlesRequestExceptions;
 use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
@@ -20,7 +21,7 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class DeepSeek implements Provider
 {
-    use InitializesClient;
+    use HandlesRequestExceptions, InitializesClient;
 
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,

--- a/src/Providers/DeepSeek/DeepSeek.php
+++ b/src/Providers/DeepSeek/DeepSeek.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\DeepSeek;
 
-use Closure;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
@@ -21,6 +20,8 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class DeepSeek implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -62,17 +63,14 @@ readonly class DeepSeek implements Provider
 
     /**
      * @param  array<string, mixed>  $options
-     * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $retry
+     * @param  array<mixed>  $retry
      */
-    protected function client(array $options, array $retry, ?string $baseUrl = null): PendingRequest
+    protected function client(array $options = [], array $retry = [], ?string $baseUrl = null): PendingRequest
     {
-        $baseUrl ??= $this->url;
-
-        return Http::withHeaders(array_filter([
-            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
-        ]))
+        return $this->baseClient()
+            ->when($this->apiKey, fn ($client) => $client->withToken($this->apiKey))
             ->withOptions($options)
-            ->retry(...$retry)
-            ->baseUrl($baseUrl);
+            ->when($retry !== [], fn ($client) => $client->retry(...$retry))
+            ->baseUrl($baseUrl ?? $this->url);
     }
 }

--- a/src/Providers/DeepSeek/Handlers/Structured.php
+++ b/src/Providers/DeepSeek/Handlers/Structured.php
@@ -17,7 +17,6 @@ use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class Structured
 {
@@ -33,17 +32,13 @@ class Structured
 
     public function handle(Request $request): StructuredResponse
     {
-        try {
-            $request = $this->appendMessageForJsonMode($request);
+        $request = $this->appendMessageForJsonMode($request);
 
-            $data = $this->sendRequest($request);
+        $data = $this->sendRequest($request);
 
-            $this->validateResponse($data);
+        $this->validateResponse($data);
 
-            return $this->createResponse($request, $data);
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        return $this->createResponse($request, $data);
     }
 
     /**

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -24,7 +24,6 @@ use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\ToolResult;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class Text
 {
@@ -103,25 +102,21 @@ class Text
      */
     protected function sendRequest(Request $request): array
     {
-        try {
-            $response = $this->client->post(
-                'chat/completions',
-                array_merge([
-                    'model' => $request->model(),
-                    'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                    'max_completion_tokens' => $request->maxTokens(),
-                ], Arr::whereNotNull([
-                    'temperature' => $request->temperature(),
-                    'top_p' => $request->topP(),
-                    'tools' => ToolMap::map($request->tools()),
-                    'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
-                ]))
-            );
+        $response = $this->client->post(
+            'chat/completions',
+            array_merge([
+                'model' => $request->model(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                'max_completion_tokens' => $request->maxTokens(),
+            ], Arr::whereNotNull([
+                'temperature' => $request->temperature(),
+                'top_p' => $request->topP(),
+                'tools' => ToolMap::map($request->tools()),
+                'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+            ]))
+        );
 
-            return $response->json();
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        return $response->json();
     }
 
     /**

--- a/src/Providers/Gemini/Concerns/ValidatesResponse.php
+++ b/src/Providers/Gemini/Concerns/ValidatesResponse.php
@@ -6,16 +6,11 @@ namespace Prism\Prism\Providers\Gemini\Concerns;
 
 use Illuminate\Http\Client\Response;
 use Prism\Prism\Exceptions\PrismException;
-use Prism\Prism\Exceptions\PrismRateLimitedException;
 
 trait ValidatesResponse
 {
     protected function validateResponse(Response $response): void
     {
-        if ($response->getStatusCode() === 429) {
-            throw new PrismRateLimitedException([]);
-        }
-
         $data = $response->json();
 
         if (! $data || data_get($data, 'error')) {

--- a/src/Providers/Gemini/Gemini.php
+++ b/src/Providers/Gemini/Gemini.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\Gemini;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
+use Prism\Prism\Concerns\HandlesRequestExceptions;
 use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Message;
 use Prism\Prism\Contracts\Provider;
@@ -26,7 +27,7 @@ use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 readonly class Gemini implements Provider
 {
-    use InitializesClient;
+    use HandlesRequestExceptions, InitializesClient;
 
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,

--- a/src/Providers/Gemini/Gemini.php
+++ b/src/Providers/Gemini/Gemini.php
@@ -6,7 +6,7 @@ namespace Prism\Prism\Providers\Gemini;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Message;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
@@ -26,6 +26,8 @@ use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 readonly class Gemini implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -109,18 +111,12 @@ readonly class Gemini implements Provider
      */
     protected function client(array $options = [], array $retry = [], ?string $baseUrl = null): PendingRequest
     {
-        $baseUrl ??= $this->url;
-
-        $client = Http::withOptions($options)
+        return $this->baseClient()
             ->withHeaders([
                 'x-goog-api-key' => $this->apiKey,
             ])
-            ->baseUrl($baseUrl);
-
-        if ($retry !== []) {
-            return $client->retry(...$retry);
-        }
-
-        return $client;
+            ->withOptions($options)
+            ->when($retry !== [], fn ($client) => $client->retry(...$retry))
+            ->baseUrl($baseUrl ?? $this->url);
     }
 }

--- a/src/Providers/Gemini/Handlers/Embeddings.php
+++ b/src/Providers/Gemini/Handlers/Embeddings.php
@@ -10,11 +10,9 @@ use Illuminate\Support\Arr;
 use Prism\Prism\Embeddings\Request;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
 use Prism\Prism\Exceptions\PrismException;
-use Prism\Prism\Exceptions\PrismRateLimitedException;
 use Prism\Prism\ValueObjects\Embedding;
 use Prism\Prism\ValueObjects\EmbeddingsUsage;
 use Prism\Prism\ValueObjects\Meta;
-use Throwable;
 
 class Embeddings
 {
@@ -26,15 +24,7 @@ class Embeddings
             throw new PrismException('Gemini Error: Prism currently only supports one input at a time with Gemini.');
         }
 
-        try {
-            $response = $this->sendRequest($request);
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
-
-        if ($response->getStatusCode() === 429) {
-            throw new PrismRateLimitedException([]);
-        }
+        $response = $this->sendRequest($request);
 
         $data = $response->json();
 

--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -16,7 +16,6 @@ use Prism\Prism\Structured\Step;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class Structured
 {
@@ -51,32 +50,28 @@ class Structured
      */
     public function sendRequest(Request $request): array
     {
-        try {
-            $providerOptions = $request->providerOptions();
+        $providerOptions = $request->providerOptions();
 
-            $response = $this->client->post(
-                "{$request->model()}:generateContent",
-                Arr::whereNotNull([
-                    ...(new MessageMap($request->messages(), $request->systemPrompts()))(),
-                    'cachedContent' => $providerOptions['cachedContentName'] ?? null,
-                    'generationConfig' => Arr::whereNotNull([
-                        'response_mime_type' => 'application/json',
-                        'response_schema' => (new SchemaMap($request->schema()))->toArray(),
-                        'temperature' => $request->temperature(),
-                        'topP' => $request->topP(),
-                        'maxOutputTokens' => $request->maxTokens(),
-                        'thinkingConfig' => Arr::whereNotNull([
-                            'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-                        ]) ?: null,
-                    ]),
-                    'safetySettings' => $providerOptions['safetySettings'] ?? null,
-                ])
-            );
+        $response = $this->client->post(
+            "{$request->model()}:generateContent",
+            Arr::whereNotNull([
+                ...(new MessageMap($request->messages(), $request->systemPrompts()))(),
+                'cachedContent' => $providerOptions['cachedContentName'] ?? null,
+                'generationConfig' => Arr::whereNotNull([
+                    'response_mime_type' => 'application/json',
+                    'response_schema' => (new SchemaMap($request->schema()))->toArray(),
+                    'temperature' => $request->temperature(),
+                    'topP' => $request->topP(),
+                    'maxOutputTokens' => $request->maxTokens(),
+                    'thinkingConfig' => Arr::whereNotNull([
+                        'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
+                    ]) ?: null,
+                ]),
+                'safetySettings' => $providerOptions['safetySettings'] ?? null,
+            ])
+        );
 
-            return $response->json();
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        return $response->json();
     }
 
     /**

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -28,7 +28,6 @@ use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\ProviderTool;
 use Prism\Prism\ValueObjects\ToolResult;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class Text
 {
@@ -76,53 +75,49 @@ class Text
 
     protected function sendRequest(Request $request): ClientResponse
     {
-        try {
-            $providerOptions = $request->providerOptions();
+        $providerOptions = $request->providerOptions();
 
-            $thinkingConfig = Arr::whereNotNull([
-                'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
-            ]);
+        $thinkingConfig = Arr::whereNotNull([
+            'thinkingBudget' => $providerOptions['thinkingBudget'] ?? null,
+        ]);
 
-            $generationConfig = Arr::whereNotNull([
-                'temperature' => $request->temperature(),
-                'topP' => $request->topP(),
-                'maxOutputTokens' => $request->maxTokens(),
-                'thinkingConfig' => $thinkingConfig !== [] ? $thinkingConfig : null,
-            ]);
+        $generationConfig = Arr::whereNotNull([
+            'temperature' => $request->temperature(),
+            'topP' => $request->topP(),
+            'maxOutputTokens' => $request->maxTokens(),
+            'thinkingConfig' => $thinkingConfig !== [] ? $thinkingConfig : null,
+        ]);
 
-            if ($request->tools() !== [] && $request->providerTools() != []) {
-                throw new Exception('Use of provider tools with custom tools is not currently supported by Gemini.');
-            }
-
-            $tools = [];
-
-            if ($request->providerTools() !== []) {
-                $tools = [
-                    Arr::mapWithKeys(
-                        $request->providerTools(),
-                        fn (ProviderTool $providerTool): array => [$providerTool->type => (object) []]
-                    ),
-                ];
-            }
-
-            if ($request->tools() !== []) {
-                $tools['function_declarations'] = ToolMap::map($request->tools());
-            }
-
-            return $this->client->post(
-                "{$request->model()}:generateContent",
-                Arr::whereNotNull([
-                    ...(new MessageMap($request->messages(), $request->systemPrompts()))(),
-                    'cachedContent' => $providerOptions['cachedContentName'] ?? null,
-                    'generationConfig' => $generationConfig !== [] ? $generationConfig : null,
-                    'tools' => $tools !== [] ? $tools : null,
-                    'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
-                    'safetySettings' => $providerOptions['safetySettings'] ?? null,
-                ])
-            );
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
+        if ($request->tools() !== [] && $request->providerTools() != []) {
+            throw new Exception('Use of provider tools with custom tools is not currently supported by Gemini.');
         }
+
+        $tools = [];
+
+        if ($request->providerTools() !== []) {
+            $tools = [
+                Arr::mapWithKeys(
+                    $request->providerTools(),
+                    fn (ProviderTool $providerTool): array => [$providerTool->type => (object) []]
+                ),
+            ];
+        }
+
+        if ($request->tools() !== []) {
+            $tools['function_declarations'] = ToolMap::map($request->tools());
+        }
+
+        return $this->client->post(
+            "{$request->model()}:generateContent",
+            Arr::whereNotNull([
+                ...(new MessageMap($request->messages(), $request->systemPrompts()))(),
+                'cachedContent' => $providerOptions['cachedContentName'] ?? null,
+                'generationConfig' => $generationConfig !== [] ? $generationConfig : null,
+                'tools' => $tools !== [] ? $tools : null,
+                'tool_config' => $request->toolChoice() ? ToolChoiceMap::map($request->toolChoice()) : null,
+                'safetySettings' => $providerOptions['safetySettings'] ?? null,
+            ])
+        );
     }
 
     /**

--- a/src/Providers/Groq/Concerns/ProcessRateLimits.php
+++ b/src/Providers/Groq/Concerns/ProcessRateLimits.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\Groq\Concerns;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
+
+trait ProcessRateLimits
+{
+    /**
+     * @return ProviderRateLimit[]
+     */
+    protected function processRateLimits(Response $response): array
+    {
+        $limitHeaders = array_filter(
+            $response->getHeaders(),
+            fn ($headerName) => Str::startsWith($headerName, 'x-ratelimit-'),
+            ARRAY_FILTER_USE_KEY
+        );
+
+        $rateLimits = [];
+
+        foreach ($limitHeaders as $headerName => $headerValues) {
+            $limitName = Str::of($headerName)->afterLast('-')->toString();
+            $fieldName = Str::of($headerName)->after('x-ratelimit-')->beforeLast('-')->toString();
+
+            $rateLimits[$limitName][$fieldName] = $headerValues[0];
+        }
+
+        return array_values(Arr::map($rateLimits, function ($fields, $limitName): ProviderRateLimit {
+            $resetsAt = data_get($fields, 'reset', '');
+
+            if (str_contains($resetsAt, 'ms')) {
+                $resetMilliseconds = Str::of($resetsAt)->before('ms')->toString();
+                $resetMinutes = 0;
+                $resetSeconds = 0;
+            } else {
+                $resetMilliseconds = 0;
+
+                $resetMinutes = str_contains($resetsAt, 'm')
+                    ? Str::of($resetsAt)->before('m')->toString()
+                    : 0;
+
+                $resetSeconds = str_contains($resetsAt, 'm')
+                    ? Str::of($resetsAt)->after('m')->before('s')->toString()
+                    : Str::of($resetsAt)->before('s')->toString();
+            }
+
+            return new ProviderRateLimit(
+                name: $limitName,
+                limit: data_get($fields, 'limit') !== null
+                    ? (int) data_get($fields, 'limit')
+                    : null,
+                remaining: data_get($fields, 'remaining') !== null
+                    ? (int) data_get($fields, 'remaining')
+                    : null,
+                resetsAt: data_get($fields, 'reset') !== null
+                    ? Carbon::now()->addMinutes((int) $resetMinutes)->addSeconds((int) $resetSeconds)->addMilliseconds((int) $resetMilliseconds)
+                    : null
+            );
+        }));
+    }
+}

--- a/src/Providers/Groq/Concerns/ValidateResponse.php
+++ b/src/Providers/Groq/Concerns/ValidateResponse.php
@@ -5,24 +5,13 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\Groq\Concerns;
 
 use Illuminate\Http\Client\Response;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
 use Prism\Prism\Exceptions\PrismException;
-use Prism\Prism\Exceptions\PrismRateLimitedException;
 use Prism\Prism\ValueObjects\ProviderRateLimit;
 
 trait ValidateResponse
 {
     protected function validateResponse(Response $response): void
     {
-        if ($response->getStatusCode() === 429) {
-            throw PrismRateLimitedException::make(
-                rateLimits: $this->processRateLimits($response),
-                retryAfter: (int) $response->header('retry-after')
-            );
-        }
-
         $data = $response->json();
 
         if (! $data || data_get($data, 'error')) {
@@ -39,54 +28,5 @@ trait ValidateResponse
     /**
      * @return ProviderRateLimit[]
      */
-    protected function processRateLimits(Response $response): array
-    {
-        $limitHeaders = array_filter(
-            $response->getHeaders(),
-            fn ($headerName) => Str::startsWith($headerName, 'x-ratelimit-'),
-            ARRAY_FILTER_USE_KEY
-        );
-
-        $rateLimits = [];
-
-        foreach ($limitHeaders as $headerName => $headerValues) {
-            $limitName = Str::of($headerName)->afterLast('-')->toString();
-            $fieldName = Str::of($headerName)->after('x-ratelimit-')->beforeLast('-')->toString();
-
-            $rateLimits[$limitName][$fieldName] = $headerValues[0];
-        }
-
-        return array_values(Arr::map($rateLimits, function ($fields, $limitName): ProviderRateLimit {
-            $resetsAt = data_get($fields, 'reset', '');
-
-            if (str_contains($resetsAt, 'ms')) {
-                $resetMilliseconds = Str::of($resetsAt)->before('ms')->toString();
-                $resetMinutes = 0;
-                $resetSeconds = 0;
-            } else {
-                $resetMilliseconds = 0;
-
-                $resetMinutes = str_contains($resetsAt, 'm')
-                    ? Str::of($resetsAt)->before('m')->toString()
-                    : 0;
-
-                $resetSeconds = str_contains($resetsAt, 'm')
-                    ? Str::of($resetsAt)->after('m')->before('s')->toString()
-                    : Str::of($resetsAt)->before('s')->toString();
-            }
-
-            return new ProviderRateLimit(
-                name: $limitName,
-                limit: data_get($fields, 'limit') !== null
-                    ? (int) data_get($fields, 'limit')
-                    : null,
-                remaining: data_get($fields, 'remaining') !== null
-                    ? (int) data_get($fields, 'remaining')
-                    : null,
-                resetsAt: data_get($fields, 'reset') !== null
-                    ? Carbon::now()->addMinutes((int) $resetMinutes)->addSeconds((int) $resetSeconds)->addMilliseconds((int) $resetMilliseconds)
-                    : null
-            );
-        }));
-    }
+    abstract protected function processRateLimits(Response $response): array;
 }

--- a/src/Providers/Groq/Groq.php
+++ b/src/Providers/Groq/Groq.php
@@ -6,21 +6,28 @@ namespace Prism\Prism\Providers\Groq;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
 use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Enums\Provider as ProviderName;
 use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Providers\Groq\Concerns\ProcessRateLimits;
 use Prism\Prism\Providers\Groq\Handlers\Structured;
 use Prism\Prism\Providers\Groq\Handlers\Text;
 use Prism\Prism\Structured\Request as StructuredRequest;
 use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Text\Request as TextRequest;
 use Prism\Prism\Text\Response as TextResponse;
+use Throwable;
 
 readonly class Groq implements Provider
 {
-    use InitializesClient;
+    use InitializesClient, ProcessRateLimits;
 
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
@@ -53,6 +60,27 @@ readonly class Groq implements Provider
     public function stream(TextRequest $request): Generator
     {
         throw PrismException::unsupportedProviderAction(__METHOD__, class_basename($this));
+    }
+
+    public function handleRequestExceptions(string $model, Throwable $e): never
+    {
+        if ($e instanceof PrismException) {
+            throw $e;
+        }
+
+        if (! $e instanceof RequestException) {
+            throw PrismException::providerRequestError($model, $e);
+        }
+
+        match ($e->response->getStatusCode()) {
+            429 => throw PrismRateLimitedException::make(
+                rateLimits: $this->processRateLimits($e->response),
+                retryAfter: (int) $e->response->header('retry-after')
+            ),
+            529 => throw PrismProviderOverloadedException::make(ProviderName::Groq),
+            413 => throw PrismRequestTooLargeException::make(ProviderName::Groq),
+            default => throw PrismException::providerRequestError($model, $e),
+        };
     }
 
     /**

--- a/src/Providers/Groq/Groq.php
+++ b/src/Providers/Groq/Groq.php
@@ -6,7 +6,7 @@ namespace Prism\Prism\Providers\Groq;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
@@ -20,6 +20,8 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class Groq implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -57,13 +59,12 @@ readonly class Groq implements Provider
      * @param  array<string, mixed>  $options
      * @param  array<mixed>  $retry
      */
-    protected function client(array $options = [], array $retry = []): PendingRequest
+    protected function client(array $options = [], array $retry = [], ?string $baseUrl = null): PendingRequest
     {
-        return Http::withHeaders(array_filter([
-            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
-        ]))
+        return $this->baseClient()
+            ->when($this->apiKey, fn ($client) => $client->withToken($this->apiKey))
             ->withOptions($options)
-            ->retry(...$retry)
-            ->baseUrl($this->url);
+            ->when($retry !== [], fn ($client) => $client->retry(...$retry))
+            ->baseUrl($baseUrl ?? $this->url);
     }
 }

--- a/src/Providers/Mistral/Concerns/ProcessRateLimits.php
+++ b/src/Providers/Mistral/Concerns/ProcessRateLimits.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Providers\Mistral\Concerns;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Carbon;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
+
+trait ProcessRateLimits
+{
+    /**
+     * @return ProviderRateLimit[]
+     */
+    protected function processRateLimits(Response $response): array
+    {
+        return [
+            new ProviderRateLimit(
+                name: 'tokens',
+                limit: (int) $response->header('ratelimitbysize-limit'),
+                remaining: (int) $response->header('ratelimitbysize-remaining'),
+                resetsAt: Carbon::now()->addSeconds((int) $response->header('ratelimitbysize-reset')),
+            ),
+        ];
+    }
+}

--- a/src/Providers/Mistral/Concerns/ValidatesResponse.php
+++ b/src/Providers/Mistral/Concerns/ValidatesResponse.php
@@ -5,22 +5,13 @@ declare(strict_types=1);
 namespace Prism\Prism\Providers\Mistral\Concerns;
 
 use Illuminate\Http\Client\Response;
-use Illuminate\Support\Carbon;
 use Prism\Prism\Exceptions\PrismException;
-use Prism\Prism\Exceptions\PrismRateLimitedException;
 use Prism\Prism\ValueObjects\ProviderRateLimit;
 
 trait ValidatesResponse
 {
     protected function validateResponse(Response $response): void
     {
-        if ($response->getStatusCode() === 429) {
-            throw PrismRateLimitedException::make(
-                rateLimits: $this->processRateLimits($response),
-                retryAfter: null
-            );
-        }
-
         $data = $response->json();
 
         if (! $data || data_get($data, 'object') === 'error') {
@@ -39,15 +30,5 @@ trait ValidatesResponse
     /**
      * @return ProviderRateLimit[]
      */
-    protected function processRateLimits(Response $response): array
-    {
-        return [
-            new ProviderRateLimit(
-                name: 'tokens',
-                limit: (int) $response->header('ratelimitbysize-limit'),
-                remaining: (int) $response->header('ratelimitbysize-remaining'),
-                resetsAt: Carbon::now()->addSeconds((int) $response->header('ratelimitbysize-reset')),
-            ),
-        ];
-    }
+    abstract protected function processRateLimits(Response $response): array;
 }

--- a/src/Providers/Mistral/Handlers/Embeddings.php
+++ b/src/Providers/Mistral/Handlers/Embeddings.php
@@ -8,26 +8,21 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Prism\Prism\Embeddings\Request;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
-use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Providers\Mistral\Concerns\ProcessRateLimits;
 use Prism\Prism\Providers\Mistral\Concerns\ValidatesResponse;
 use Prism\Prism\ValueObjects\Embedding;
 use Prism\Prism\ValueObjects\EmbeddingsUsage;
 use Prism\Prism\ValueObjects\Meta;
-use Throwable;
 
 class Embeddings
 {
-    use ValidatesResponse;
+    use ProcessRateLimits, ValidatesResponse;
 
     public function __construct(protected PendingRequest $client) {}
 
     public function handle(Request $request): EmbeddingsResponse
     {
-        try {
-            $response = $this->sendRequest($request);
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        $response = $this->sendRequest($request);
 
         $this->validateResponse($response);
 

--- a/src/Providers/Mistral/Handlers/OCR.php
+++ b/src/Providers/Mistral/Handlers/OCR.php
@@ -9,17 +9,18 @@ use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Exceptions\PrismRateLimitedException;
 use Prism\Prism\Providers\Mistral\Concerns\MapsFinishReason;
+use Prism\Prism\Providers\Mistral\Concerns\ProcessRateLimits;
 use Prism\Prism\Providers\Mistral\Concerns\ValidatesResponse;
 use Prism\Prism\Providers\Mistral\Maps\DocumentMapper;
 use Prism\Prism\Providers\Mistral\ValueObjects\OCRResponse;
 use Prism\Prism\Text\ResponseBuilder;
 use Prism\Prism\ValueObjects\Messages\Support\Document;
-use Throwable;
 
 class OCR
 {
     use CallsTools;
     use MapsFinishReason;
+    use ProcessRateLimits;
     use ValidatesResponse;
 
     protected ResponseBuilder $responseBuilder;
@@ -50,15 +51,11 @@ class OCR
      */
     protected function sendRequest(): array
     {
-        try {
-            $response = $this->client->post('/ocr', [
-                'model' => $this->model,
-                'document' => (new DocumentMapper($this->document))->toPayload(),
-            ]);
+        $response = $this->client->post('/ocr', [
+            'model' => $this->model,
+            'document' => (new DocumentMapper($this->document))->toPayload(),
+        ]);
 
-            return $response->json();
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($this->model, $e);
-        }
+        return $response->json();
     }
 }

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -6,7 +6,7 @@ namespace Prism\Prism\Providers\Mistral;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
@@ -26,6 +26,8 @@ use Prism\Prism\ValueObjects\Messages\Support\Document;
 
 readonly class Mistral implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -103,18 +105,12 @@ readonly class Mistral implements Provider
      * @param  array<string, mixed>  $options
      * @param  array<mixed>  $retry
      */
-    protected function client(array $options = [], array $retry = []): PendingRequest
+    protected function client(array $options = [], array $retry = [], ?string $baseUrl = null): PendingRequest
     {
-        $client = Http::withHeaders(array_filter([
-            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
-        ]))
+        return $this->baseClient()
+            ->when($this->apiKey, fn ($client) => $client->withToken($this->apiKey))
             ->withOptions($options)
-            ->baseUrl($this->url);
-
-        if ($retry !== []) {
-            return $client->retry(...$retry);
-        }
-
-        return $client;
+            ->when($retry !== [], fn ($client) => $client->retry(...$retry))
+            ->baseUrl($baseUrl ?? $this->url);
     }
 }

--- a/src/Providers/Ollama/Handlers/Embeddings.php
+++ b/src/Providers/Ollama/Handlers/Embeddings.php
@@ -13,7 +13,6 @@ use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\ValueObjects\Embedding;
 use Prism\Prism\ValueObjects\EmbeddingsUsage;
 use Prism\Prism\ValueObjects\Meta;
-use Throwable;
 
 class Embeddings
 {
@@ -21,12 +20,8 @@ class Embeddings
 
     public function handle(Request $request): EmbeddingsResponse
     {
-        try {
-            $response = $this->sendRequest($request);
-            $data = $response->json();
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        $response = $this->sendRequest($request);
+        $data = $response->json();
 
         if (! $data || data_get($data, 'error')) {
             throw PrismException::providerResponseError(sprintf(

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -17,7 +17,6 @@ use Prism\Prism\Structured\Step;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class Structured
 {
@@ -81,23 +80,19 @@ class Structured
             throw new PrismException('Ollama does not support multiple system prompts using withSystemPrompt / withSystemPrompts. However, you can provide additional system prompts by including SystemMessages in with withMessages.');
         }
 
-        try {
-            $response = $this->client->post('api/chat', [
-                'model' => $request->model(),
-                'system' => data_get($request->systemPrompts(), '0.content', ''),
-                'messages' => (new MessageMap($request->messages()))->map(),
-                'format' => $request->schema()->toArray(),
-                'stream' => false,
-                'options' => Arr::whereNotNull(array_merge([
-                    'temperature' => $request->temperature(),
-                    'num_predict' => $request->maxTokens() ?? 2048,
-                    'top_p' => $request->topP(),
-                ], $request->providerOptions())),
-            ]);
+        $response = $this->client->post('api/chat', [
+            'model' => $request->model(),
+            'system' => data_get($request->systemPrompts(), '0.content', ''),
+            'messages' => (new MessageMap($request->messages()))->map(),
+            'format' => $request->schema()->toArray(),
+            'stream' => false,
+            'options' => Arr::whereNotNull(array_merge([
+                'temperature' => $request->temperature(),
+                'num_predict' => $request->maxTokens() ?? 2048,
+                'top_p' => $request->topP(),
+            ], $request->providerOptions())),
+        ]);
 
-            return $response->json();
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        return $response->json();
     }
 }

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -23,7 +23,6 @@ use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\ToolCall;
 use Prism\Prism\ValueObjects\ToolResult;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class Text
 {
@@ -73,26 +72,22 @@ class Text
             throw new PrismException('Ollama does not support multiple system prompts using withSystemPrompt / withSystemPrompts. However, you can provide additional system prompts by including SystemMessages in with withMessages.');
         }
 
-        try {
-            $response = $this
-                ->client
-                ->post('api/chat', [
-                    'model' => $request->model(),
-                    'system' => data_get($request->systemPrompts(), '0.content', ''),
-                    'messages' => (new MessageMap($request->messages()))->map(),
-                    'tools' => ToolMap::map($request->tools()),
-                    'stream' => false,
-                    'options' => Arr::whereNotNull(array_merge([
-                        'temperature' => $request->temperature(),
-                        'num_predict' => $request->maxTokens() ?? 2048,
-                        'top_p' => $request->topP(),
-                    ], $request->providerOptions())),
-                ]);
+        $response = $this
+            ->client
+            ->post('api/chat', [
+                'model' => $request->model(),
+                'system' => data_get($request->systemPrompts(), '0.content', ''),
+                'messages' => (new MessageMap($request->messages()))->map(),
+                'tools' => ToolMap::map($request->tools()),
+                'stream' => false,
+                'options' => Arr::whereNotNull(array_merge([
+                    'temperature' => $request->temperature(),
+                    'num_predict' => $request->maxTokens() ?? 2048,
+                    'top_p' => $request->topP(),
+                ], $request->providerOptions())),
+            ]);
 
-            return $response->json();
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        return $response->json();
     }
 
     /**

--- a/src/Providers/Ollama/Ollama.php
+++ b/src/Providers/Ollama/Ollama.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\Ollama;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
+use Prism\Prism\Concerns\HandlesRequestExceptions;
 use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingsRequest;
@@ -21,7 +22,7 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class Ollama implements Provider
 {
-    use InitializesClient;
+    use HandlesRequestExceptions, InitializesClient;
 
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,

--- a/src/Providers/OpenAI/Concerns/ValidatesResponse.php
+++ b/src/Providers/OpenAI/Concerns/ValidatesResponse.php
@@ -6,19 +6,11 @@ namespace Prism\Prism\Providers\OpenAI\Concerns;
 
 use Illuminate\Http\Client\Response;
 use Prism\Prism\Exceptions\PrismException;
-use Prism\Prism\Exceptions\PrismRateLimitedException;
 
 trait ValidatesResponse
 {
     protected function validateResponse(Response $response): void
     {
-        if ($response->getStatusCode() === 429) {
-            throw PrismRateLimitedException::make(
-                rateLimits: $this->processRateLimits($response),
-                retryAfter: $response->header('retry-after') === '' ? null : (int) $response->header('retry-after'),
-            );
-        }
-
         $data = $response->json();
 
         if (! $data || data_get($data, 'error')) {

--- a/src/Providers/OpenAI/Handlers/Embeddings.php
+++ b/src/Providers/OpenAI/Handlers/Embeddings.php
@@ -8,13 +8,11 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Prism\Prism\Embeddings\Request;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
-use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
 use Prism\Prism\Providers\OpenAI\Concerns\ValidatesResponse;
 use Prism\Prism\ValueObjects\Embedding;
 use Prism\Prism\ValueObjects\EmbeddingsUsage;
 use Prism\Prism\ValueObjects\Meta;
-use Throwable;
 
 class Embeddings
 {
@@ -24,11 +22,7 @@ class Embeddings
 
     public function handle(Request $request): EmbeddingsResponse
     {
-        try {
-            $response = $this->sendRequest($request);
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        $response = $this->sendRequest($request);
 
         $this->validateResponse($response);
 

--- a/src/Providers/OpenAI/Handlers/Stream.php
+++ b/src/Providers/OpenAI/Handlers/Stream.php
@@ -6,7 +6,6 @@ namespace Prism\Prism\Providers\OpenAI\Handlers;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -14,8 +13,6 @@ use Prism\Prism\Concerns\CallsTools;
 use Prism\Prism\Enums\ChunkType;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Exceptions\PrismChunkDecodeException;
-use Prism\Prism\Exceptions\PrismException;
-use Prism\Prism\Exceptions\PrismRateLimitedException;
 use Prism\Prism\Providers\OpenAI\Concerns\ProcessesRateLimits;
 use Prism\Prism\Providers\OpenAI\Maps\FinishReasonMap;
 use Prism\Prism\Providers\OpenAI\Maps\MessageMap;
@@ -321,35 +318,26 @@ class Stream
 
     protected function sendRequest(Request $request): Response
     {
-        try {
-            return $this
-                ->client
-                ->withOptions(['stream' => true])
-                ->throw()
-                ->post(
-                    'responses',
-                    array_merge([
-                        'stream' => true,
-                        'model' => $request->model(),
-                        'input' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                        'max_output_tokens' => $request->maxTokens(),
-                    ], Arr::whereNotNull([
-                        'temperature' => $request->temperature(),
-                        'top_p' => $request->topP(),
-                        'metadata' => $request->providerOptions('metadata'),
-                        'tools' => ToolMap::map($request->tools()),
-                        'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
-                        'previous_response_id' => $request->providerOptions('previous_response_id'),
-                        'truncation' => $request->providerOptions('truncation'),
-                    ]))
-                );
-        } catch (Throwable $e) {
-            if ($e instanceof RequestException && $e->response->getStatusCode() === 429) {
-                throw new PrismRateLimitedException($this->processRateLimits($e->response));
-            }
-
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        return $this
+            ->client
+            ->withOptions(['stream' => true])
+            ->post(
+                'responses',
+                array_merge([
+                    'stream' => true,
+                    'model' => $request->model(),
+                    'input' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                    'max_output_tokens' => $request->maxTokens(),
+                ], Arr::whereNotNull([
+                    'temperature' => $request->temperature(),
+                    'top_p' => $request->topP(),
+                    'metadata' => $request->providerOptions('metadata'),
+                    'tools' => ToolMap::map($request->tools()),
+                    'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                    'previous_response_id' => $request->providerOptions('previous_response_id'),
+                    'truncation' => $request->providerOptions('truncation'),
+                ]))
+            );
     }
 
     protected function readLine(StreamInterface $stream): string

--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -20,7 +20,6 @@ use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class Structured
 {
@@ -93,27 +92,23 @@ class Structured
      */
     protected function sendRequest(Request $request, array $responseFormat): ClientResponse
     {
-        try {
-            return $this->client->post(
-                'responses',
-                array_merge([
-                    'model' => $request->model(),
-                    'input' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                    'max_output_tokens' => $request->maxTokens(),
-                ], Arr::whereNotNull([
-                    'temperature' => $request->temperature(),
-                    'top_p' => $request->topP(),
-                    'metadata' => $request->providerOptions('metadata'),
-                    'previous_response_id' => $request->providerOptions('previous_response_id'),
-                    'truncation' => $request->providerOptions('truncation'),
-                    'text' => [
-                        'format' => $responseFormat,
-                    ],
-                ]))
-            );
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        return $this->client->post(
+            'responses',
+            array_merge([
+                'model' => $request->model(),
+                'input' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                'max_output_tokens' => $request->maxTokens(),
+            ], Arr::whereNotNull([
+                'temperature' => $request->temperature(),
+                'top_p' => $request->topP(),
+                'metadata' => $request->providerOptions('metadata'),
+                'previous_response_id' => $request->providerOptions('previous_response_id'),
+                'truncation' => $request->providerOptions('truncation'),
+                'text' => [
+                    'format' => $responseFormat,
+                ],
+            ]))
+        );
     }
 
     protected function handleAutoMode(Request $request): ClientResponse

--- a/src/Providers/OpenAI/Handlers/Text.php
+++ b/src/Providers/OpenAI/Handlers/Text.php
@@ -27,7 +27,6 @@ use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\ProviderTool;
 use Prism\Prism\ValueObjects\ToolResult;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class Text
 {
@@ -108,26 +107,22 @@ class Text
 
     protected function sendRequest(Request $request): ClientResponse
     {
-        try {
-            return $this->client->post(
-                'responses',
-                array_merge([
-                    'model' => $request->model(),
-                    'input' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                    'max_output_tokens' => $request->maxTokens(),
-                ], Arr::whereNotNull([
-                    'temperature' => $request->temperature(),
-                    'top_p' => $request->topP(),
-                    'metadata' => $request->providerOptions('metadata'),
-                    'tools' => $this->buildTools($request),
-                    'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
-                    'previous_response_id' => $request->providerOptions('previous_response_id'),
-                    'truncation' => $request->providerOptions('truncation'),
-                ]))
-            );
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        return $this->client->post(
+            'responses',
+            array_merge([
+                'model' => $request->model(),
+                'input' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                'max_output_tokens' => $request->maxTokens(),
+            ], Arr::whereNotNull([
+                'temperature' => $request->temperature(),
+                'top_p' => $request->topP(),
+                'metadata' => $request->providerOptions('metadata'),
+                'tools' => $this->buildTools($request),
+                'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                'previous_response_id' => $request->providerOptions('previous_response_id'),
+                'truncation' => $request->providerOptions('truncation'),
+            ]))
+        );
     }
 
     /**

--- a/src/Providers/VoyageAI/VoyageAI.php
+++ b/src/Providers/VoyageAI/VoyageAI.php
@@ -4,7 +4,7 @@ namespace Prism\Prism\Providers\VoyageAI;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingsResponse;
@@ -16,6 +16,8 @@ use Prism\Prism\Text\Response as TextResponse;
 
 class VoyageAI implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] protected string $apiKey,
         protected string $baseUrl
@@ -54,11 +56,12 @@ class VoyageAI implements Provider
      * @param  array<string, mixed>  $options
      * @param  array<mixed>  $retry
      */
-    protected function client(array $options = [], array $retry = []): PendingRequest
+    protected function client(array $options = [], array $retry = [], ?string $baseUrl = null): PendingRequest
     {
-        return Http::withToken($this->apiKey)
+        return $this->baseClient()
+            ->when($this->apiKey, fn ($client) => $client->withToken($this->apiKey))
             ->withOptions($options)
-            ->retry(...$retry)
-            ->baseUrl($this->baseUrl);
+            ->when($retry !== [], fn ($client) => $client->retry(...$retry))
+            ->baseUrl($baseUrl ?? $this->baseUrl);
     }
 }

--- a/src/Providers/VoyageAI/VoyageAI.php
+++ b/src/Providers/VoyageAI/VoyageAI.php
@@ -4,6 +4,7 @@ namespace Prism\Prism\Providers\VoyageAI;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
+use Prism\Prism\Concerns\HandlesRequestExceptions;
 use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
@@ -16,7 +17,7 @@ use Prism\Prism\Text\Response as TextResponse;
 
 class VoyageAI implements Provider
 {
-    use InitializesClient;
+    use HandlesRequestExceptions, InitializesClient;
 
     public function __construct(
         #[\SensitiveParameter] protected string $apiKey,

--- a/src/Providers/XAI/Concerns/ValidatesResponses.php
+++ b/src/Providers/XAI/Concerns/ValidatesResponses.php
@@ -6,16 +6,11 @@ namespace Prism\Prism\Providers\XAI\Concerns;
 
 use Illuminate\Http\Client\Response;
 use Prism\Prism\Exceptions\PrismException;
-use Prism\Prism\Exceptions\PrismRateLimitedException;
 
 trait ValidatesResponses
 {
     protected function validateResponse(Response $response): void
     {
-        if ($response->getStatusCode() === 429) {
-            throw new PrismRateLimitedException([]);
-        }
-
         $data = $response->json();
 
         if (! $data || data_get($data, 'error')) {

--- a/src/Providers/XAI/Handlers/Text.php
+++ b/src/Providers/XAI/Handlers/Text.php
@@ -25,7 +25,6 @@ use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\ToolCall;
 use Prism\Prism\ValueObjects\ToolResult;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class Text
 {
@@ -102,23 +101,19 @@ class Text
 
     protected function sendRequest(Request $request): ClientResponse
     {
-        try {
-            return $this->client->post(
-                'chat/completions',
-                array_merge([
-                    'model' => $request->model(),
-                    'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
-                    'max_tokens' => $request->maxTokens() ?? 2048,
-                ], Arr::whereNotNull([
-                    'temperature' => $request->temperature(),
-                    'top_p' => $request->topP(),
-                    'tools' => ToolMap::map($request->tools()),
-                    'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
-                ]))
-            );
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        return $this->client->post(
+            'chat/completions',
+            array_merge([
+                'model' => $request->model(),
+                'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                'max_tokens' => $request->maxTokens() ?? 2048,
+            ], Arr::whereNotNull([
+                'temperature' => $request->temperature(),
+                'top_p' => $request->topP(),
+                'tools' => ToolMap::map($request->tools()),
+                'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+            ]))
+        );
     }
 
     /**

--- a/src/Providers/XAI/XAI.php
+++ b/src/Providers/XAI/XAI.php
@@ -6,7 +6,7 @@ namespace Prism\Prism\Providers\XAI;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
@@ -19,6 +19,8 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class XAI implements Provider
 {
+    use InitializesClient;
+
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,
         public string $url,
@@ -54,13 +56,12 @@ readonly class XAI implements Provider
      * @param  array<string, mixed>  $options
      * @param  array<mixed>  $retry
      */
-    protected function client(array $options = [], array $retry = []): PendingRequest
+    protected function client(array $options = [], array $retry = [], ?string $baseUrl = null): PendingRequest
     {
-        return Http::withHeaders(array_filter([
-            'Authorization' => $this->apiKey !== '' && $this->apiKey !== '0' ? sprintf('Bearer %s', $this->apiKey) : null,
-        ]))
+        return $this->baseClient()
+            ->when($this->apiKey, fn ($client) => $client->withToken($this->apiKey))
             ->withOptions($options)
-            ->retry(...$retry)
-            ->baseUrl($this->url);
+            ->when($retry !== [], fn ($client) => $client->retry(...$retry))
+            ->baseUrl($baseUrl ?? $this->url);
     }
 }

--- a/src/Providers/XAI/XAI.php
+++ b/src/Providers/XAI/XAI.php
@@ -6,6 +6,7 @@ namespace Prism\Prism\Providers\XAI;
 
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
+use Prism\Prism\Concerns\HandlesRequestExceptions;
 use Prism\Prism\Concerns\InitializesClient;
 use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
@@ -19,7 +20,7 @@ use Prism\Prism\Text\Response as TextResponse;
 
 readonly class XAI implements Provider
 {
-    use InitializesClient;
+    use HandlesRequestExceptions, InitializesClient;
 
     public function __construct(
         #[\SensitiveParameter] public string $apiKey,

--- a/src/Testing/PrismFake.php
+++ b/src/Testing/PrismFake.php
@@ -12,6 +12,7 @@ use Prism\Prism\Contracts\Provider;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
 use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Structured\Request as StructuredRequest;
 use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Testing\Concerns\CanGenerateFakeChunksFromTextResponses;
@@ -21,6 +22,7 @@ use Prism\Prism\Text\Response as TextResponse;
 use Prism\Prism\ValueObjects\EmbeddingsUsage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\Usage;
+use Throwable;
 
 class PrismFake implements Provider
 {
@@ -121,6 +123,11 @@ class PrismFake implements Provider
         );
 
         yield from $this->chunksFromTextResponse($fixture);
+    }
+
+    public function handleRequestExceptions(string $model, Throwable $e): never
+    {
+        throw PrismException::providerRequestError($model, $e);
     }
 
     /**

--- a/tests/Providers/Mistral/MistralExceptionsTest.php
+++ b/tests/Providers/Mistral/MistralExceptionsTest.php
@@ -28,7 +28,7 @@ it('throws a PrismRateLimitedException with a 429 response code', function (): v
     Prism::text()
         ->using(Provider::Mistral, 'fake-model')
         ->withPrompt('Hello world!')
-        ->generate();
+        ->asText();
 
 })->throws(PrismRateLimitedException::class);
 
@@ -50,7 +50,7 @@ it('sets the correct data on the PrismRateLimitedException', function (): void {
             Prism::text()
                 ->using(Provider::Mistral, 'fake-model')
                 ->withPrompt('Hello world!')
-                ->generate();
+                ->asText();
         } catch (PrismRateLimitedException $e) {
             expect($e->retryAfter)->toEqual(null);
             expect($e->rateLimits)->toHaveCount(1);

--- a/tests/Providers/Mistral/StreamTest.php
+++ b/tests/Providers/Mistral/StreamTest.php
@@ -143,19 +143,11 @@ it('handles invalid stream data correctly', function (): void {
         ->withPrompt('This will trigger invalid JSON')
         ->asStream();
 
-    $exception = null;
-
-    try {
-        // Consume the generator to trigger the exception
-        foreach ($response as $chunk) {
-            // The test should throw before completing
-        }
-    } catch (PrismChunkDecodeException $e) {
-        $exception = $e;
+    // Consume the generator to trigger the exception
+    foreach ($response as $chunk) {
+        // The test should throw before completing
     }
-
-    expect($exception)->toBeInstanceOf(PrismChunkDecodeException::class);
-});
+})->throws(PrismChunkDecodeException::class);
 
 it('respects system prompts in the requests', function (): void {
     Http::fake([

--- a/tests/TestDoubles/TestProvider.php
+++ b/tests/TestDoubles/TestProvider.php
@@ -18,6 +18,7 @@ use Prism\Prism\ValueObjects\EmbeddingsUsage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\ProviderResponse;
 use Prism\Prism\ValueObjects\Usage;
+use Throwable;
 
 class TestProvider implements Provider
 {
@@ -89,6 +90,11 @@ class TestProvider implements Provider
     public function stream(TextRequest $request): Generator
     {
         throw PrismException::unsupportedProviderAction(__METHOD__, class_basename($this));
+    }
+
+    public function handleRequestExceptions(string $model, Throwable $e): never
+    {
+        throw PrismException::providerRequestError($model, $e);
     }
 
     public function withResponse(StructuredResponse|TextResponse $response): Provider


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

### Base client Trait
Add a trait in Provider classes to initialize a base client that can be used in providers `client` method.
A centralize baseClient makes possible to trace http requests using middlewares that are alredy included here even if not used yet.

```php
trait InitializesClient
{
    protected function baseClient(): PendingRequest
    {
        return Http::withRequestMiddleware(fn (RequestInterface $request): RequestInterface => $request)
            ->withResponseMiddleware(fn (ResponseInterface $response): ResponseInterface => $response)
            ->throw();
    }
}
```

`->throw()` is added in `baseClient` to make sure an exception is always raised if a request error happens.

### Exceptions
Exceptions are refactored to be managed in common `Pending` classes instead of separately in each provider handler.
`handleRequestExceptions` from provider class is then called to manage differences between providers when needed while a standard implementation is used for other classes.

```php
// src/Text/PendingRequest.php
    public function asText(): Response
    {
        $request = $this->toRequest();

        try {
            return $this->provider->text($request);
        } catch (Throwable $e) {
            $this->provider->handleRequestExceptions($request->model(), $e);
        }
    }
```

In many cases exceptions where not catched in some provider handles because Http client was called wihout `throw()` so no exception was raised on error making it hard to debug problems, like in #419
