### PR TITLE
fix(gemini): structured output compatibility issues

### DIFF
--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -88,6 +88,18 @@ class Structured
                 ]
             ));
         }
+
+        // Check for thinking token exhaustion pattern
+        $finishReason = data_get($data, 'candidates.0.finishReason');
+        $content = data_get($data, 'candidates.0.content.parts.0.text', '');
+        $thoughtTokens = data_get($data, 'usageMetadata.thoughtsTokenCount', 0);
+
+        if ($finishReason === 'MAX_TOKENS' && in_array(trim((string) $content), ['', '0'], true) && $thoughtTokens > 0) {
+            throw PrismException::providerResponseError(
+                'Gemini thinking tokens exhausted the token limit, leaving no tokens for structured output generation. '.
+                'Try increasing maxTokens to account for thinking overhead (suggested: 2-3x current value).'
+            );
+        }
     }
 
     /**

--- a/src/Providers/Gemini/Maps/SchemaMap.php
+++ b/src/Providers/Gemini/Maps/SchemaMap.php
@@ -19,11 +19,15 @@ class SchemaMap
      */
     public function toArray(): array
     {
+        $schemaArray = $this->schema->toArray();
+
+        // Remove additionalProperties from the schema array since Gemini doesn't support it
+        unset($schemaArray['additionalProperties']);
+
         return array_merge([
             ...array_filter([
-                ...$this->schema->toArray(),
+                ...$schemaArray,
                 'type' => $this->mapType(),
-                'additionalProperties' => null,
             ]),
         ], array_filter([
             'items' => property_exists($this->schema, 'items') ?

--- a/tests/Providers/Gemini/GeminiStructuredTest.php
+++ b/tests/Providers/Gemini/GeminiStructuredTest.php
@@ -128,3 +128,30 @@ it('can use a cache object with a structured request', function (): void {
     expect($response->structured['legal_jurisdiction'])->toBe('European Union');
     expect($response->structured['legislation_type'])->toBe('Treaty');
 });
+
+it('works with allowAdditionalProperties set to true', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'gemini/generate-structured');
+
+    $schema = new ObjectSchema(
+        'book_info',
+        'Book information',
+        [
+            new StringSchema('title', 'Book title'),
+            new StringSchema('author', 'Book author'),
+        ],
+        ['title', 'author'],
+        true  // allowAdditionalProperties: true
+    );
+
+    $response = Prism::structured()
+        ->using(Provider::Gemini, 'gemini-1.5-flash-002')
+        ->withSchema($schema)
+        ->withPrompt('Generate information about a book')
+        ->asStructured();
+
+    expect($response->structured)->toBeArray();
+    // The fixture data contains different keys, so we'll just verify it's not empty
+    expect($response->structured)->not->toBeEmpty();
+    expect($response->usage->promptTokens)->toBe(81);
+    expect($response->usage->completionTokens)->toBe(64);
+});


### PR DESCRIPTION
## Problems

### Issue 1: additionalProperties Schema Compatibility
The Gemini API does not support the `additionalProperties` field in JSON schemas, causing HTTP 400 errors when using ObjectSchema instances with this field.

### Issue 2: Thinking Token Exhaustion Detection
Gemini 2.5 Pro and Flash models consume significant thinking tokens (200-450+) during structured output generation, causing token exhaustion with low `maxTokens` values and resulting in empty array responses with unclear error messages.

## Root Causes

### Schema Compatibility Issue
The `SchemaMap` class was including the `additionalProperties` field from ObjectSchema in API requests, which Gemini rejects with:
```
Invalid JSON payload received. Unknown name "additionalProperties"
```

### Silent Token Exhaustion Issue
When users specify low token limits (e.g., 200 tokens), thinking tokens consume almost all available tokens, leaving no room for actual structured output generation. This results in `finishReason: "MAX_TOKENS"` and empty response content with no clear indication of the root cause.

## Solutions

### Fix 1: Schema Compatibility
```php
// Remove additionalProperties for Gemini compatibility
$schemaArray = $this->schema->toArray();
unset($schemaArray['additionalProperties']);
```

### Fix 2: Clear Error Detection and Messaging
```php
// Check for thinking token exhaustion pattern
$finishReason = data_get($data, 'candidates.0.finishReason');
$content = data_get($data, 'candidates.0.content.parts.0.text', '');
$thoughtTokens = data_get($data, 'usageMetadata.thoughtsTokenCount', 0);

if ($finishReason === 'MAX_TOKENS' && empty(trim($content)) && $thoughtTokens > 0) {
    throw PrismException::providerResponseError(
        'Gemini thinking tokens exhausted the token limit, leaving no tokens for structured output generation. ' .
        'Try increasing maxTokens to account for thinking overhead (suggested: 2-3x current value).'
    );
}
```

## Implementation Details

### Clear Error Messages
- **Detection**: Identifies thinking token exhaustion pattern automatically
- **Guidance**: Provides specific solution (2-3x token increase)
- **User-friendly**: Clear explanation of root cause and fix
- **No cost impact**: Doesn't automatically increase tokens, lets user decide

### Schema Processing
- Removes unsupported `additionalProperties` field before API calls
- Maintains full ObjectSchema API compatibility
- Preserves all other schema features

## Testing & Verification

### Before Fix
```php
// With maxTokens: 200
$response->structured = []; // Empty array with no clear error
$response->usage->completionTokens = 0; // No output generated
```

### After Fix
```php
// Same request now throws clear error:
// "Gemini thinking tokens exhausted the token limit, leaving no tokens 
//  for structured output generation. Try increasing maxTokens to account 
//  for thinking overhead (suggested: 2-3x current value)."
```

## Impact

This comprehensive fix resolves both major Gemini structured output issues:
- **Schema compatibility**: ObjectSchema with `allowAdditionalProperties` now works
- **Error clarity**: Users get clear guidance when thinking tokens cause issues
- **Cost awareness**: No automatic token increases, user maintains control
- **Backward compatibility**: No breaking changes to existing code