### PR TITLE
Feat/withprompt media

### DIFF
--- a/docs/core-concepts/text-generation.md
+++ b/docs/core-concepts/text-generation.md
@@ -48,6 +48,69 @@ $response = Prism::text()
 
 You an also pass a View to the `withPrompt` method.
 
+## Multi-Modal Input
+
+Prism supports including images, documents, audio, and video files in your prompts for rich multi-modal analysis:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\ValueObjects\Media\Image;
+use Prism\Prism\ValueObjects\Media\Document;
+use Prism\Prism\ValueObjects\Media\Audio;
+use Prism\Prism\ValueObjects\Media\Video;
+
+// Analyze an image
+$response = Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
+    ->withPrompt(
+        'What objects do you see in this image?',
+        [Image::fromLocalPath('/path/to/image.jpg')]
+    )
+    ->asText();
+
+// Process a document
+$response = Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
+    ->withPrompt(
+        'Summarize the key points from this document',
+        [Document::fromLocalPath('/path/to/document.pdf')]
+    )
+    ->asText();
+
+// Analyze audio content
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'What is being discussed in this audio?',
+        [Audio::fromLocalPath('/path/to/audio.mp3')]
+    )
+    ->asText();
+
+// Process video content
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'Describe what happens in this video',
+        [Video::fromUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')]
+    )
+    ->asText();
+
+// Multiple media types in one prompt
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'Compare this image with the information in this document',
+        [
+            Image::fromLocalPath('/path/to/chart.png'),
+            Document::fromLocalPath('/path/to/report.pdf')
+        ]
+    )
+    ->asText();
+```
+
+For detailed information about supported media types and transfer methods, see the [input modalities documentation](/input-modalities/).
+
 ## Message Chains and Conversations
 
 For interactive conversations, use message chains to maintain context:

--- a/docs/input-modalities/audio.md
+++ b/docs/input-modalities/audio.md
@@ -14,49 +14,79 @@ For other input modalities like videos and images, see their respective document
 
 ## Getting started
 
-To add an audio file to your message, add an `Audio` value object to the `additionalContent` property:
+To add an audio file to your prompt, use the `withPrompt` method with an `Audio` value object:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\ValueObjects\Media\Audio;
+
+// From a local path
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        "What's in this audio?",
+        [Audio::fromLocalPath(path: '/path/to/audio.mp3')]
+    )
+    ->asText();
+
+// From a path on a storage disk
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        "What's in this audio?",
+        [Audio::fromStoragePath(
+            path: '/path/to/audio.mp3', 
+            disk: 'my-disk' // optional - omit/null for default disk
+        )]
+    )
+    ->asText();
+
+// From a URL
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'Analyze this audio:',
+        [Audio::fromUrl(url: 'https://example.com/audio.mp3')]
+    )
+    ->asText();
+
+// From base64
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'Analyze this audio:',
+        [Audio::fromBase64(
+            base64: base64_encode(file_get_contents('/path/to/audio.mp3')),
+            mimeType: 'audio/mpeg'
+        )]
+    )
+    ->asText();
+
+// From raw content
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'Analyze this audio:',
+        [Audio::fromRawContent(
+            rawContent: file_get_contents('/path/to/audio.mp3'),
+            mimeType: 'audio/mpeg'
+        )]
+    )
+    ->asText();
+```
+
+## Alternative: Using withMessages
+
+You can also include audio files using the message-based approach:
 
 ```php
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Prism\Prism\ValueObjects\Media\Audio;
 
-// From a local path
 $message = new UserMessage(
     "What's in this audio?",
     [Audio::fromLocalPath(path: '/path/to/audio.mp3')]
-);
-
-// From a path on a storage disk
-$message = new UserMessage(
-    "What's in this audio?",
-    [Audio::fromStoragePath(
-        path: '/path/to/audio.mp3', 
-        disk: 'my-disk' // optional - omit/null for default disk
-    )]
-);
-
-// From a URL
-$message = new UserMessage(
-    'Analyze this audio:',
-    [Audio::fromUrl(url: 'https://example.com/audio.mp3')]
-);
-
-// From base64
-$message = new UserMessage(
-    'Analyze this audio:',
-    [Audio::fromBase64(
-        base64: base64_encode(file_get_contents('/path/to/audio.mp3')),
-        mimeType: 'audio/mpeg'
-    )]
-);
-
-// From raw content
-$message = new UserMessage(
-    'Analyze this audio:',
-    [Audio::fromRawContent(
-        rawContent: file_get_contents('/path/to/audio.mp3'),
-        mimeType: 'audio/mpeg'
-    )]
 );
 
 $response = Prism::text()

--- a/docs/input-modalities/documents.md
+++ b/docs/input-modalities/documents.md
@@ -35,92 +35,138 @@ Prism tries to smooth over these rough edges, but its not always possible.
 
 ## Getting started
 
-To add a document to your message, add a `Document` value object to the `additionalContent` property:
+To add a document to your prompt, use the `withPrompt` method with a `Document` value object:
 
 ```php
 use Prism\Prism\Enums\Provider;
 use Prism\Prism\Prism;
