### PR TITLE
fix(ollama-provider): remove unsupported 'system' param

### DIFF
--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -28,9 +28,9 @@ class Anthropic extends Provider
     use InitializesClient, ProcessesRateLimits;
 
     public function __construct(
-        #[\SensitiveParameter] readonly public string $apiKey,
-        readonly public string $apiVersion,
-        readonly public ?string $betaFeatures = null
+        #[\SensitiveParameter] public readonly string $apiKey,
+        public readonly string $apiVersion,
+        public readonly ?string $betaFeatures = null
     ) {}
 
     #[\Override]

--- a/src/Providers/DeepSeek/DeepSeek.php
+++ b/src/Providers/DeepSeek/DeepSeek.php
@@ -19,8 +19,8 @@ class DeepSeek extends Provider
     use InitializesClient;
 
     public function __construct(
-        #[\SensitiveParameter] readonly public string $apiKey,
-        readonly public string $url,
+        #[\SensitiveParameter] public readonly string $apiKey,
+        public readonly string $url,
     ) {}
 
     #[\Override]

--- a/src/Providers/Gemini/Gemini.php
+++ b/src/Providers/Gemini/Gemini.php
@@ -30,8 +30,8 @@ class Gemini extends Provider
     use InitializesClient;
 
     public function __construct(
-        #[\SensitiveParameter] readonly public string $apiKey,
-        readonly public string $url,
+        #[\SensitiveParameter] public readonly string $apiKey,
+        public readonly string $url,
     ) {}
 
     #[\Override]

--- a/src/Providers/Groq/Groq.php
+++ b/src/Providers/Groq/Groq.php
@@ -29,8 +29,8 @@ class Groq extends Provider
     use InitializesClient, ProcessRateLimits;
 
     public function __construct(
-        #[\SensitiveParameter] readonly public string $apiKey,
-        readonly public string $url,
+        #[\SensitiveParameter] public readonly string $apiKey,
+        public readonly string $url,
     ) {}
 
     #[\Override]

--- a/src/Providers/Mistral/Mistral.php
+++ b/src/Providers/Mistral/Mistral.php
@@ -34,8 +34,8 @@ class Mistral extends Provider
     use InitializesClient, ProcessRateLimits;
 
     public function __construct(
-        #[\SensitiveParameter] readonly public string $apiKey,
-        readonly public string $url,
+        #[\SensitiveParameter] public readonly string $apiKey,
+        public readonly string $url,
     ) {}
 
     #[\Override]

