### PR TITLE
fix(deepseek): text generation without tools

### DIFF
--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -111,7 +111,7 @@ class Text
             ], Arr::whereNotNull([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
-                'tools' => ToolMap::map($request->tools()),
+                'tools' => ToolMap::map($request->tools()) ?: null,
                 'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
             ]))
         );

--- a/tests/Providers/DeepSeek/TextTest.php
+++ b/tests/Providers/DeepSeek/TextTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Enums\Provider;
 use Prism\Prism\Facades\Tool;
@@ -20,6 +22,12 @@ it('can generate text with a prompt', function (): void {
         ->using(Provider::DeepSeek, 'deepseek-chat')
         ->withPrompt('Who are you?')
         ->generate();
+
+    Http::assertSent(function (Request $request): true {
+        expect($request->data())->not->toHaveKeys(['tools']);
+
+        return true;
+    });
 
     // Assert response type
     expect($response)->toBeInstanceOf(TextResponse::class);


### PR DESCRIPTION
## Description
When not sending tools an empty array is passed and this causes an error on DeepSeek side.
This PR removes `tools` parameter if empty.

DeepSeek [docs](https://api-docs.deepseek.com/api/create-chat-completion) shows `tools` parameter as nullable.

Fixes #465