-use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Prism\Prism\ValueObjects\Media\Document;
-use Prism\Prism\ValueObjects\Media\OpenAIFile;
 
-Prism::text()
+// From a local path
+$response = Prism::text()
     ->using('my-provider', 'my-model')
-    ->withMessages([
-        // From a local path
-        new UserMessage('Here is the document from a local path', [
-            Document::fromLocalPath(
-                path: 'tests/Fixtures/test-pdf.pdf', 
-                title: 'My document title' // optional
-            ),
-        ]),
-        // From a storage path
-        new UserMessage('Here is the document from a storage path', [
-            Document::fromStoragePath(
-                path: 'mystoragepath/file.pdf', 
-                disk: 'my-disk', // optional - omit/null for default disk
-                title: 'My document title' // optional
-            ),
-        ]),
-        // From base64
-        new UserMessage('Here is the document from base64', [
-            Document::fromBase64(
-                base64: $baseFromDB, 
-                mimeType: 'optional/mimetype', // optional 
-                title: 'My document title' // optional
-            ),
-        ]),
-        // From raw content
-        new UserMessage('Here is the document from raw content', [
-            Document::fromRawContent(
-                rawContent: $rawContent, 
-                mimeType: 'optional/mimetype', // optional 
-                title: 'My document title' // optional
-            ),
-        ]),
-        // From a text string
-        new UserMessage('Here is the document from a text string (e.g. from your database)', [
-            Document::fromText(
-                text: 'Hello world!', 
-                title: 'My document title' // optional
-            ),
-        ]),
-        // From an URL
-        new UserMessage('Here is the document from a url (make sure this is publically accessible)', [
-            Document::fromUrl(
-                url: 'https://example.com/test-pdf.pdf', 
-                title: 'My document title' // optional
-            ),
-        ]),
-        // From chunks
-        new UserMessage('Here is a chunked document', [
-            Document::fromChunks(
-                chunks: [
-                    'chunk one',
-                    'chunk two'
-                ], 
-                title: 'My document title' // optional
-            ),
-        ]),
-    ])
+    ->withPrompt(
+        'Analyze this document',
+        [Document::fromLocalPath(
+            path: 'tests/Fixtures/test-pdf.pdf', 
+            title: 'My document title' // optional
+        )]
+    )
     ->asText();
 