--- a/src/Providers/Ollama/Handlers/Stream.php
+++ b/src/Providers/Ollama/Handlers/Stream.php
@@ -174,17 +174,15 @@ class Stream
 
     protected function sendRequest(Request $request): Response
     {
-        if (count($request->systemPrompts()) > 1) {
-            throw new PrismException('Ollama does not support multiple system prompts using withSystemPrompt / withSystemPrompts. However, you can provide additional system prompts by including SystemMessages in with withMessages.');
-        }
-
         return $this
             ->client
             ->withOptions(['stream' => true])
             ->post('api/chat', [
                 'model' => $request->model(),
-                'system' => data_get($request->systemPrompts(), '0.content', ''),
-                'messages' => (new MessageMap($request->messages()))->map(),
+                'messages' => (new MessageMap(array_merge(
+                    $request->systemPrompts(),
+                    $request->messages()
+                )))->map(),
                 'tools' => ToolMap::map($request->tools()),
                 'stream' => true,
                 'options' => Arr::whereNotNull(array_merge([

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -84,9 +84,9 @@ class Structured
             'format' => $request->schema()->toArray(),
             'stream' => false,
             'options' => Arr::whereNotNull(array_merge([
-            'temperature' => $request->temperature(),
-            'num_predict' => $request->maxTokens() ?? 2048,
-            'top_p' => $request->topP(),
+                'temperature' => $request->temperature(),
+                'num_predict' => $request->maxTokens() ?? 2048,
+                'top_p' => $request->topP(),
             ], $request->providerOptions())),
         ]);
 

--- a/src/Providers/Ollama/Handlers/Structured.php
+++ b/src/Providers/Ollama/Handlers/Structured.php
@@ -6,7 +6,6 @@ namespace Prism\Prism\Providers\Ollama\Handlers;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Arr;
-use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Providers\Ollama\Concerns\MapsFinishReason;
 use Prism\Prism\Providers\Ollama\Concerns\ValidatesResponse;
 use Prism\Prism\Providers\Ollama\Maps\MessageMap;
@@ -76,20 +75,18 @@ class Structured
      */
     protected function sendRequest(Request $request): array
     {
-        if (count($request->systemPrompts()) > 1) {
-            throw new PrismException('Ollama does not support multiple system prompts using withSystemPrompt / withSystemPrompts. However, you can provide additional system prompts by including SystemMessages in with withMessages.');
-        }
-
         $response = $this->client->post('api/chat', [
             'model' => $request->model(),
-            'system' => data_get($request->systemPrompts(), '0.content', ''),
-            'messages' => (new MessageMap($request->messages()))->map(),
+            'messages' => (new MessageMap(array_merge(
+                $request->systemPrompts(),
+                $request->messages()
+            )))->map(),
             'format' => $request->schema()->toArray(),
             'stream' => false,
             'options' => Arr::whereNotNull(array_merge([
-                'temperature' => $request->temperature(),
-                'num_predict' => $request->maxTokens() ?? 2048,
-                'top_p' => $request->topP(),
+            'temperature' => $request->temperature(),
+            'num_predict' => $request->maxTokens() ?? 2048,
+            'top_p' => $request->topP(),
             ], $request->providerOptions())),
         ]);
 

--- a/src/Providers/Ollama/Handlers/Text.php
+++ b/src/Providers/Ollama/Handlers/Text.php
@@ -68,16 +68,14 @@ class Text
      */
     protected function sendRequest(Request $request): array
     {
-        if (count($request->systemPrompts()) > 1) {
-            throw new PrismException('Ollama does not support multiple system prompts using withSystemPrompt / withSystemPrompts. However, you can provide additional system prompts by including SystemMessages in with withMessages.');
-        }
-
         $response = $this
             ->client
             ->post('api/chat', [
                 'model' => $request->model(),
-                'system' => data_get($request->systemPrompts(), '0.content', ''),
-                'messages' => (new MessageMap($request->messages()))->map(),
+                'messages' => (new MessageMap(array_merge(
+                    $request->systemPrompts(),
+                    $request->messages()
+                )))->map(),
                 'tools' => ToolMap::map($request->tools()),
                 'stream' => false,
                 'options' => Arr::whereNotNull(array_merge([

--- a/src/Providers/Ollama/Ollama.php
+++ b/src/Providers/Ollama/Ollama.php
@@ -24,8 +24,8 @@ class Ollama extends Provider
     use InitializesClient;
 
     public function __construct(
-        #[\SensitiveParameter] readonly public string $apiKey,
-        readonly public string $url,
+        #[\SensitiveParameter] public readonly string $apiKey,
+        public readonly string $url,
     ) {}
 
     #[\Override]

--- a/src/Providers/OpenAI/OpenAI.php
+++ b/src/Providers/OpenAI/OpenAI.php
@@ -33,10 +33,10 @@ class OpenAI extends Provider
     use InitializesClient;
 
     public function __construct(
-        #[\SensitiveParameter] readonly public string $apiKey,
-        readonly public string $url,
-        readonly public ?string $organization,
-        readonly public ?string $project,
+        #[\SensitiveParameter] public readonly string $apiKey,
+        public readonly string $url,
+        public readonly ?string $organization,
+        public readonly ?string $project,
     ) {}
 
     #[\Override]

--- a/src/Providers/OpenRouter/OpenRouter.php
+++ b/src/Providers/OpenRouter/OpenRouter.php
@@ -27,8 +27,8 @@ class OpenRouter extends Provider
     use InitializesClient;
 
     public function __construct(
-        #[\SensitiveParameter] readonly public string $apiKey,
-        readonly public string $url,
+        #[\SensitiveParameter] public readonly string $apiKey,
+        public readonly string $url,
     ) {}
 
     #[\Override]

--- a/src/Providers/VoyageAI/VoyageAI.php
+++ b/src/Providers/VoyageAI/VoyageAI.php
@@ -13,8 +13,8 @@ class VoyageAI extends Provider
     use InitializesClient;
 
     public function __construct(
-        #[\SensitiveParameter] readonly protected string $apiKey,
-        readonly protected string $baseUrl
+        #[\SensitiveParameter] protected readonly string $apiKey,
+        protected readonly string $baseUrl
     ) {}
 
     #[\Override]

--- a/src/Providers/XAI/XAI.php
+++ b/src/Providers/XAI/XAI.php
@@ -16,8 +16,8 @@ class XAI extends Provider
     use InitializesClient;
 
     public function __construct(
-        #[\SensitiveParameter] readonly public string $apiKey,
-        readonly public string $url,
+        #[\SensitiveParameter] public readonly string $apiKey,
+        public readonly string $url,
     ) {}
 
     #[\Override]

--- a/tests/Providers/Ollama/StructuredTest.php
+++ b/tests/Providers/Ollama/StructuredTest.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Ollama;
 
-use Illuminate\Support\Facades\Http;
 use Prism\Prism\Enums\Provider;
-use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Prism;
 use Prism\Prism\Schema\ArraySchema;
 use Prism\Prism\Schema\ObjectSchema;
 use Prism\Prism\Schema\StringSchema;
-use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Tests\Fixtures\FixtureResponse;
 
 it('returns structured output', function (): void {

--- a/tests/Providers/Ollama/StructuredTest.php
+++ b/tests/Providers/Ollama/StructuredTest.php
@@ -53,33 +53,3 @@ it('returns structured output', function (): void {
     expect($response->structured['open_source'])->toBeArray();
 
 });
-
-it('throws an exception with multiple system prompts', function (): void {
-    Http::preventStrayRequests();
-
-    $schema = new ObjectSchema(
-        'output',
-        'the output object',
-        [
-            new StringSchema('name', 'The users name'),
-            new ArraySchema('hobbies', 'a list of the users hobbies',
-                new StringSchema('name', 'the name of the hobby'),
-            ),
-            new ArraySchema('open_source', 'The users open source contributions',
-                new StringSchema('name', 'the name of the project'),
-            ),
-        ],
-        ['name', 'hobbies', 'open_source']
-    );
-
-    $response = Prism::structured()
-        ->using('ollama', 'qwen2.5:14b')
-        ->withSchema($schema)
-        ->withSystemPrompts([
-            new SystemMessage('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]!'),
-            new SystemMessage('But my friends call my Nyx.'),
-        ])
-        ->withPrompt('Who are you?')
-        ->asStructured();
-
-})->throws(PrismException::class, 'Ollama does not support multiple system prompts using withSystemPrompt / withSystemPrompts. However, you can provide additional system prompts by including SystemMessages in with withMessages.');

--- a/tests/Providers/Ollama/TextTest.php
+++ b/tests/Providers/Ollama/TextTest.php
@@ -167,17 +167,3 @@ describe('Image support', function (): void {
         });
     });
 });
-
-it('throws an exception with multiple system prompts', function (): void {
-    Http::preventStrayRequests();
-
-    $response = Prism::text()
-        ->using('ollama', 'qwen2.5:14b')
-        ->withSystemPrompts([
-            new SystemMessage('MODEL ADOPTS ROLE of [PERSONA: Nyx the Cthulhu]!'),
-            new SystemMessage('But my friends call my Nyx.'),
-        ])
-        ->withPrompt('Who are you?')
-        ->asText();
-
-})->throws(PrismException::class, 'Ollama does not support multiple system prompts using withSystemPrompt / withSystemPrompts. However, you can provide additional system prompts by including SystemMessages in with withMessages.');

--- a/tests/Providers/Ollama/TextTest.php
+++ b/tests/Providers/Ollama/TextTest.php
@@ -7,7 +7,6 @@ namespace Tests\Providers\Ollama;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Prism\Prism\Enums\Provider;
-use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Facades\Tool;
 use Prism\Prism\Prism;
 use Prism\Prism\ValueObjects\Messages\Support\Image;


### PR DESCRIPTION
## Description

Remove unsupported 'system' param from `api/chat` endpoint and allow multiple system prompts

Replace the incorrect use of the `system` body param with the correct `{ role, content }` message structure, as per Ollama's API spec. Now system prompts are prepended to the messages array to maintain compatibility with the chat format expected by `api/chat`. `system` body param is only available for `api/generate` endpoint. Since we are now prepending the system prompts, multiple system prompts are allowed by default, remove the restriction on multiple system prompts and remove the relevant tests as well.

## Breaking Changes

N/A
