### PR TITLE
fix(openai): update usage token keys to match API changes

### DIFF
--- a/src/Providers/OpenAI/Handlers/Audio.php
+++ b/src/Providers/OpenAI/Handlers/Audio.php
@@ -55,8 +55,8 @@ class Audio
         $usage = null;
         if (isset($data['usage'])) {
             $usage = new Usage(
-                promptTokens: $data['usage']['prompt_tokens'] ?? 0,
-                completionTokens: $data['usage']['completion_tokens'] ?? 0,
+                promptTokens: $data['usage']['input_tokens'] ?? 0,
+                completionTokens: $data['usage']['total_tokens'] ?? 0,
             );
         }
 

--- a/tests/Providers/OpenAI/AudioTest.php
+++ b/tests/Providers/OpenAI/AudioTest.php
@@ -252,8 +252,7 @@ describe('Speech-to-Text', function (): void {
             'api.openai.com/v1/audio/transcriptions' => Http::response([
                 'text' => 'Usage tracking test.',
                 'usage' => [
-                    'prompt_tokens' => 5,
-                    'completion_tokens' => 8,
+                    'input_tokens' => 5,
                     'total_tokens' => 13,
                 ],
             ], 200),
@@ -268,7 +267,7 @@ describe('Speech-to-Text', function (): void {
 
         expect($response->usage)->not->toBeNull();
         expect($response->usage->promptTokens)->toBe(5);
-        expect($response->usage->completionTokens)->toBe(8);
+        expect($response->usage->completionTokens)->toBe(13);
     });
 
     it('handles transcription without usage information', function (): void {


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
Currently while using Openai Audio SpeechToText the correct usagae is not visible.

https://platform.openai.com/docs/api-reference/audio/createTranscription

## Breaking Changes
<!-- Put any breaking changes here. Remove this section if there are no breaking changes -->
No breaking change