### PR TITLE
fix(anthropic): nested usage

### DIFF
--- a/src/Providers/Anthropic/ValueObjects/StreamState.php
+++ b/src/Providers/Anthropic/ValueObjects/StreamState.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Prism\Prism\Providers\Anthropic\ValueObjects;
 
+use Illuminate\Support\Arr;
+
 class StreamState
 {
     /**
@@ -167,8 +169,8 @@ class StreamState
         if ($this->usage === []) {
             $this->usage = $usage;
         } else {
-            foreach ($usage as $key => $value) {
-                $this->usage[$key] = ($this->usage[$key] ?? 0) + $value;
+            foreach (Arr::dot($usage) as $key => $value) {
+                Arr::set($this->usage, $key, Arr::get($this->usage, $key, 0) + $value);
             }
         }
 

--- a/tests/Fixtures/anthropic/stream-basic-text-1.sse
+++ b/tests/Fixtures/anthropic/stream-basic-text-1.sse
@@ -104,7 +104,7 @@ event: content_block_stop
 data: {"type":"content_block_stop","index":0}
 
 event: message_delta
-data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":104}}
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":104,"server_tool_use":{"web_search_requests":1}}}
 
 event: message_stop
 data: {"type":"message_stop"}


### PR DESCRIPTION
## Description
Fixes setting usage in `StreamState` when there is a nested object like:
```json
"usage": {
  "output_tokens": 104,
  "server_tool_use": {"web_search_requests": 1}
}
```

