### PR TITLE
bugfix: Updated logic for Strict flag in OpenAi Structured Output

### DIFF
--- a/src/Providers/OpenAI/Handlers/Structured.php
+++ b/src/Providers/OpenAI/Handlers/Structured.php
@@ -127,12 +127,12 @@ class Structured
             throw new PrismException(sprintf('%s model does not support structured mode', $request->model()));
         }
 
-        /** @var array{type: 'json_schema', name: string, schema: array<mixed>, strict?: bool} $responseFormat */
+        /** @var array{type: 'json_schema', name: string, schema: array<mixed>, strict: bool} $responseFormat */
         $responseFormat = Arr::whereNotNull([
             'type' => 'json_schema',
             'name' => $request->schema()->name(),
             'schema' => $request->schema()->toArray(),
-            'strict' => $request->providerOptions('schema.strict') ? true : null,
+            'strict' => (bool) $request->providerOptions('schema.strict'),
         ]);
 
         return $this->sendRequest($request, $responseFormat);


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

This is a fix for #479 allowing both true and false to be valid options for `schema.strict`
