### PR TITLE
feat(openrouter): Improve OpenRouter reasoning and structured response handling

### DIFF
--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -165,6 +165,28 @@ foreach ($stream as $chunk) {
 }
 ```
 
+#### Reasoning Effort
+
+Control how much reasoning the model performs before generating a response using the `reasoning` parameter. The way this is structured depends on the underlying model you are calling:
+
+```php
+$response = Prism::text()
+    ->using(Provider::OpenRouter, 'openai/gpt-5-mini')
+    ->withPrompt('Write a PHP function to implement a binary search algorithm with proper error handling')
+    ->withProviderOptions([
+        'reasoning' => [
+            'effort' => 'high',  // Can be "high", "medium", or "low" (OpenAI-style)
+            'max_tokens' =>  2000, // Specific token limit (Gemini / Anthropic-style)
+            
+            // Optional: Default is false. All models support this.
+            'exclude': false, // Set to true to exclude reasoning tokens from response
+            // Or enable reasoning with the default parameters:
+            'enabled': true // Default: inferred from `effort` or `max_tokens`
+        ]
+    ])
+    ->asText();
+```
+
 ## Available Models
 
 OpenRouter supports many models from different providers. Some popular options include:

--- a/src/Providers/OpenRouter/Handlers/Stream.php
+++ b/src/Providers/OpenRouter/Handlers/Stream.php
@@ -334,6 +334,7 @@ class Stream
                 ], Arr::whereNotNull([
                     'temperature' => $request->temperature(),
                     'top_p' => $request->topP(),
+                    'reasoning' => $request->providerOptions('reasoning') ?? null,
                     'tools' => ToolMap::map($request->tools()),
                     'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
                     'stream_options' => ['include_usage' => true],

--- a/src/Providers/OpenRouter/Handlers/Structured.php
+++ b/src/Providers/OpenRouter/Handlers/Structured.php
@@ -34,8 +34,6 @@ class Structured
 
     public function handle(Request $request): StructuredResponse
     {
-        $request = $this->appendMessageForJsonMode($request);
-
         $data = $this->sendRequest($request);
 
         $this->validateResponse($data);
@@ -44,6 +42,8 @@ class Structured
     }
 
     /**
+     * @see https://openrouter.ai/docs/features/structured-outputs
+     *
      * @return array<string, mixed>
      */
     protected function sendRequest(Request $request): array
@@ -54,10 +54,19 @@ class Structured
                 'model' => $request->model(),
                 'messages' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
                 'max_tokens' => $request->maxTokens(),
+                'structured_outputs' => true,
             ], Arr::whereNotNull([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
-                'response_format' => ['type' => 'json_object'],
+                'reasoning' => $request->providerOptions('reasoning') ?? null,
+                'response_format' => [
+                    'type' => 'json_object',
+                    'json_schema' => [
+                        'name' => $request->schema()->name(),
+                        'strict' => true,
+                        'schema' => $request->schema()->toArray(),
+                    ],
+                ],
             ]))
         );
 
@@ -103,13 +112,5 @@ class Structured
         $this->responseBuilder->addStep($step);
 
         return $this->responseBuilder->toResponse();
-    }
-
-    protected function appendMessageForJsonMode(Request $request): Request
-    {
-        return $request->addMessage(new SystemMessage(sprintf(
-            "You MUST respond EXCLUSIVELY with a JSON object that strictly adheres to the following schema. \n Do NOT explain or add other content. Validate your response against this schema \n %s",
-            json_encode($request->schema()->toArray(), JSON_PRETTY_PRINT)
-        )));
     }
 }

--- a/src/Providers/OpenRouter/Handlers/Structured.php
+++ b/src/Providers/OpenRouter/Handlers/Structured.php
@@ -16,7 +16,6 @@ use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Structured\ResponseBuilder;
 use Prism\Prism\Structured\Step;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
-use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Prism\Prism\ValueObjects\Meta;
 use Prism\Prism\ValueObjects\Usage;
 

--- a/src/Providers/OpenRouter/Handlers/Text.php
+++ b/src/Providers/OpenRouter/Handlers/Text.php
@@ -109,6 +109,7 @@ class Text
             ], Arr::whereNotNull([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
+                'reasoning' => $request->providerOptions('reasoning') ?? null,
                 'tools' => ToolMap::map($request->tools()),
                 'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
             ]))


### PR DESCRIPTION
## Description

This PR aims to improve the handling of OpenRouter `reasoning` parameter, as well as adhere to their suggested structure for structured responses.

## Breaking Changes

For my use-case using a variety of newer models through OpenRouter, this was actually a fix rather than a breaking change, however it's possible that this may break things for older models.

Tested models include:

- OpenAI: gpt-oss-20b (free)
- Google: Gemma 3 12B
- Google: Gemini 2.0 Flash Lite
- OpenAI: GPT-5 Nano
- Google: Gemini 2.5 Flash Lite
- Google: Gemini 2.0 Flash
- Meta: Llama 4 Maverick
- Qwen: Qwen3 30B A3B Instruct 2507
- OpenAI: GPT-5 Mini
- MoonshotAI: Kimi K2
- Google: Gemini 2.5 Flash
