### PR TITLE
Add provider to request objects

### DIFF
--- a/src/Embeddings/PendingRequest.php
+++ b/src/Embeddings/PendingRequest.php
@@ -80,6 +80,7 @@ class PendingRequest
     {
         return new Request(
             model: $this->model,
+            providerKey: $this->providerKey(),
             inputs: $this->inputs,
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,

--- a/src/Embeddings/Request.php
+++ b/src/Embeddings/Request.php
@@ -21,6 +21,7 @@ class Request implements PrismRequest
      */
     public function __construct(
         protected string $model,
+        protected string $providerKey,
         protected array $inputs,
         protected array $clientOptions,
         protected array $clientRetry,
@@ -57,5 +58,10 @@ class Request implements PrismRequest
     public function model(): string
     {
         return $this->model;
+    }
+
+    public function provider(): string
+    {
+        return $this->providerKey;
     }
 }

--- a/src/Images/PendingRequest.php
+++ b/src/Images/PendingRequest.php
@@ -42,6 +42,7 @@ class PendingRequest
     {
         return new Request(
             model: $this->model,
+            providerKey: $this->providerKey(),
             prompt: $this->prompt,
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,

--- a/src/Images/Request.php
+++ b/src/Images/Request.php
@@ -20,6 +20,7 @@ class Request implements PrismRequest
      */
     public function __construct(
         protected string $model,
+        protected string $providerKey,
         protected string $prompt,
         protected array $clientOptions,
         protected array $clientRetry,
@@ -53,5 +54,10 @@ class Request implements PrismRequest
     public function model(): string
     {
         return $this->model;
+    }
+
+    public function provider(): string
+    {
+        return $this->providerKey;
     }
 }

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -64,6 +64,7 @@ class PendingRequest
 
         return new Request(
             model: $this->model,
+            providerKey: $this->providerKey(),
             systemPrompts: $this->systemPrompts,
             prompt: $this->prompt,
             messages: $messages,

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -27,6 +27,7 @@ class Request implements PrismRequest
     public function __construct(
         protected array $systemPrompts,
         protected string $model,
+        protected string $providerKey,
         protected ?string $prompt,
         protected array $messages,
         protected ?int $maxTokens,
@@ -53,6 +54,11 @@ class Request implements PrismRequest
     public function model(): string
     {
         return $this->model;
+    }
+
+    public function provider(): string
+    {
+        return $this->providerKey;
     }
 
     public function prompt(): ?string

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -83,6 +83,7 @@ class PendingRequest
 
         return new Request(
             model: $this->model,
+            providerKey: $this->providerKey(),
             systemPrompts: $this->systemPrompts,
             prompt: $this->prompt,
             messages: $messages,

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -29,6 +29,7 @@ class Request implements PrismRequest
      */
     public function __construct(
         protected string $model,
+        protected string $providerKey,
         protected array $systemPrompts,
         protected ?string $prompt,
         protected array $messages,
@@ -128,6 +129,11 @@ class Request implements PrismRequest
     public function model(): string
     {
         return $this->model;
+    }
+
+    public function provider(): string
+    {
+        return $this->providerKey;
     }
 
     public function addMessage(Message $message): self

--- a/tests/Testing/AssertRequestTest.php
+++ b/tests/Testing/AssertRequestTest.php
@@ -24,7 +24,7 @@ it('can generate text and assert provider', function (): void {
     // Make assertions
     expect($response->text)->toBe('Hello, I am Claude!');
 
-    $fake->assertRequest(function ($requests): void {
+    $fake->assertRequest(function (array $requests): void {
         expect($requests[0]->provider())->toBe('anthropic');
         expect($requests[0]->model())->toBe('claude-3-5-sonnet-latest');
     });
@@ -47,7 +47,7 @@ it('can generate text and assert provider with different providers', function ()
     // Make assertions
     expect($response->text)->toBe('Hello from OpenAI!');
 
-    $fake->assertRequest(function ($requests): void {
+    $fake->assertRequest(function (array $requests): void {
         expect($requests[0]->provider())->toBe('openai');
         expect($requests[0]->model())->toBe('gpt-4');
     });

--- a/tests/Testing/AssertRequestTest.php
+++ b/tests/Testing/AssertRequestTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\ValueObjects\Usage;
+
+it('can generate text and assert provider', function (): void {
+    $fakeResponse = TextResponseFake::make()
+        ->withText('Hello, I am Claude!')
+        ->withUsage(new Usage(10, 20));
+
+    // Set up the fake
+    $fake = Prism::fake([$fakeResponse]);
+
+    // Run your code
+    $response = Prism::text()
+        ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
+        ->withPrompt('Who are you?')
+        ->asText();
+
+    // Make assertions
+    expect($response->text)->toBe('Hello, I am Claude!');
+
+    $fake->assertRequest(function ($requests): void {
+        expect($requests[0]->provider())->toBe('anthropic');
+        expect($requests[0]->model())->toBe('claude-3-5-sonnet-latest');
+    });
+});
+
+it('can generate text and assert provider with different providers', function (): void {
+    $fakeResponse = TextResponseFake::make()
+        ->withText('Hello from OpenAI!')
+        ->withUsage(new Usage(15, 25));
+
+    // Set up the fake
+    $fake = Prism::fake([$fakeResponse]);
+
+    // Run your code
+    $response = Prism::text()
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withPrompt('Hello')
+        ->asText();
+
+    // Make assertions
+    expect($response->text)->toBe('Hello from OpenAI!');
+
+    $fake->assertRequest(function ($requests): void {
+        expect($requests[0]->provider())->toBe('openai');
+        expect($requests[0]->model())->toBe('gpt-4');
+    });
+});


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Closes #439

This PR adds the `providerKey` to the request object so that we can later assert it in our testing fixtures.
