### PR TITLE
feat(openai): add detail option to payload in ImageMapper

### DIFF
--- a/src/Providers/OpenAI/Maps/ImageMapper.php
+++ b/src/Providers/OpenAI/Maps/ImageMapper.php
@@ -32,6 +32,10 @@ class ImageMapper extends ProviderMediaMapper
             );
         }
 
+        if ($this->media->providerOptions('detail')) {
+            $payload['detail'] = $this->media->providerOptions('detail');
+        }
+
         return array_filter($payload);
     }
 


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
This MR add support for the detail for openai provider.
https://platform.openai.com/docs/guides/images-vision?api-mode=responses#specify-image-input-detail-level

Resolves #504

Usage:

```php
use Prism\Prism\Prism;
use Prism\Prism\ValueObjects\Media\Image;

$image = Image::fromLocalPath('/path/to/image.jpg')
    ->withProviderOptions(['detail' => 'high']);

$response = Prism::text()
    ->using('openai', 'gpt-4o')
    ->withPrompt('What do you see in this image?', [$image])
    ->asText();
```

## Breaking Changes
No breaking Chnages.
