### PR TITLE
docs(media): update parameter names for fromStoragePath

### DIFF
--- a/docs/input-modalities/audio.md
+++ b/docs/input-modalities/audio.md
@@ -36,8 +36,8 @@ $response = Prism::text()
     ->withPrompt(
         "What's in this audio?",
         [Audio::fromStoragePath(
-            path: '/path/to/audio.mp3', 
-            disk: 'my-disk' // optional - omit/null for default disk
+            path: '/path/to/audio.mp3',
+            diskName: 'my-disk' // optional - omit/null for default disk
         )]
     )
     ->asText();
@@ -106,7 +106,7 @@ Prism supports a variety of audio formats, including:
 
 The specific supported formats depend on the provider. Gemini is currently the main provider with comprehensive audio analysis capabilities. Check the provider's documentation for a complete list of supported formats.
 
-## Transfer mediums 
+## Transfer mediums
 
 Providers are not consistent in their support of sending raw contents, base64 and/or URLs.
 

--- a/docs/input-modalities/documents.md
+++ b/docs/input-modalities/documents.md
@@ -62,7 +62,7 @@ $response = Prism::text()
         'Summarize this document',
         [Document::fromStoragePath(
             path: 'mystoragepath/file.pdf',
-            disk: 'my-disk', // optional - omit/null for default disk
+            diskName: 'my-disk', // optional - omit/null for default disk
             title: 'My document title' // optional
         )]
     )

--- a/docs/input-modalities/images.md
+++ b/docs/input-modalities/images.md
@@ -30,8 +30,8 @@ $response = Prism::text()
     ->withPrompt(
         "What's in this image?",
         [Image::fromStoragePath(
-            path: '/path/to/image.jpg', 
-            disk: 'my-disk' // optional - omit/null for default disk
+            path: '/path/to/image.jpg',
+            diskName: 'my-disk' // optional - omit/null for default disk
         )]
     )
     ->asText();
@@ -83,9 +83,9 @@ $response = Prism::text()
     ->asText();
 ```
 
-## Transfer mediums 
+## Transfer mediums
 
-Providers are not consistent in their support of sending raw contents, base64 and/or URLs (as noted above). 
+Providers are not consistent in their support of sending raw contents, base64 and/or URLs (as noted above).
 
 Prism tries to smooth over these rough edges, but its not always possible.
 

--- a/docs/input-modalities/video.md
+++ b/docs/input-modalities/video.md
@@ -36,8 +36,8 @@ $response = Prism::text()
     ->withPrompt(
         "What's in this video?",
         [Video::fromStoragePath(
-            path: '/path/to/video.mp4', 
-            disk: 'my-disk' // optional - omit/null for default disk
+            path: '/path/to/video.mp4',
+            diskName: 'my-disk' // optional - omit/null for default disk
         )]
     )
     ->asText();
@@ -146,7 +146,7 @@ $response = Prism::text()
     ->asText();
 ```
 
-## Transfer mediums 
+## Transfer mediums
 
 Providers are not consistent in their support of sending raw contents, base64 and/or URLs.
 


### PR DESCRIPTION
<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description
The wrong parameter name is used in the docs.
In all `fromStoragePath` functions, change `disk` to `diskName` as used in the code.

Also remove any trailing whitespace at the ends of lines.

## Breaking Changes
-
