### PR TITLE
Prevent recursive endless loop on create a resource from url media

### DIFF
--- a/src/ValueObjects/Media/Media.php
+++ b/src/ValueObjects/Media/Media.php
@@ -247,7 +247,7 @@ class Media
         if ($this->url) {
             $this->fetchUrlContent();
 
-            return $this->resource();
+            return $this->createStreamFromContent($this->rawContent());
         }
 
         if ($this->rawContent || $this->base64) {

--- a/tests/ValueObjects/Media/MediaTest.php
+++ b/tests/ValueObjects/Media/MediaTest.php
@@ -153,6 +153,16 @@ describe('conversion', function (): void {
         expect($media->rawContent())->toBe(file_get_contents('tests/Fixtures/diamond.png'));
     });
 
+    it('converts url to a resource', function (): void {
+        Http::fake([
+            'https://prismphp.com/storage/diamond.png' => Http::response(file_get_contents('tests/Fixtures/diamond.png')),
+        ])->preventStrayRequests();
+
+        $media = Media::fromUrl('https://prismphp.com/storage/diamond.png');
+
+        expect($media->resource())->toBeResource();
+    });
+
     it('converts base64 to rawContent', function (): void {
         $media = Media::fromBase64(base64_encode('content'), 'text/plain');
 


### PR DESCRIPTION
## Description

When calling `->resource()` on an Url media, it recursively calls `->resource()` but always end up back in the same if-statement because the url check always takes precedence over the rawContent check.

```php
Media::fromUrl('https://prismphp.com/storage/diamond.png')->resource();
```

### Alternative fixes

- Move the url check below the raw content check
- Fetch the url content, then continue the code so it will reach the rawContent check

Let me know if you prefer one of the alternative fixes over this one. 
