### PR TITLE
Feat/anthropic file support

### DIFF
--- a/src/Providers/Anthropic/Maps/DocumentMapper.php
+++ b/src/Providers/Anthropic/Maps/DocumentMapper.php
@@ -79,6 +79,10 @@ class DocumentMapper extends ProviderMediaMapper
 
     protected function validateMedia(): bool
     {
+        if ($this->media->isFileId()) {
+            return true;
+        }
+
         if ($this->media->isUrl()) {
             return true;
         }

--- a/src/Providers/Anthropic/Maps/DocumentMapper.php
+++ b/src/Providers/Anthropic/Maps/DocumentMapper.php
@@ -40,7 +40,12 @@ class DocumentMapper extends ProviderMediaMapper
                 : null,
         ];
 
-        if ($this->media->isUrl()) {
+        if ($this->media->isFileId()) {
+            $payload['source'] = [
+                'type' => 'file',
+                'file_id' => $this->media->fileId(),
+            ];
+        } elseif ($this->media->isUrl()) {
             $payload['source'] = [
                 'type' => 'url',
                 'url' => $this->media->url(),

--- a/src/ValueObjects/Messages/Support/Document.php
+++ b/src/ValueObjects/Messages/Support/Document.php
@@ -11,6 +11,8 @@ class Document extends Media
 {
     protected ?string $documentTitle = null;
 
+    protected ?string $fileId = null;
+
     /**
      * @var null|array<string>
      */
@@ -22,6 +24,15 @@ class Document extends Media
     public static function fromPath(string $path, ?string $title = null): static
     {
         return self::fromLocalPath($path, $title);
+    }
+
+    public static function fromFileId(string $fileId, ?string $title = null): static
+    {
+        $instance = new static;
+        $instance->documentTitle = $title;
+        $instance->fileId = $fileId;
+
+        return $instance;
     }
 
     public static function fromLocalPath(string $path, ?string $title = null): static
@@ -71,6 +82,11 @@ class Document extends Media
         return $this->chunks !== null;
     }
 
+    public function isFileId(): bool
+    {
+        return $this->fileId !== null;
+    }
+
     public function setDocumentTitle(?string $title): static
     {
         $this->documentTitle = $title;
@@ -81,6 +97,11 @@ class Document extends Media
     public function documentTitle(): ?string
     {
         return $this->documentTitle;
+    }
+
+    public function fileId(): ?string
+    {
+        return $this->fileId;
     }
 
     /**

--- a/tests/ValueObjects/Messages/Support/DocumentTest.php
+++ b/tests/ValueObjects/Messages/Support/DocumentTest.php
@@ -8,3 +8,10 @@ it('can create a document from chunks', function (): void {
     expect($document->chunks())->toBe(['chunk1', 'chunk2']);
     expect($document->documentTitle())->toBe('title');
 });
+
+it('can create a document from a file ID', function (): void {
+    $document = Document::fromFileId('file-id', 'title');
+
+    expect($document->fileId())->toBe('file-id');
+    expect($document->documentTitle())->toBe('title');
+});


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
When using Anthropic file beta flag (`files-api-2025-04-14`) user can call `Document::fromFileId()` to provide an Anthropic File uploaded using the Anthropic Files API.

