### PR TITLE
fix(ollama): embeddings not working with empty options

### DIFF
--- a/src/Providers/Ollama/Handlers/Embeddings.php
+++ b/src/Providers/Ollama/Handlers/Embeddings.php
@@ -47,7 +47,7 @@ class Embeddings
             Arr::whereNotNull([
                 'model' => $request->model(),
                 'input' => $request->inputs(),
-                'options' => Arr::whereNotNull($request->providerOptions()),
+                'options' => $request->providerOptions() ?: null,
             ])
         );
     }

--- a/tests/Providers/Ollama/EmbeddingsTest.php
+++ b/tests/Providers/Ollama/EmbeddingsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Ollama;
 
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
 use Prism\Prism\Enums\Provider;
 use Prism\Prism\Prism;
 use Prism\Prism\ValueObjects\Embedding;
@@ -16,6 +18,14 @@ it('returns embeddings from input', function (): void {
         ->using(Provider::Ollama, 'mxbai-embed-large')
         ->fromInput('The food was delicious and the waiter...')
         ->asEmbeddings();
+
+    Http::assertSent(function (Request $request): true {
+        expect($request->data()['model'])->toBe('mxbai-embed-large');
+        expect($request->data()['input'])->toBe(['The food was delicious and the waiter...']);
+        expect($request->data())->not->toHaveKeys(['options']);
+
+        return true;
+    });
 
     $embeddings = json_decode(file_get_contents('tests/Fixtures/ollama/embeddings-input-1.json'), true);
     $embeddings = array_map(fn (array $item): \Prism\Prism\ValueObjects\Embedding => Embedding::fromArray($item), data_get($embeddings, 'embeddings'));


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
When provider options are not defined an empty array is passed and this causes an error on Ollama side.
This PR removes `options` parameter if empty.

Ollama [docs](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings) are not explicit but the example code shows `options` parameter as optional.

Fixes #460