### PR TITLE
fix(anthropic): Anthropic media mappers call validation method

### DIFF
--- a/src/Contracts/ProviderMediaMapper.php
+++ b/src/Contracts/ProviderMediaMapper.php
@@ -10,6 +10,17 @@ abstract class ProviderMediaMapper
 {
     public function __construct(public readonly Media $media)
     {
+        $this->runValidation();
+    }
+
+    abstract public function toPayload(): mixed;
+
+    abstract protected function provider(): string|Provider;
+
+    abstract protected function validateMedia(): bool;
+
+    protected function runValidation(): void
+    {
         if ($this->validateMedia() === false) {
             $providerName = $this->provider() instanceof Provider ? $this->provider()->value : $this->provider();
 
@@ -18,10 +29,4 @@ abstract class ProviderMediaMapper
             throw new PrismException("The $providerName provider does not support the mediums available in the provided `$calledClass`. Pleae consult the Prism documentation for more information on which mediums the $providerName provider supports.");
         }
     }
-
-    abstract public function toPayload(): mixed;
-
-    abstract protected function provider(): string|Provider;
-
-    abstract protected function validateMedia(): bool;
 }

--- a/src/Providers/Anthropic/Maps/DocumentMapper.php
+++ b/src/Providers/Anthropic/Maps/DocumentMapper.php
@@ -19,7 +19,9 @@ class DocumentMapper extends ProviderMediaMapper
         public readonly Media $media,
         public ?array $cacheControl = null,
         public array $requestProviderOptions = [],
-    ) {}
+    ) {
+        $this->runValidation();
+    }
 
     /**
      * @return array<string,mixed>

--- a/src/Providers/Anthropic/Maps/ImageMapper.php
+++ b/src/Providers/Anthropic/Maps/ImageMapper.php
@@ -16,7 +16,9 @@ class ImageMapper extends ProviderMediaMapper
     public function __construct(
         public readonly Media $media,
         public ?array $cacheControl = null,
-    ) {}
+    ) {
+        $this->runValidation();
+    }
 
     /**
      * @return array<string,mixed>


### PR DESCRIPTION
## Description

Anthropic wasn't calling validation on media mappers due to overwriting the constructor.

Not an issue that will have come up as Anthropic supports all current mediums. However, it came up extending the Anthropic mapper for the bedrock provider.