### PR TITLE
[Gemini] Remove false restriction for using custom and provider tools

### DIFF
--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -87,10 +87,6 @@ class Text
             'thinkingConfig' => $thinkingConfig !== [] ? $thinkingConfig : null,
         ]);
 
-        if ($request->tools() !== [] && $request->providerTools() != []) {
-            throw new PrismException('Use of provider tools with custom tools is not currently supported by Gemini.');
-        }
-
         $tools = [];
 
         if ($request->providerTools() !== []) {


### PR DESCRIPTION
## Description

The Gemini provider doesn't allow using custom tools together with private tools in one request but it's possible:

```
$prism = Prism::text()->using( 'gemini', 'gemini-2.0-flash' )
    ->whenProvider( 'gemini', fn( $request ) => $request
        ->withProviderTools( [
            new ProviderTool( 'google_search_retrieval' ),
            new ProviderTool( 'urlContext' )
        ] )
    )->withPrompt( $prompt )->asText();
```
