### PR TITLE
Use media value object for generated audio and image

### DIFF
--- a/src/ValueObjects/GeneratedAudio.php
+++ b/src/ValueObjects/GeneratedAudio.php
@@ -4,20 +4,12 @@ declare(strict_types=1);
 
 namespace Prism\Prism\ValueObjects;
 
-readonly class GeneratedAudio
+class GeneratedAudio extends Media\Media
 {
     public function __construct(
-        public ?string $base64 = null,
+        ?string $base64 = null,
         public ?string $type = null,
-    ) {}
-
-    public function hasBase64(): bool
-    {
-        return $this->base64 !== null;
-    }
-
-    public function getMimeType(): ?string
-    {
-        return $this->type;
+    ) {
+        parent::construct(null, $base64, $type);
     }
 }

--- a/src/ValueObjects/GeneratedImage.php
+++ b/src/ValueObjects/GeneratedImage.php
@@ -4,32 +4,19 @@ declare(strict_types=1);
 
 namespace Prism\Prism\ValueObjects;
 
-readonly class GeneratedImage
+class GeneratedImage extends Media\Media
 {
     public function __construct(
-        public ?string $url = null,
-        public ?string $base64 = null,
+        ?string $url = null,
+        ?string $base64 = null,
         public ?string $revisedPrompt = null,
-        public ?string $mimeType = null,
-    ) {}
-
-    public function hasUrl(): bool
-    {
-        return $this->url !== null;
-    }
-
-    public function hasBase64(): bool
-    {
-        return $this->base64 !== null;
+        ?string $mimeType = null,
+    ) {
+        parent::__construct($url, $base64, $mimeType);
     }
 
     public function hasRevisedPrompt(): bool
     {
         return $this->revisedPrompt !== null;
-    }
-
-    public function hasMimeType(): bool
-    {
-        return $this->mimeType !== null;
     }
 }

--- a/src/ValueObjects/Media/Media.php
+++ b/src/ValueObjects/Media/Media.php
@@ -20,15 +20,23 @@ class Media
 
     protected ?string $storagePath = null;
 
-    protected ?string $url = null;
+    public ?string $url = null;
 
     protected ?string $rawContent = null;
 
-    protected ?string $base64 = null;
+    public ?string $base64 = null;
 
-    protected ?string $mimeType = null;
+    public ?string $mimeType = null;
 
-    final public function __construct() {}
+    public function __construct(
+        ?string $url = null,
+        ?string $base64 = null,
+        ?string $mimeType = null,
+    ) {
+        $this->url = $url;
+        $this->base64 = $base64;
+        $this->mimeType = $mimeType;
+    }
 
     public static function fromFileId(string $fileId): static
     {
@@ -153,6 +161,11 @@ class Media
         return $this->hasRawContent();
     }
 
+    public function hasMimeType(): bool
+    {
+        return $this->mimeType !== null;
+    }
+
     public function hasRawContent(): bool
     {
         if ($this->base64 !== null) {
@@ -166,6 +179,11 @@ class Media
         }
 
         return $this->isUrl();
+    }
+
+    public function hasUrl(): bool
+    {
+        return $this->url !== null;
     }
 
     public function fileId(): ?string


### PR DESCRIPTION
## Description

Provides methods from media value object in objects returned for generated audio and image. This simplifies the handling in client code because now it can be written as:

```php
            $images = collect( $response->images )
                ->map( fn( $image ) => $image->base64() )
```

instead of:

```php
            $images = collect( $response->images )
                ->map( fn( $image ) => $image->base64 ?? Image::fromUrl( $image->url )->base64() )
```

It automatically converts the returned format if necessary (in case it's an URL).
This is an implementation for https://github.com/prism-php/prism/issues/530.

## Breaking Changes

Breaking changes has been avoided and GeneratedImage and GeneratedAudio classes still provide exactly the same interface. Therefore, it was necessary to remove the "readonly" for both classes and to make the properties of these classes public in the Media class. Accessing public properties should be deprecated and change to "protected" again in the next major release.