### PR TITLE
security(server)!: Disable insecure server setup by default

### DIFF
--- a/config/prism.php
+++ b/config/prism.php
@@ -4,7 +4,7 @@ return [
     'prism_server' => [
         // The middleware that will be applied to the Prism Server routes.
         'middleware' => [],
-        'enabled' => env('PRISM_SERVER_ENABLED', true),
+        'enabled' => env('PRISM_SERVER_ENABLED', false),
     ],
     'providers' => [
         'openai' => [


### PR DESCRIPTION
## Description

By default, the Prism server is enabled in every new installation without any restrictions offering its service to the whole internet. These open servers will be used by others sooner or later leading to high costs for the owner. This PR disables the  Prism server in new installations to get a secure setup by default, following best security practices.