### PR TITLE
feat: Automatic Tool Error Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ phpunit.xml
 .vscode
 ray.php
 CLAUDE.md
+.phpunit.result.cache

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -227,7 +227,7 @@ class Tool
             return $value;
         } catch (Throwable $e) {
             // If we have a failed handler, use it instead of throwing
-            if ($this->failedHandler instanceof \Closure) {
+            if ($this->failedHandler instanceof Closure) {
                 // Extract the provided parameters for context
                 $providedParams = $this->extractProvidedParams($args);
 

--- a/tests/Integration/InvalidToolParametersTest.php
+++ b/tests/Integration/InvalidToolParametersTest.php
@@ -2,193 +2,209 @@
 
 declare(strict_types=1);
 
-namespace Tests\Integration;
-
 use Illuminate\Support\Facades\Http;
-use PHPUnit\Framework\Attributes\Test;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Prism;
 use Prism\Prism\Tool;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
-use Tests\TestCase;
 
-class InvalidToolParametersTest extends TestCase
-{
-    #[Test]
-    public function it_throws_exception_when_ai_provides_invalid_parameters_to_tool(): void
-    {
-        // Create a tool that expects specific parameters
-        $readFileTool = (new Tool)
-            ->as('read_file')
-            ->for('Read a file with optional line range')
-            ->withStringParameter('path', 'The file path to read')
-            ->withNumberParameter('start_line', 'Starting line number', required: false)
-            ->withNumberParameter('end_line', 'Ending line number', required: false)
-            ->using(function (string $path, ?int $start_line = null, ?int $end_line = null): string {
-                // This simulates a real file reading function
-                if (! file_exists($path)) {
-                    throw new \InvalidArgumentException("File not found: $path");
-                }
+beforeEach(function (): void {
+    config()->set('prism.providers.anthropic.api_key', env('ANTHROPIC_API_KEY', 'sk-1234'));
+});
 
-                return 'File contents here...';
-            });
+it('throws exception when AI provides invalid parameters to tool', function (): void {
+    // Create a tool that expects specific parameters
+    $readFileTool = (new Tool)
+        ->as('read_file')
+        ->for('Read a file with optional line range')
+        ->withStringParameter('path', 'The file path to read')
+        ->withNumberParameter('start_line', 'Starting line number', required: false)
+        ->withNumberParameter('end_line', 'Ending line number', required: false)
+        ->using(function (string $path, ?int $start_line = null, ?int $end_line = null): string {
+            // This simulates a real file reading function
+            if (! file_exists($path)) {
+                throw new \InvalidArgumentException("File not found: $path");
+            }
 
-        // Fake the AI response with invalid parameters (passing strings instead of numbers)
-        Http::fake([
-            'https://api.anthropic.com/v1/messages' => Http::sequence()
-                ->push([
-                    'id' => 'msg_123',
-                    'type' => 'message',
-                    'role' => 'assistant',
-                    'model' => 'claude-3-5-sonnet-20241022',
-                    'content' => [
-                        [
-                            'type' => 'tool_use',
-                            'id' => 'toolu_01',
-                            'name' => 'read_file',
-                            'input' => [
-                                'path' => 'resources/views/test.blade.php',
-                                'start_line' => '37', // String instead of number - this will cause the error
-                                'end_line' => '43',   // String instead of number - this will cause the error
-                            ],
+            return 'File contents here...';
+        });
+
+    // Fake the AI response with invalid parameters (passing strings instead of numbers)
+    Http::fake([
+        'https://api.anthropic.com/v1/messages' => Http::sequence()
+            ->push([
+                'id' => 'msg_123',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-3-5-sonnet-20241022',
+                'content' => [
+                    [
+                        'type' => 'tool_use',
+                        'id' => 'toolu_01',
+                        'name' => 'read_file',
+                        'input' => [
+                            'path' => 'resources/views/test.blade.php',
+                            'start_line' => '37', // String instead of number - this will cause an error
+                            'end_line' => '43',   // String instead of number - this will cause an error
                         ],
                     ],
-                    'stop_reason' => 'tool_use',
-                    'stop_sequence' => null,
-                    'usage' => [
-                        'input_tokens' => 50,
-                        'output_tokens' => 25,
-                    ],
-                ]),
-        ]);
+                ],
+                'stop_reason' => 'tool_use',
+                'stop_sequence' => null,
+                'usage' => [
+                    'input_tokens' => 50,
+                    'output_tokens' => 25,
+                ],
+            ]),
+    ]);
 
-        // Set up Prism with the tool
-        $prism = Prism::text()
-            ->using('anthropic', 'claude-3-5-sonnet-20241022')
-            ->withSystemPrompt('You are a helpful assistant.')
-            ->withMessages([new UserMessage('Read lines 37-43 from the test.blade.php file')])
-            ->withTools([$readFileTool]);
+    // Set up Prism with the tool
+    $prism = Prism::text()
+        ->using('anthropic', 'claude-3-5-sonnet-20241022')
+        ->withSystemPrompt('You are a helpful assistant.')
+        ->withMessages([new UserMessage('Read lines 37-43 from the test.blade.php file')])
+        ->withTools([$readFileTool]);
 
-        // This should throw an exception because of invalid parameter types
-        $this->expectException(PrismException::class);
-        $this->expectExceptionMessage('Invalid parameters for tool : read_file');
+    // This will fail and break the flow
+    expect(fn (): \Prism\Prism\Text\Response => $prism->asText())
+        ->toThrow(PrismException::class, 'Invalid parameters for tool : read_file');
+});
 
-        // This will fail and break the flow
-        $prism->generate();
-    }
+it('demonstrates the need for graceful error handling', function (): void {
+    // Create a tool that will receive wrong parameter types
+    $mathTool = (new Tool)
+        ->as('calculate')
+        ->for('Perform a calculation')
+        ->withNumberParameter('a', 'First number')
+        ->withNumberParameter('b', 'Second number')
+        ->withStringParameter('operation', 'The operation to perform')
+        ->using(fn (int $a, int $b, string $operation): string => match ($operation) {
+            'add' => (string) ($a + $b),
+            'subtract' => (string) ($a - $b),
+            default => throw new \InvalidArgumentException("Unknown operation: $operation"),
+        });
 
-    #[Test]
-    public function it_demonstrates_the_need_for_graceful_error_handling(): void
-    {
-        // Create a tool that will receive wrong parameter types
-        $mathTool = (new Tool)
-            ->as('calculate')
-            ->for('Perform a calculation')
-            ->withNumberParameter('a', 'First number')
-            ->withNumberParameter('b', 'Second number')
-            ->withStringParameter('operation', 'The operation to perform')
-            ->using(fn(int $a, int $b, string $operation): string => match ($operation) {
-                'add' => (string) ($a + $b),
-                'subtract' => (string) ($a - $b),
-                default => throw new \InvalidArgumentException("Unknown operation: $operation"),
-            });
-
-        // Simulate multiple tool calls where one has invalid parameters
-        Http::fake([
-            'https://api.anthropic.com/v1/messages' => Http::sequence()
-                ->push([
-                    'id' => 'msg_123',
-                    'type' => 'message',
-                    'role' => 'assistant',
-                    'model' => 'claude-3-5-sonnet-20241022',
-                    'content' => [
-                        [
-                            'type' => 'tool_use',
-                            'id' => 'toolu_01',
-                            'name' => 'calculate',
-                            'input' => [
-                                'a' => 5,
-                                'b' => 3,
-                                'operation' => 'add',
-                            ],
-                        ],
-                        [
-                            'type' => 'tool_use',
-                            'id' => 'toolu_02',
-                            'name' => 'calculate',
-                            'input' => [
-                                'a' => 'ten', // Invalid: string instead of number
-                                'b' => 'five', // Invalid: string instead of number
-                                'operation' => 'subtract',
-                            ],
+    // Simulate multiple tool calls where one has invalid parameters
+    Http::fake([
+        'https://api.anthropic.com/v1/messages' => Http::sequence()
+            ->push([
+                'id' => 'msg_123',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-3-5-sonnet-20241022',
+                'content' => [
+                    [
+                        'type' => 'tool_use',
+                        'id' => 'toolu_01',
+                        'name' => 'calculate',
+                        'input' => [
+                            'a' => 5,
+                            'b' => 3,
+                            'operation' => 'add',
                         ],
                     ],
-                    'stop_reason' => 'tool_use',
-                    'stop_sequence' => null,
-                    'usage' => [
-                        'input_tokens' => 50,
-                        'output_tokens' => 25,
-                    ],
-                ]),
-        ]);
-
-        $prism = Prism::text()
-            ->using('anthropic', 'claude-3-5-sonnet-20241022')
-            ->withMessages([new UserMessage('Calculate 5+3 and then ten minus five')])
-            ->withTools([$mathTool]);
-
-        // The first tool call would succeed, but the second fails
-        // This breaks the entire flow even though we could potentially handle it gracefully
-        $this->expectException(PrismException::class);
-
-        $prism->generate();
-    }
-
-    #[Test]
-    public function it_shows_how_missing_required_parameters_break_the_flow(): void
-    {
-        $searchTool = (new Tool)
-            ->as('search')
-            ->for('Search for files')
-            ->withStringParameter('query', 'Search query')
-            ->withStringParameter('path', 'Directory to search in')
-            ->withNumberParameter('limit', 'Max results', required: false)
-            ->using(fn(string $query, string $path, ?int $limit = 10): string => "Found 5 results for '$query' in $path");
-
-        // AI forgets to provide required 'path' parameter
-        Http::fake([
-            'https://api.anthropic.com/v1/messages' => Http::sequence()
-                ->push([
-                    'id' => 'msg_123',
-                    'type' => 'message',
-                    'role' => 'assistant',
-                    'model' => 'claude-3-5-sonnet-20241022',
-                    'content' => [
-                        [
-                            'type' => 'tool_use',
-                            'id' => 'toolu_01',
-                            'name' => 'search',
-                            'input' => [
-                                'query' => 'test files', // Missing required 'path' parameter
-                            ],
+                    [
+                        'type' => 'tool_use',
+                        'id' => 'toolu_02',
+                        'name' => 'calculate',
+                        'input' => [
+                            'a' => 'ten', // Invalid: string instead of number
+                            'b' => 'five', // Invalid: string instead of number
+                            'operation' => 'subtract',
                         ],
                     ],
-                    'stop_reason' => 'tool_use',
-                    'stop_sequence' => null,
-                    'usage' => [
-                        'input_tokens' => 50,
-                        'output_tokens' => 25,
+                ],
+                'stop_reason' => 'tool_use',
+                'stop_sequence' => null,
+                'usage' => [
+                    'input_tokens' => 50,
+                    'output_tokens' => 25,
+                ],
+            ]),
+    ]);
+
+    $prism = Prism::text()
+        ->using('anthropic', 'claude-3-5-sonnet-20241022')
+        ->withMessages([new UserMessage('Calculate 5+3 and then ten minus five')])
+        ->withTools([$mathTool]);
+
+    // The first tool call would succeed, but the second fails
+    // This breaks the entire flow even though we could potentially handle it gracefully
+    expect(fn (): \Prism\Prism\Text\Response => $prism->asText())->toThrow(PrismException::class);
+});
+
+it('shows how missing required parameters break the flow', function (): void {
+    $searchTool = (new Tool)
+        ->as('search')
+        ->for('Search for files')
+        ->withStringParameter('query', 'Search query')
+        ->withStringParameter('path', 'Directory to search in')
+        ->withNumberParameter('limit', 'Max results', required: false)
+        ->using(fn (string $query, string $path, ?int $limit = 10): string => "Found 5 results for '$query' in $path");
+
+    // AI forgets to provide required 'path' parameter
+    Http::fake([
+        'https://api.anthropic.com/v1/messages' => Http::sequence()
+            ->push([
+                'id' => 'msg_123',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-3-5-sonnet-20241022',
+                'content' => [
+                    [
+                        'type' => 'tool_use',
+                        'id' => 'toolu_01',
+                        'name' => 'search',
+                        'input' => [
+                            'query' => 'test files', // Missing required 'path' parameter
+                        ],
                     ],
-                ]),
-        ]);
+                ],
+                'stop_reason' => 'tool_use',
+                'stop_sequence' => null,
+                'usage' => [
+                    'input_tokens' => 50,
+                    'output_tokens' => 25,
+                ],
+            ]),
+    ]);
 
-        $prism = Prism::text()
-            ->using('anthropic', 'claude-3-5-sonnet-20241022')
-            ->withMessages([new UserMessage('Search for test files')])
-            ->withTools([$searchTool]);
+    $prism = Prism::text()
+        ->using('anthropic', 'claude-3-5-sonnet-20241022')
+        ->withMessages([new UserMessage('Search for test files')])
+        ->withTools([$searchTool]);
 
-        $this->expectException(PrismException::class);
+    expect(fn (): \Prism\Prism\Text\Response => $prism->asText())->toThrow(PrismException::class);
+});
 
-        $prism->generate();
-    }
-}
+it('demonstrates that error handling works same way for streaming and non-streaming', function (): void {
+    // Create a tool that will get invalid parameters
+    $mathTool = (new Tool)
+        ->as('calculate')
+        ->for('Perform a calculation')
+        ->withNumberParameter('a', 'First number')
+        ->withNumberParameter('b', 'Second number')
+        ->using(fn (int $a, int $b): string => (string) ($a + $b));
+
+    // Test 1: Without error handling - both modes throw exception
+    $invalidParams = ['a' => 'five', 'b' => 10];
+
+    expect(fn (): string => $mathTool->handle(...$invalidParams))
+        ->toThrow(PrismException::class, 'Invalid parameters for tool : calculate');
+
+    // Test 2: With error handling - both modes return error message
+    $mathToolWithErrorHandling = (new Tool)
+        ->as('calculate')
+        ->for('Perform a calculation')
+        ->withNumberParameter('a', 'First number')
+        ->withNumberParameter('b', 'Second number')
+        ->using(fn (int $a, int $b): string => (string) ($a + $b))
+        ->handleToolErrors();
+
+    $result = $mathToolWithErrorHandling->handle(...$invalidParams);
+    expect($result)
+        ->toContain('Parameter validation error: Type mismatch')
+        ->toContain('Expected: [a (NumberSchema, required), b (NumberSchema, required)]');
+
+    // The same error handling behavior applies whether used in streaming or non-streaming mode
+});

--- a/tests/Integration/InvalidToolParametersTest.php
+++ b/tests/Integration/InvalidToolParametersTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Prism;
+use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Tests\TestCase;
+
+class InvalidToolParametersTest extends TestCase
+{
+    #[Test]
+    public function it_throws_exception_when_ai_provides_invalid_parameters_to_tool(): void
+    {
+        // Create a tool that expects specific parameters
+        $readFileTool = (new Tool)
+            ->as('read_file')
+            ->for('Read a file with optional line range')
+            ->withStringParameter('path', 'The file path to read')
+            ->withNumberParameter('start_line', 'Starting line number', required: false)
+            ->withNumberParameter('end_line', 'Ending line number', required: false)
+            ->using(function (string $path, ?int $start_line = null, ?int $end_line = null): string {
+                // This simulates a real file reading function
+                if (! file_exists($path)) {
+                    throw new \InvalidArgumentException("File not found: $path");
+                }
+
+                return 'File contents here...';
+            });
+
+        // Fake the AI response with invalid parameters (passing strings instead of numbers)
+        Http::fake([
+            'https://api.anthropic.com/v1/messages' => Http::sequence()
+                ->push([
+                    'id' => 'msg_123',
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'model' => 'claude-3-5-sonnet-20241022',
+                    'content' => [
+                        [
+                            'type' => 'tool_use',
+                            'id' => 'toolu_01',
+                            'name' => 'read_file',
+                            'input' => [
+                                'path' => 'resources/views/test.blade.php',
+                                'start_line' => '37', // String instead of number - this will cause the error
+                                'end_line' => '43',   // String instead of number - this will cause the error
+                            ],
+                        ],
+                    ],
+                    'stop_reason' => 'tool_use',
+                    'stop_sequence' => null,
+                    'usage' => [
+                        'input_tokens' => 50,
+                        'output_tokens' => 25,
+                    ],
+                ]),
+        ]);
+
+        // Set up Prism with the tool
+        $prism = Prism::text()
+            ->using('anthropic', 'claude-3-5-sonnet-20241022')
+            ->withSystemPrompt('You are a helpful assistant.')
+            ->withMessages([new UserMessage('Read lines 37-43 from the test.blade.php file')])
+            ->withTools([$readFileTool]);
+
+        // This should throw an exception because of invalid parameter types
+        $this->expectException(PrismException::class);
+        $this->expectExceptionMessage('Invalid parameters for tool : read_file');
+
+        // This will fail and break the flow
+        $prism->generate();
+    }
+
+    #[Test]
+    public function it_demonstrates_the_need_for_graceful_error_handling(): void
+    {
+        // Create a tool that will receive wrong parameter types
+        $mathTool = (new Tool)
+            ->as('calculate')
+            ->for('Perform a calculation')
+            ->withNumberParameter('a', 'First number')
+            ->withNumberParameter('b', 'Second number')
+            ->withStringParameter('operation', 'The operation to perform')
+            ->using(fn(int $a, int $b, string $operation): string => match ($operation) {
+                'add' => (string) ($a + $b),
+                'subtract' => (string) ($a - $b),
+                default => throw new \InvalidArgumentException("Unknown operation: $operation"),
+            });
+
+        // Simulate multiple tool calls where one has invalid parameters
+        Http::fake([
+            'https://api.anthropic.com/v1/messages' => Http::sequence()
+                ->push([
+                    'id' => 'msg_123',
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'model' => 'claude-3-5-sonnet-20241022',
+                    'content' => [
+                        [
+                            'type' => 'tool_use',
+                            'id' => 'toolu_01',
+                            'name' => 'calculate',
+                            'input' => [
+                                'a' => 5,
+                                'b' => 3,
+                                'operation' => 'add',
+                            ],
+                        ],
+                        [
+                            'type' => 'tool_use',
+                            'id' => 'toolu_02',
+                            'name' => 'calculate',
+                            'input' => [
+                                'a' => 'ten', // Invalid: string instead of number
+                                'b' => 'five', // Invalid: string instead of number
+                                'operation' => 'subtract',
+                            ],
+                        ],
+                    ],
+                    'stop_reason' => 'tool_use',
+                    'stop_sequence' => null,
+                    'usage' => [
+                        'input_tokens' => 50,
+                        'output_tokens' => 25,
+                    ],
+                ]),
+        ]);
+
+        $prism = Prism::text()
+            ->using('anthropic', 'claude-3-5-sonnet-20241022')
+            ->withMessages([new UserMessage('Calculate 5+3 and then ten minus five')])
+            ->withTools([$mathTool]);
+
+        // The first tool call would succeed, but the second fails
+        // This breaks the entire flow even though we could potentially handle it gracefully
+        $this->expectException(PrismException::class);
+
+        $prism->generate();
+    }
+
+    #[Test]
+    public function it_shows_how_missing_required_parameters_break_the_flow(): void
+    {
+        $searchTool = (new Tool)
+            ->as('search')
+            ->for('Search for files')
+            ->withStringParameter('query', 'Search query')
+            ->withStringParameter('path', 'Directory to search in')
+            ->withNumberParameter('limit', 'Max results', required: false)
+            ->using(fn(string $query, string $path, ?int $limit = 10): string => "Found 5 results for '$query' in $path");
+
+        // AI forgets to provide required 'path' parameter
+        Http::fake([
+            'https://api.anthropic.com/v1/messages' => Http::sequence()
+                ->push([
+                    'id' => 'msg_123',
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'model' => 'claude-3-5-sonnet-20241022',
+                    'content' => [
+                        [
+                            'type' => 'tool_use',
+                            'id' => 'toolu_01',
+                            'name' => 'search',
+                            'input' => [
+                                'query' => 'test files', // Missing required 'path' parameter
+                            ],
+                        ],
+                    ],
+                    'stop_reason' => 'tool_use',
+                    'stop_sequence' => null,
+                    'usage' => [
+                        'input_tokens' => 50,
+                        'output_tokens' => 25,
+                    ],
+                ]),
+        ]);
+
+        $prism = Prism::text()
+            ->using('anthropic', 'claude-3-5-sonnet-20241022')
+            ->withMessages([new UserMessage('Search for test files')])
+            ->withTools([$searchTool]);
+
+        $this->expectException(PrismException::class);
+
+        $prism->generate();
+    }
+}

--- a/tests/ToolErrorHandlingTest.php
+++ b/tests/ToolErrorHandlingTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use ArgumentCountError;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Tool;
+use TypeError;
+
+it('throws exception when no error handler is set', function (): void {
+    $tool = (new Tool)
+        ->as('calculate')
+        ->for('Perform calculation')
+        ->withNumberParameter('a', 'First number')
+        ->withNumberParameter('b', 'Second number')
+        ->using(fn(int $a, int $b): string => (string) ($a + $b));
+
+    expect(fn (): string => $tool->handle('five', 10))
+        ->toThrow(PrismException::class, 'Invalid parameters for tool : calculate');
+});
+
+it('uses custom failed handler when provided', function (): void {
+    $tool = (new Tool)
+        ->as('calculate')
+        ->for('Perform calculation')
+        ->withNumberParameter('a', 'First number')
+        ->withNumberParameter('b', 'Second number')
+        ->using(fn(int $a, int $b): string => (string) ($a + $b))
+        ->failed(fn(\Throwable $e, array $params): string => 'Custom error: Parameters must be numbers');
+
+    $result = $tool->handle('five', 10);
+
+    expect($result)->toBe('Custom error: Parameters must be numbers');
+});
+
+it('uses default error handler with handleErrors()', function (): void {
+    $tool = (new Tool)
+        ->as('calculate')
+        ->for('Perform calculation')
+        ->withNumberParameter('a', 'First number')
+        ->withNumberParameter('b', 'Second number')
+        ->using(fn(int $a, int $b): string => (string) ($a + $b))
+        ->handleErrors();
+
+    $result = $tool->handle('five', 10);
+
+    expect($result)
+        ->toContain('Type mismatch in parameters')
+        ->toContain('Expected: [a (NumberSchema, required), b (NumberSchema, required)]')
+        ->toContain('Received: {"a":"five","b":10}');
+});
+
+it('handles missing required parameters gracefully', function (): void {
+    $tool = (new Tool)
+        ->as('search')
+        ->for('Search files')
+        ->withStringParameter('query', 'Search query')
+        ->withStringParameter('path', 'Directory path')
+        ->using(fn(string $query, string $path): string => "Found results for $query in $path")
+        ->handleErrors();
+
+    // Missing second parameter
+    $result = $tool->handle('test query');
+
+    expect($result)
+        ->toContain('Missing required parameters')
+        ->toContain('Expected: [query (StringSchema, required), path (StringSchema, required)]');
+});
+
+it('handles unknown parameters gracefully', function (): void {
+    $tool = (new Tool)
+        ->as('simple')
+        ->for('Simple tool')
+        ->withStringParameter('name', 'Name')
+        ->using(fn(string $name): string => "Hello $name")
+        ->handleErrors();
+
+    // Unknown parameter 'unknown'
+    $result = $tool->handle(name: 'John', unknown: 'parameter');
+
+    expect($result)
+        ->toContain('Unknown parameters provided')
+        ->toContain('Expected: [name (StringSchema, required)]');
+});
+
+it('handles optional parameters correctly', function (): void {
+    $tool = (new Tool)
+        ->as('read_file')
+        ->for('Read file')
+        ->withStringParameter('path', 'File path')
+        ->withNumberParameter('lines', 'Number of lines', required: false)
+        ->using(fn(string $path, ?int $lines = null): string => "Reading $path".($lines ? " ($lines lines)" : ''))
+        ->handleErrors();
+
+    // Valid call with optional parameter as wrong type
+    $result = $tool->handle('/path/to/file', 'ten');
+
+    expect($result)
+        ->toContain('Type mismatch in parameters')
+        ->toContain('lines (NumberSchema)'); // Note: not marked as required
+});
+
+it('returns successful result when parameters are valid', function (): void {
+    $tool = (new Tool)
+        ->as('calculate')
+        ->for('Perform calculation')
+        ->withNumberParameter('a', 'First number')
+        ->withNumberParameter('b', 'Second number')
+        ->using(fn(int $a, int $b): string => (string) ($a + $b))
+        ->handleErrors();
+
+    $result = $tool->handle(5, 10);
+
+    expect($result)->toBe('15');
+});
+
+it('allows custom error messages based on exception type', function (): void {
+    $tool = (new Tool)
+        ->as('api_call')
+        ->for('Make API call')
+        ->withStringParameter('endpoint', 'API endpoint')
+        ->withArrayParameter('data', 'Request data', new \Prism\Prism\Schema\StringSchema('item', 'Data item'))
+        ->using(fn(string $endpoint, array $data): string => "Called $endpoint")
+        ->failed(function (\Throwable $e, array $params): string {
+            if ($e instanceof TypeError && str_contains($e->getMessage(), 'array')) {
+                return "The 'data' parameter must be an array, not a string. Example: ['item1', 'item2']";
+            }
+            if ($e instanceof ArgumentCountError) {
+                return "Missing parameters. Both 'endpoint' and 'data' are required.";
+            }
+
+            return "API call failed: {$e->getMessage()}";
+        });
+
+    // Test with wrong type
+    $result1 = $tool->handle('/api/users', 'not-an-array');
+    expect($result1)->toBe("The 'data' parameter must be an array, not a string. Example: ['item1', 'item2']");
+
+    // Test with missing parameter
+    $result2 = $tool->handle('/api/users');
+    expect($result2)->toBe("Missing parameters. Both 'endpoint' and 'data' are required.");
+});


### PR DESCRIPTION
# Summary

This PR adds support for automatic error handling for tool parameters, allowing AI models to receive helpful error messages instead of breaking the entire flow when they provide invalid parameters to tools. 

## Problem

When using tools with AI models, the models sometimes provide invalid parameters (wrong types, missing required parameters, etc.). Currently, this throws an exception that breaks the entire conversation flow, even though the AI could potentially correct itself if given proper feedback.

### Example Issues (from `InvalidToolParametersTest.php`)

1. **Type Mismatches**: AI passes strings instead of numbers
   ```php
   // AI provides: {'start_line': '37', 'end_line': '43'}
   // Expected: integers
   // Result: PrismException breaks the flow
   ```

2. **Missing Required Parameters**: AI forgets required parameters
   ```php
   // Tool expects: query (required), path (required)
   // AI provides: {'query': 'test files'} // missing 'path'
   // Result: PrismException breaks the flow
   ```

3. **Multiple Tool Calls**: One invalid call breaks all tool executions
   ```php
   // First tool call: calculate(5, 3, 'add') ✓ Works
   // Second tool call: calculate('ten', 'five', 'subtract') ✗ Fails
   // Result: Entire flow breaks, first successful result is lost
   ```

## Solution

Added two methods to the `Tool` class for error handling:

### 1. `handleToolErrors()` - Default error handling
```php
$tool = (new Tool)
    ->as('calculate')
    ->withNumberParameter('a', 'First number')
    ->withNumberParameter('b', 'Second number')
    ->using(fn(int $a, int $b): string => (string) ($a + $b))
    ->handleToolErrors(); // Enable graceful error handling
```

Returns helpful error messages that distinguish between:
- **Parameter validation errors**: Wrong types, missing parameters, unknown parameters
- **Runtime errors**: File not found, API failures, etc.

Example error messages:
```
Parameter validation error: Type mismatch. Expected: [a (NumberSchema, required), b (NumberSchema, required)]. Received: {"a":"five","b":10}.
Please provide correct parameter types and names.
```

### 2. `failed()` - Custom error handling
```php
$tool->failed(function (Throwable $e, array $params): string {
    if ($e instanceof TypeError) {
        return "Please provide numbers for calculation";
    }
    return "Calculation failed: {$e->getMessage()}";
});
```

## Benefits

- **AI can recover**: Instead of breaking, AI receives error feedback and can retry
- **Better UX**: Tools can provide context-specific error messages
- **Backward compatible**: Only affects tools that explicitly enable error handling
- **Works with streaming**: Same error handling behavior in both streaming and non-streaming modes

## Testing

- Added comprehensive tests in `ToolErrorHandlingTest.php` covering various error scenarios
- `InvalidToolParametersTest.php` demonstrates the problems and verifies the solution

## Breaking Changes

None. This is an opt-in feature that maintains backward compatibility.