### PR TITLE
fix: make PendingRequest only catch RequestExceptions

### DIFF
--- a/src/Concerns/HandlesRequestExceptions.php
+++ b/src/Concerns/HandlesRequestExceptions.php
@@ -13,7 +13,7 @@ use Throwable;
 
 trait HandlesRequestExceptions
 {
-    public function handleRequestExceptions(string $model, Throwable $e): never
+    public function handleRequestException(string $model, Throwable $e): never
     {
         // Keep already raised PrismException
         if ($e instanceof PrismException) {

--- a/src/Embeddings/PendingRequest.php
+++ b/src/Embeddings/PendingRequest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Embeddings;
 
+use Illuminate\Http\Client\RequestException;
 use Prism\Prism\Concerns\ConfiguresClient;
 use Prism\Prism\Concerns\ConfiguresProviders;
 use Prism\Prism\Concerns\HasProviderOptions;
 use Prism\Prism\Exceptions\PrismException;
-use Throwable;
 
 class PendingRequest
 {
@@ -71,7 +71,7 @@ class PendingRequest
 
         try {
             return $this->provider->embeddings($request);
-        } catch (Throwable $e) {
+        } catch (RequestException $e) {
             $this->provider->handleRequestExceptions($request->model(), $e);
         }
     }

--- a/src/Embeddings/PendingRequest.php
+++ b/src/Embeddings/PendingRequest.php
@@ -72,7 +72,7 @@ class PendingRequest
         try {
             return $this->provider->embeddings($request);
         } catch (RequestException $e) {
-            $this->provider->handleRequestExceptions($request->model(), $e);
+            $this->provider->handleRequestException($request->model(), $e);
         }
     }
 

--- a/src/Images/PendingRequest.php
+++ b/src/Images/PendingRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Images;
 
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\Client\RequestException;
 use Prism\Prism\Concerns\ConfiguresClient;
 use Prism\Prism\Concerns\ConfiguresModels;
 use Prism\Prism\Concerns\ConfiguresProviders;
@@ -28,7 +29,13 @@ class PendingRequest
 
     public function generate(): Response
     {
-        return $this->provider->images($this->toRequest());
+        $request = $this->toRequest();
+
+        try {
+            return $this->provider->images($this->toRequest());
+        } catch (RequestException $e) {
+            $this->provider->handleRequestExceptions($request->model(), $e);
+        }
     }
 
     public function toRequest(): Request

--- a/src/Images/PendingRequest.php
+++ b/src/Images/PendingRequest.php
@@ -34,7 +34,7 @@ class PendingRequest
         try {
             return $this->provider->images($this->toRequest());
         } catch (RequestException $e) {
-            $this->provider->handleRequestExceptions($request->model(), $e);
+            $this->provider->handleRequestException($request->model(), $e);
         }
     }
 

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -22,7 +22,6 @@ use Prism\Prism\Structured\Request as StructuredRequest;
 use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Text\Request as TextRequest;
 use Prism\Prism\Text\Response as TextResponse;
-use Throwable;
 
 class Anthropic extends Provider
 {
@@ -73,16 +72,8 @@ class Anthropic extends Provider
         return $handler->handle($request);
     }
 
-    public function handleRequestExceptions(string $model, Throwable $e): never
+    public function handleRequestExceptions(string $model, RequestException $e): never
     {
-        if ($e instanceof PrismException) {
-            throw $e;
-        }
-
-        if (! $e instanceof RequestException) {
-            throw PrismException::providerRequestError($model, $e);
-        }
-
         match ($e->response->getStatusCode()) {
             429 => throw PrismRateLimitedException::make(
                 rateLimits: $this->processRateLimits($e->response),

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -72,7 +72,7 @@ class Anthropic extends Provider
         return $handler->handle($request);
     }
 
-    public function handleRequestExceptions(string $model, RequestException $e): never
+    public function handleRequestException(string $model, RequestException $e): never
     {
         match ($e->response->getStatusCode()) {
             429 => throw PrismRateLimitedException::make(

--- a/src/Providers/Gemini/Handlers/Cache.php
+++ b/src/Providers/Gemini/Handlers/Cache.php
@@ -49,7 +49,7 @@ class Cache
         try {
             $response = $this->client->post('/cachedContents', $request);
         } catch (Throwable $e) {
-            $this->handleRequestExceptions($this->model, $e);
+            $this->handleRequestException($this->model, $e);
         }
 
         return $response->json();

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\Gemini\Handlers;
 
-use Exception;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
 use Illuminate\Support\Arr;
@@ -89,7 +88,7 @@ class Text
         ]);
 
         if ($request->tools() !== [] && $request->providerTools() != []) {
-            throw new Exception('Use of provider tools with custom tools is not currently supported by Gemini.');
+            throw new PrismException('Use of provider tools with custom tools is not currently supported by Gemini.');
         }
 
         $tools = [];

--- a/src/Providers/Groq/Groq.php
+++ b/src/Providers/Groq/Groq.php
@@ -46,7 +46,7 @@ class Groq extends Provider
         return $handler->handle($request);
     }
 
-    public function handleRequestExceptions(string $model, RequestException $e): never
+    public function handleRequestException(string $model, RequestException $e): never
     {
         match ($e->response->getStatusCode()) {
             429 => throw PrismRateLimitedException::make(

--- a/src/Providers/Groq/Groq.php
+++ b/src/Providers/Groq/Groq.php
@@ -20,7 +20,6 @@ use Prism\Prism\Structured\Request as StructuredRequest;
 use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Text\Request as TextRequest;
 use Prism\Prism\Text\Response as TextResponse;
-use Throwable;
 
 class Groq extends Provider
 {
@@ -47,16 +46,8 @@ class Groq extends Provider
         return $handler->handle($request);
     }
 
-    public function handleRequestExceptions(string $model, Throwable $e): never
+    public function handleRequestExceptions(string $model, RequestException $e): never
     {
-        if ($e instanceof PrismException) {
-            throw $e;
-        }
-
-        if (! $e instanceof RequestException) {
-            throw PrismException::providerRequestError($model, $e);
-        }
-
         match ($e->response->getStatusCode()) {
             429 => throw PrismRateLimitedException::make(
                 rateLimits: $this->processRateLimits($e->response),

--- a/src/Providers/Groq/Maps/ToolChoiceMap.php
+++ b/src/Providers/Groq/Maps/ToolChoiceMap.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\Groq\Maps;
 
-use InvalidArgumentException;
 use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Exceptions\PrismException;
 
 class ToolChoiceMap
 {
@@ -26,7 +26,7 @@ class ToolChoiceMap
         return match ($toolChoice) {
             ToolChoice::Auto => 'auto',
             null => $toolChoice,
-            default => throw new InvalidArgumentException('Invalid tool choice')
+            default => throw new PrismException('Invalid tool choice')
         };
     }
 }

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -106,7 +106,7 @@ class Mistral extends Provider
         return $handler->handle($request);
     }
 
-    public function handleRequestExceptions(string $model, RequestException $e): never
+    public function handleRequestException(string $model, RequestException $e): never
     {
         match ($e->response->getStatusCode()) {
             429 => throw PrismRateLimitedException::make(

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -28,7 +28,6 @@ use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Text\Request as TextRequest;
 use Prism\Prism\Text\Response as TextResponse;
 use Prism\Prism\ValueObjects\Messages\Support\Document;
-use Throwable;
 
 class Mistral extends Provider
 {
@@ -107,16 +106,8 @@ class Mistral extends Provider
         return $handler->handle($request);
     }
 
-    public function handleRequestExceptions(string $model, Throwable $e): never
+    public function handleRequestExceptions(string $model, RequestException $e): never
     {
-        if ($e instanceof PrismException) {
-            throw $e;
-        }
-
-        if (! $e instanceof RequestException) {
-            throw PrismException::providerRequestError($model, $e);
-        }
-
         match ($e->response->getStatusCode()) {
             429 => throw PrismRateLimitedException::make(
                 rateLimits: $this->processRateLimits($e->response),

--- a/src/Providers/OpenAI/Handlers/Images.php
+++ b/src/Providers/OpenAI/Handlers/Images.php
@@ -6,7 +6,6 @@ namespace Prism\Prism\Providers\OpenAI\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
-use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Images\Request;
 use Prism\Prism\Images\Response;
 use Prism\Prism\Images\ResponseBuilder;
@@ -16,7 +15,6 @@ use Prism\Prism\Providers\OpenAI\Maps\ImageRequestMap;
 use Prism\Prism\ValueObjects\GeneratedImage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class Images
 {
@@ -53,11 +51,7 @@ class Images
 
     protected function sendRequest(Request $request): ClientResponse
     {
-        try {
-            return $this->client->post('images/generations', ImageRequestMap::map($request));
-        } catch (Throwable $e) {
-            throw PrismException::providerRequestError($request->model(), $e);
-        }
+        return $this->client->post('images/generations', ImageRequestMap::map($request));
     }
 
     /**

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -28,7 +28,6 @@ use Prism\Prism\Structured\Request as StructuredRequest;
 use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Text\Request as TextRequest;
 use Prism\Prism\Text\Response as TextResponse;
-use Throwable;
 
 class OpenAI extends Provider
 {
@@ -96,16 +95,8 @@ class OpenAI extends Provider
         return $handler->handle($request);
     }
 
-    public function handleRequestExceptions(string $model, Throwable $e): never
+    public function handleRequestExceptions(string $model, RequestException $e): never
     {
-        if ($e instanceof PrismException) {
-            throw $e;
-        }
-
-        if (! $e instanceof RequestException) {
-            throw PrismException::providerRequestError($model, $e);
-        }
-
         match ($e->response->getStatusCode()) {
             429 => throw PrismRateLimitedException::make(
                 rateLimits: $this->processRateLimits($e->response),

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -95,7 +95,7 @@ class OpenAI extends Provider
         return $handler->handle($request);
     }
 
-    public function handleRequestExceptions(string $model, RequestException $e): never
+    public function handleRequestException(string $model, RequestException $e): never
     {
         match ($e->response->getStatusCode()) {
             429 => throw PrismRateLimitedException::make(

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -47,7 +47,7 @@ abstract class Provider
         throw PrismException::unsupportedProviderAction(__METHOD__, class_basename($this));
     }
 
-    public function handleRequestExceptions(string $model, RequestException $e): never
+    public function handleRequestException(string $model, RequestException $e): never
     {
         throw PrismException::providerRequestError($model, $e);
     }

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -16,7 +16,6 @@ use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Text\Chunk;
 use Prism\Prism\Text\Request as TextRequest;
 use Prism\Prism\Text\Response as TextResponse;
-use Throwable;
 
 abstract class Provider
 {
@@ -48,16 +47,8 @@ abstract class Provider
         throw PrismException::unsupportedProviderAction(__METHOD__, class_basename($this));
     }
 
-    public function handleRequestExceptions(string $model, Throwable $e): never
+    public function handleRequestExceptions(string $model, RequestException $e): never
     {
-        if ($e instanceof PrismException) {
-            throw $e;
-        }
-
-        if (! $e instanceof RequestException) {
-            throw PrismException::providerRequestError($model, $e);
-        }
-
         throw PrismException::providerRequestError($model, $e);
     }
 }

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -42,7 +42,7 @@ class PendingRequest
         try {
             return $this->provider->structured($request);
         } catch (RequestException $e) {
-            $this->provider->handleRequestExceptions($request->model(), $e);
+            $this->provider->handleRequestException($request->model(), $e);
         }
     }
 

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Structured;
 
+use Illuminate\Http\Client\RequestException;
 use Prism\Prism\Concerns\ConfiguresClient;
 use Prism\Prism\Concerns\ConfiguresModels;
 use Prism\Prism\Concerns\ConfiguresProviders;
@@ -14,7 +15,6 @@ use Prism\Prism\Concerns\HasProviderOptions;
 use Prism\Prism\Concerns\HasSchema;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
-use Throwable;
 
 class PendingRequest
 {
@@ -41,7 +41,7 @@ class PendingRequest
 
         try {
             return $this->provider->structured($request);
-        } catch (Throwable $e) {
+        } catch (RequestException $e) {
             $this->provider->handleRequestExceptions($request->model(), $e);
         }
     }

--- a/src/Testing/PrismFake.php
+++ b/src/Testing/PrismFake.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\Assert as PHPUnit;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
 use Prism\Prism\Enums\FinishReason;
-use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Images\Request as ImageRequest;
 use Prism\Prism\Images\Response as ImageResponse;
 use Prism\Prism\Providers\Provider;
@@ -25,7 +24,6 @@ use Prism\Prism\ValueObjects\EmbeddingsUsage;
 use Prism\Prism\ValueObjects\GeneratedImage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class PrismFake extends Provider
 {
@@ -144,11 +142,6 @@ class PrismFake extends Provider
         );
 
         yield from $this->chunksFromTextResponse($fixture);
-    }
-
-    public function handleRequestExceptions(string $model, Throwable $e): never
-    {
-        throw PrismException::providerRequestError($model, $e);
     }
 
     /**

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -47,7 +47,7 @@ class PendingRequest
         try {
             return $this->provider->text($request);
         } catch (RequestException $e) {
-            $this->provider->handleRequestExceptions($request->model(), $e);
+            $this->provider->handleRequestException($request->model(), $e);
         }
     }
 
@@ -65,7 +65,7 @@ class PendingRequest
                 yield $chunk;
             }
         } catch (RequestException $e) {
-            $this->provider->handleRequestExceptions($request->model(), $e);
+            $this->provider->handleRequestException($request->model(), $e);
         }
     }
 

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism\Text;
 
 use Generator;
+use Illuminate\Http\Client\RequestException;
 use Prism\Prism\Concerns\ConfiguresClient;
 use Prism\Prism\Concerns\ConfiguresGeneration;
 use Prism\Prism\Concerns\ConfiguresModels;
@@ -17,7 +18,6 @@ use Prism\Prism\Concerns\HasProviderTools;
 use Prism\Prism\Concerns\HasTools;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
-use Throwable;
 
 class PendingRequest
 {
@@ -46,7 +46,7 @@ class PendingRequest
 
         try {
             return $this->provider->text($request);
-        } catch (Throwable $e) {
+        } catch (RequestException $e) {
             $this->provider->handleRequestExceptions($request->model(), $e);
         }
     }
@@ -64,7 +64,7 @@ class PendingRequest
             foreach ($chunks as $chunk) {
                 yield $chunk;
             }
-        } catch (Throwable $e) {
+        } catch (RequestException $e) {
             $this->provider->handleRequestExceptions($request->model(), $e);
         }
     }

--- a/tests/Providers/Groq/GroqTextTest.php
+++ b/tests/Providers/Groq/GroqTextTest.php
@@ -142,7 +142,7 @@ describe('Text generation for Groq', function (): void {
             ->using('groq', 'gpt-4')
             ->withPrompt('Who are you?')
             ->withToolChoice(ToolChoice::Any)
-            ->generate();
+            ->asText();
     });
 });
 

--- a/tests/TestDoubles/TestProvider.php
+++ b/tests/TestDoubles/TestProvider.php
@@ -21,7 +21,6 @@ use Prism\Prism\ValueObjects\GeneratedImage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\ProviderResponse;
 use Prism\Prism\ValueObjects\Usage;
-use Throwable;
 
 class TestProvider extends Provider
 {
@@ -86,6 +85,10 @@ class TestProvider extends Provider
         return $this->responses[$this->callCount - 1] ?? new EmbeddingResponse(
             embeddings: [],
             usage: new EmbeddingsUsage(10),
+            meta: new Meta(
+                id: '123',
+                model: 'your-model',
+            )
         );
     }
 
@@ -112,11 +115,6 @@ class TestProvider extends Provider
     public function stream(TextRequest $request): Generator
     {
         throw PrismException::unsupportedProviderAction(__METHOD__, class_basename($this));
-    }
-
-    public function handleRequestExceptions(string $model, Throwable $e): never
-    {
-        throw PrismException::providerRequestError($model, $e);
     }
 
     public function withResponse(StructuredResponse|TextResponse $response): Provider


### PR DESCRIPTION
## Description

#427 introduced a refactor moving request exception handling to the provider - which was a good refactor.

However, it also converts all exceptions that are not request exceptions to `PrismException`, which I don't think is needed/desired.

It also keeps the functionality of the `handleRequestException` method "true to its name".

This PR therefore changes each `PendingRequest` to only catch and delegate a `RequestException` to the provider's `handleRequestException` method - with all other exceptions thrown in their original form.

