### PR TITLE
fix: ensure tool result `output` is always string

### DIFF
--- a/src/Providers/OpenAI/Maps/MessageMap.php
+++ b/src/Providers/OpenAI/Maps/MessageMap.php
@@ -68,10 +68,18 @@ class MessageMap
     protected function mapToolResultMessage(ToolResultMessage $message): void
     {
         foreach ($message->toolResults as $toolResult) {
+            $output = $toolResult->result;
+            if (! is_string($output)) {
+                $output = is_array($output) ? json_encode(
+                    $output,
+                    JSON_THROW_ON_ERROR,
+                ) : strval($output);
+            }
+
             $this->mappedMessages[] = [
                 'type' => 'function_call_output',
                 'call_id' => $toolResult->toolCallResultId,
-                'output' => $toolResult->result,
+                'output' => $output,
             ];
         }
     }


### PR DESCRIPTION
ChatGPT requires the `output` field to be a string. Previously, non-string results (arrays, numbers, etc.) were passed directly, causing errors. Now all non-string outputs are converted to JSON or stringified.

If I tried to pass the result as an array like in this example: 
```php
//This is not a working example
Prism::text()
    ->using(
        Provider::OpenAI,
        'gpt-4.1-mini'
    )
    ->withTools([
        (new Tool())->as('someFunc')
            ->for('Description')
            ->withStringParameter('someParam', 'Description')
            ->using(function ($someParam) {
                return json_encode(['hello' => 'world']);
            }),
    ])
    ->withMessages([
        new UserMessage('Hello there'),
        new AssistantMessage(
            '',
            [
                new ToolCall(
                    'fc_000000000000000000000000000000000000000000000',
                    'someFunc',
                    ['hello' => 'world'],
                    'call_000000000000000000000000',
                    null,
                ),
            ]
        ),
        new ToolResultMessage([
            new ToolResult(
                'call_000000000000000000000000',
                'someFunc',
                ['hello' => 'world'],
                ['hello' => 'world'],
                'fc_000000000000000000000000000000000000000000000'
            ),
        ]),
    ])
    ->asText();
```

It always gave me this error:
```json
{
    "error": {
        "message": "Invalid type for 'input[3].output': expected a string, but got an object instead.",
        "type": "invalid_request_error",
        "param": "input[3].output",
        "code": "invalid_type"
    }
}
```

The solution was to simple pass result always as an string:
```php
json_encode(['hello' => 'world'])
```

But with these changes that will not be necessary.