+// From a storage path
+$response = Prism::text()
+    ->using('my-provider', 'my-model')
+    ->withPrompt(
+        'Summarize this document',
+        [Document::fromStoragePath(
+            path: 'mystoragepath/file.pdf', 
+            disk: 'my-disk', // optional - omit/null for default disk
+            title: 'My document title' // optional
+        )]
+    )
+    ->asText();
+
+// From base64
+$response = Prism::text()
+    ->using('my-provider', 'my-model')
+    ->withPrompt(
+        'Extract key points from this document',
+        [Document::fromBase64(
+            base64: $baseFromDB, 
+            mimeType: 'optional/mimetype', // optional 
+            title: 'My document title' // optional
+        )]
+    )
+    ->asText();
+
+// From raw content
+$response = Prism::text()
+    ->using('my-provider', 'my-model')
+    ->withPrompt(
+        'Review this document',
+        [Document::fromRawContent(
+            rawContent: $rawContent, 
+            mimeType: 'optional/mimetype', // optional 
+            title: 'My document title' // optional
+        )]
+    )
+    ->asText();
+
+// From a text string
+$response = Prism::text()
+    ->using('my-provider', 'my-model')
+    ->withPrompt(
+        'Process this text document',
+        [Document::fromText(
+            text: 'Hello world!', 
+            title: 'My document title' // optional
+        )]
+    )
+    ->asText();
+
+// From an URL
+$response = Prism::text()
+    ->using('my-provider', 'my-model')
+    ->withPrompt(
+        'Analyze this document from URL',
+        [Document::fromUrl(
+            url: 'https://example.com/test-pdf.pdf', 
+            title: 'My document title' // optional
+        )]
+    )
+    ->asText();
+
+// From chunks
+$response = Prism::text()
+    ->using('my-provider', 'my-model')
+    ->withPrompt(
+        'Process this chunked document',
+        [Document::fromChunks(
+            chunks: [
+                'chunk one',
+                'chunk two'
+            ], 
+            title: 'My document title' // optional
+        )]
+    )
+    ->asText();
+```
+
+## Alternative: Using withMessages
+
+You can also include documents using the message-based approach:
+
+```php
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+use Prism\Prism\ValueObjects\Media\Document;
+
+$message = new UserMessage(
+    'Analyze this document',
+    [Document::fromLocalPath(
+        path: 'tests/Fixtures/test-pdf.pdf', 
+        title: 'My document title' // optional
+    )]
+);
+
+$response = Prism::text()
+    ->using('my-provider', 'my-model')
+    ->withMessages([$message])
+    ->asText();
 ```
 
 Or, if using an OpenAI file_id - add an `OpenAIFile`:
 
 ```php
-use Prism\Enums\Provider;
+use Prism\Prism\Enums\Provider;
 use Prism\Prism\Prism;
-use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Prism\Prism\ValueObjects\Media\OpenAIFile;
 
-Prism::text()
+$response = Prism::text()
     ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
