### PR TITLE
docs: Add ObjectSchema requirement warnings for structured output

### DIFF
--- a/docs/core-concepts/schemas.md
+++ b/docs/core-concepts/schemas.md
@@ -6,6 +6,9 @@ Schemas are the blueprints that help you define the shape of your data in Prism.
 
 Let's dive right in with a practical example:
 
+> [!IMPORTANT]
+> **Structured Output Requirement**: When using schemas for structured output with providers like OpenAI (especially in strict mode), the root schema should be an `ObjectSchema`. Other schema types can only be used as properties within an ObjectSchema, not as the top-level schema. Different providers may have varying requirements.
+
 ```php
 use Prism\Prism\Schema\ArraySchema;
 use Prism\Prism\Schema\ObjectSchema;
@@ -107,6 +110,9 @@ $statusSchema = new EnumSchema(
 ### ObjectSchema
 
 For complex, nested data structures. The Swiss Army knife of schemas!
+
+> [!NOTE]
+> ObjectSchema is typically required as the root schema for structured output operations with providers like OpenAI. It's the recommended schema type to use directly with `withSchema()` in structured output requests, though different providers may have varying requirements.
 
 ```php
 use Prism\Prism\Schema\ObjectSchema;

--- a/docs/core-concepts/structured-output.md
+++ b/docs/core-concepts/structured-output.md
@@ -6,6 +6,9 @@ Want your AI responses as neat and tidy as a Marie Kondo-approved closet? Struct
 
 Here's how to get structured data from your AI:
 
+> [!IMPORTANT]
+> **Schema Requirement for OpenAI**: When using OpenAI's structured output (especially strict mode), the root schema must be an `ObjectSchema`. Other schema types (StringSchema, NumberSchema, etc.) can only be used as properties within an ObjectSchema, not as the top-level schema. Other providers may have different requirements.
+
 ```php
 use Prism\Prism\Prism;
 use Prism\Prism\Enums\Provider;

--- a/docs/core-concepts/testing.md
+++ b/docs/core-concepts/testing.md
@@ -321,6 +321,9 @@ expect($outputText)->toBe('fake response text')
 
 ## Testing Structured Output
 
+> [!NOTE]
+> When testing OpenAI-style structured output (strict mode), the root schema should be an `ObjectSchema`.
+
 ```php
 use Prism\Prism\Prism;
 use Prism\Prism\Testing\StructuredResponseFake;

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -42,6 +42,9 @@ echo $response->text;
 
 ### Structured Output
 
+> [!NOTE]
+> OpenRouter uses OpenAI-compatible structured outputs. For strict schema validation, the root schema should be an `ObjectSchema`.
+
 ```php
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\Enums\Provider;

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -57,6 +57,9 @@ foreach ($stream as $chunk) {
 
 xAI supports structured output through JSON schema validation. The following models support structured output:
 
+> [!NOTE]
+> xAI uses an OpenAI-compatible API. For strict schema validation, the root schema should be an `ObjectSchema`.
+
 - `grok-3`
 - `grok-4`
 


### PR DESCRIPTION
- Add provider-specific ObjectSchema requirement notes
- Clarify that ObjectSchema requirement is primarily for OpenAI strict mode
- Update core structured output and schemas documentation
- Modify provider docs (XAI, OpenRouter) to note OpenAI compatibility
- Remove incorrect universal requirement from Anthropic docs
- Update testing docs to clarify OpenAI-style structured output

Fixes #587

<!-- Please review our contributing guidelines https://github.com/echolabsdev/prism/blob/main/.github/CONTRIBUTING.md -->
## Description

## Breaking Changes
<!-- Put any breaking changes here. Remove this section if there are no breaking changes -->
