### PR TITLE
Fix formatting in openai.md

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -306,7 +306,6 @@ $audioData = base64_decode($response->audio->base64);
 file_put_contents('welcome.mp3', $audioData);
 ```
 
-\
 #### High-Definition Audio
 
 For higher quality audio output, use the model:


### PR DESCRIPTION
Removed unnecessary backslash before the High-Definition Audio section.

## Description
Clean up docs.

## Breaking Changes
None