-    ->withMessages([
-        new UserMessage('Here is the document from file_id', [
-            new OpenAIFile('file-lsfgSXyV2xEb8gw8fYjXU6'),
-        ]),
-    ])
+    ->withPrompt(
+        'Analyze this OpenAI file',
+        [new OpenAIFile('file-lsfgSXyV2xEb8gw8fYjXU6')]
+    )
     ->asText();
 ```

--- a/docs/input-modalities/images.md
+++ b/docs/input-modalities/images.md
@@ -12,43 +12,73 @@ For other media types like videos, audio files, and YouTube videos, see the [Med
 
 ## Getting started
 
-To add an image to your message, add an `Image` value object to the `additionalContent` property:
+To add an image to your prompt, use the `withPrompt` method with an `Image` value object:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\ValueObjects\Media\Image;
+
+// From a local path
+$response = Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
+    ->withPrompt(
+        "What's in this image?",
+        [Image::fromLocalPath(path: '/path/to/image.jpg')]
+    )
+    ->asText();
+
+// From a path on a storage disk
+$response = Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
+    ->withPrompt(
+        "What's in this image?",
+        [Image::fromStoragePath(
+            path: '/path/to/image.jpg', 
+            disk: 'my-disk' // optional - omit/null for default disk
+        )]
+    )
+    ->asText();
+
+// From a URL
+$response = Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
+    ->withPrompt(
+        'Analyze this diagram:',
+        [Image::fromUrl(url: 'https://example.com/diagram.png')]
+    )
+    ->asText();
+
+// From base64
+$response = Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
+    ->withPrompt(
+        'Analyze this diagram:',
+        [Image::fromBase64(base64: base64_encode(file_get_contents('/path/to/image.jpg')))]
+    )
+    ->asText();
+
+// From raw content
+$response = Prism::text()
+    ->using(Provider::Anthropic, 'claude-3-5-sonnet-20241022')
+    ->withPrompt(
+        'Analyze this diagram:',
+        [Image::fromRawContent(rawContent: file_get_contents('/path/to/image.jpg'))]
+    )
+    ->asText();
+```
+
+## Alternative: Using withMessages
+
+You can also include images using the message-based approach:
 
 ```php
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Prism\Prism\ValueObjects\Media\Image;
 
-// From a local path
 $message = new UserMessage(
     "What's in this image?",
     [Image::fromLocalPath(path: '/path/to/image.jpg')]
-);
-
-// From a path on a storage disk
-$message = new UserMessage(
-    "What's in this image?",
-    [Image::fromStoragePath(
-        path: '/path/to/image.jpg', 
-        disk: 'my-disk' // optional - omit/null for default disk
-    )]
-);
-
-// From a URL
-$message = new UserMessage(
-    'Analyze this diagram:',
-    [Image::fromUrl(url: 'https://example.com/diagram.png')]
-);
-
-// From base64
-$message = new UserMessage(
-    'Analyze this diagram:',
-    [Image::fromBase64(base64: base64_encode(file_get_contents('/path/to/image.jpg')))]
-);
-
-// From raw content
-$message = new UserMessage(
-    'Analyze this diagram:',
-    [Image::fromRawContent(rawContent: file_get_contents('/path/to/image.jpg'))]
 );
 
 $response = Prism::text()

--- a/docs/input-modalities/video.md
+++ b/docs/input-modalities/video.md
@@ -14,61 +14,97 @@ For other input modalities like audio and images, see their respective documenta
 
 ## Getting started
 
-To add a video to your message, add a `Video` value object to the `additionalContent` property:
+To add a video to your prompt, use the `withPrompt` method with a `Video` value object:
+
+```php
+use Prism\Prism\Prism;
+use Prism\Prism\Enums\Provider;
+use Prism\Prism\ValueObjects\Media\Video;
+
+// From a local path
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        "What's in this video?",
+        [Video::fromLocalPath(path: '/path/to/video.mp4')]
+    )
+    ->asText();
+
+// From a path on a storage disk
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        "What's in this video?",
+        [Video::fromStoragePath(
+            path: '/path/to/video.mp4', 
+            disk: 'my-disk' // optional - omit/null for default disk
+        )]
+    )
+    ->asText();
+
+// From a URL
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'Analyze this video:',
+        [Video::fromUrl(url: 'https://example.com/video.mp4')]
+    )
+    ->asText();
+
+// From a YouTube URL (automatically extracts the video ID)
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'What is this YouTube video about?',
+        [Video::fromUrl(url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ')]
+    )
+    ->asText();
+
+// From shortened YouTube URL
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'What is this YouTube video about?',
+        [Video::fromUrl(url: 'https://youtu.be/dQw4w9WgXcQ')]
+    )
+    ->asText();
+
+// From base64
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'Analyze this video:',
+        [Video::fromBase64(
+            base64: base64_encode(file_get_contents('/path/to/video.mp4')),
+            mimeType: 'video/mp4'
+        )]
+    )
+    ->asText();
+
+// From raw content
+$response = Prism::text()
+    ->using(Provider::Gemini, 'gemini-1.5-flash')
+    ->withPrompt(
+        'Analyze this video:',
+        [Video::fromRawContent(
+            rawContent: file_get_contents('/path/to/video.mp4'),
+            mimeType: 'video/mp4'
+        )]
+    )
+    ->asText();
+```
+
+## Alternative: Using withMessages
+
+You can also include videos using the message-based approach:
 
 ```php
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Prism\Prism\ValueObjects\Media\Video;
 
-// From a local path
 $message = new UserMessage(
     "What's in this video?",
     [Video::fromLocalPath(path: '/path/to/video.mp4')]
-);
-
-// From a path on a storage disk
-$message = new UserMessage(
-    "What's in this video?",
-    [Video::fromStoragePath(
-        path: '/path/to/video.mp4', 
-        disk: 'my-disk' // optional - omit/null for default disk
-    )]
-);
-
-// From a URL
-$message = new UserMessage(
-    'Analyze this video:',
-    [Video::fromUrl(url: 'https://example.com/video.mp4')]
-);
-
-// From a YouTube URL (automatically extracts the video ID)
-$message = new UserMessage(
-    'What is this YouTube video about?',
-    [Video::fromUrl(url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ')]
-);
-
-// From shortened YouTube URL
-$message = new UserMessage(
-    'What is this YouTube video about?',
-    [Video::fromUrl(url: 'https://youtu.be/dQw4w9WgXcQ')]
-);
-
-// From base64
-$message = new UserMessage(
-    'Analyze this video:',
-    [Video::fromBase64(
-        base64: base64_encode(file_get_contents('/path/to/video.mp4')),
-        mimeType: 'video/mp4'
-    )]
-);
-
-// From raw content
-$message = new UserMessage(
-    'Analyze this video:',
-    [Video::fromRawContent(
-        rawContent: file_get_contents('/path/to/video.mp4'),
-        mimeType: 'video/mp4'
-    )]
 );
 
 $response = Prism::text()
@@ -103,14 +139,10 @@ Example:
 ```php
 $response = Prism::text()
     ->using(Provider::Gemini, 'gemini-1.5-flash')
-    ->withMessages([
-        new UserMessage(
-            'What is this YouTube video about?',
-            additionalContent: [
-                Video::fromUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ'),
-            ],
-        ),
-    ])
+    ->withPrompt(
+        'What is this YouTube video about?',
+        [Video::fromUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')]
+    )
     ->asText();
 ```
 

--- a/src/Concerns/HasPrompts.php
+++ b/src/Concerns/HasPrompts.php
@@ -5,6 +5,13 @@ declare(strict_types=1);
 namespace Prism\Prism\Concerns;
 
 use Illuminate\Contracts\View\View;
+use Prism\Prism\ValueObjects\Messages\Support\Audio;
+use Prism\Prism\ValueObjects\Messages\Support\Document;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
+use Prism\Prism\ValueObjects\Messages\Support\Media;
+use Prism\Prism\ValueObjects\Messages\Support\OpenAIFile;
+use Prism\Prism\ValueObjects\Messages\Support\Text;
+use Prism\Prism\ValueObjects\Messages\Support\Video;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 trait HasPrompts
@@ -12,13 +19,22 @@ trait HasPrompts
     protected ?string $prompt = null;
 
     /**
+     * @var array<int, Audio|Text|Image|Media|Document|OpenAIFile|Video>
+     */
+    protected array $additionalContent = [];
+
+    /**
      * @var SystemMessage[]
      */
     protected array $systemPrompts = [];
 
-    public function withPrompt(string|View $prompt): self
+    /**
+     * @param  array<int, Audio|Text|Image|Media|Document|OpenAIFile|Video>  $additionalContent
+     */
+    public function withPrompt(string|View $prompt, array $additionalContent = []): self
     {
         $this->prompt = is_string($prompt) ? $prompt : $prompt->render();
+        $this->additionalContent = $additionalContent;
 
         return $this;
     }

--- a/src/Concerns/HasPrompts.php
+++ b/src/Concerns/HasPrompts.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Prism\Prism\Concerns;
 
 use Illuminate\Contracts\View\View;
-use Prism\Prism\ValueObjects\Messages\Support\Audio;
-use Prism\Prism\ValueObjects\Messages\Support\Document;
-use Prism\Prism\ValueObjects\Messages\Support\Image;
-use Prism\Prism\ValueObjects\Messages\Support\Media;
-use Prism\Prism\ValueObjects\Messages\Support\OpenAIFile;
-use Prism\Prism\ValueObjects\Messages\Support\Text;
-use Prism\Prism\ValueObjects\Messages\Support\Video;
+use Prism\Prism\ValueObjects\Media\Audio;
+use Prism\Prism\ValueObjects\Media\Document;
+use Prism\Prism\ValueObjects\Media\Image;
+use Prism\Prism\ValueObjects\Media\Media;
+use Prism\Prism\ValueObjects\Media\OpenAIFile;
+use Prism\Prism\ValueObjects\Media\Text;
+use Prism\Prism\ValueObjects\Media\Video;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 trait HasPrompts

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -55,7 +55,7 @@ class PendingRequest
         $messages = $this->messages;
 
         if ($this->prompt) {
-            $messages[] = new UserMessage($this->prompt);
+            $messages[] = new UserMessage($this->prompt, $this->additionalContent);
         }
 
         if (! $this->schema instanceof \Prism\Prism\Contracts\Schema) {

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -78,7 +78,7 @@ class PendingRequest
         $messages = $this->messages;
 
         if ($this->prompt) {
-            $messages[] = new UserMessage($this->prompt);
+            $messages[] = new UserMessage($this->prompt, $this->additionalContent);
         }
 
         return new Request(

--- a/tests/Structured/PendingRequestTest.php
+++ b/tests/Structured/PendingRequestTest.php
@@ -8,6 +8,7 @@ use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Schema\StringSchema;
 use Prism\Prism\Structured\PendingRequest;
 use Prism\Prism\Structured\Request;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 
@@ -144,4 +145,34 @@ test('it gets nested provider option value', function (): void {
     $generated = $request->toRequest();
 
     expect($generated->providerOptions('deep.nested'))->toBe('value');
+});
+
+test('it can set prompt with additional content in structured request', function (): void {
+    $image = Image::fromUrl('https://example.com/image.jpg');
+
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withSchema(new StringSchema('test', 'test description'))
+        ->withPrompt('Analyze this image', [$image]);
+
+    $generated = $request->toRequest();
+
+    expect($generated->prompt())->toBe('Analyze this image')
+        ->and($generated->messages()[0])->toBeInstanceOf(UserMessage::class)
+        ->and($generated->messages()[0]->additionalContent)->toHaveCount(2) // Text + Image
+        ->and($generated->messages()[0]->images())->toHaveCount(1)
+        ->and($generated->messages()[0]->images()[0])->toBe($image);
+});
+
+test('structured withPrompt maintains backward compatibility without additional content', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withSchema(new StringSchema('test', 'test description'))
+        ->withPrompt('Hello AI');
+
+    $generated = $request->toRequest();
+
+    expect($generated->prompt())->toBe('Hello AI')
+        ->and($generated->messages()[0])->toBeInstanceOf(UserMessage::class)
+        ->and($generated->messages()[0]->additionalContent)->toHaveCount(1); // Only Text
 });

--- a/tests/Text/PendingRequestTest.php
+++ b/tests/Text/PendingRequestTest.php
@@ -10,6 +10,7 @@ use Prism\Prism\Facades\Tool;
 use Prism\Prism\Providers\Provider as ProviderContract;
 use Prism\Prism\Text\PendingRequest;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
+use Prism\Prism\ValueObjects\Messages\Support\Image;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Tests\TestDoubles\TestProvider;
@@ -324,3 +325,31 @@ test('you can run toRequest multiple times', function (): void {
     $request->toRequest();
     $request->toRequest();
 })->throwsNoExceptions();
+
+test('it can set prompt with additional content', function (): void {
+    $image = Image::fromUrl('https://example.com/image.jpg');
+
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withPrompt('Analyze this image', [$image]);
+
+    $generated = $request->toRequest();
+
+    expect($generated->prompt())->toBe('Analyze this image')
+        ->and($generated->messages()[0])->toBeInstanceOf(UserMessage::class)
+        ->and($generated->messages()[0]->additionalContent)->toHaveCount(2) // Text + Image
+        ->and($generated->messages()[0]->images())->toHaveCount(1)
+        ->and($generated->messages()[0]->images()[0])->toBe($image);
+});
+
+test('withPrompt maintains backward compatibility without additional content', function (): void {
+    $request = $this->pendingRequest
+        ->using(Provider::OpenAI, 'gpt-4')
+        ->withPrompt('Hello AI');
+
+    $generated = $request->toRequest();
+
+    expect($generated->prompt())->toBe('Hello AI')
+        ->and($generated->messages()[0])->toBeInstanceOf(UserMessage::class)
+        ->and($generated->messages()[0]->additionalContent)->toHaveCount(1); // Only Text
+});


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

Adds support for `additionalContent` (media) to be provided when using `withPrompt`.

```php
Prism::text()
    ->using(Provider::Anthropic, 'claude-sonnet-4-0')
    ->withPrompt(
        "Analyze this screenshot",
        [Image::fromPath($screenshot->getPathname())]
    )
    ->asText()
```
