### PR TITLE
feat(openai) Extend Schema's to allow for newly added values for the OpenAI API

### DIFF
--- a/src/Schema/AnyOfSchema.php
+++ b/src/Schema/AnyOfSchema.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Schema;
+
+use Prism\Prism\Contracts\Schema;
+
+class AnyOfSchema implements Schema
+{
+    /**
+     * @param  Schema[]  $schemas  Array of schema instances to match any of
+     * @param  string  $name  Optional name for the schema
+     * @param  string  $description  Optional description
+     */
+    public function __construct(
+        public readonly array $schemas,
+        public readonly ?string $name = null,
+        public readonly ?string $description = null,
+    ) {}
+
+    public function name(): string
+    {
+        return $this->name ?? 'item';
+    }
+
+    public function toArray(): array
+    {
+        $result = [
+            'anyOf' => array_map(fn (\Prism\Prism\Contracts\Schema $schema): array => $schema->toArray(), $this->schemas),
+        ];
+        if ($this->description !== null) {
+            $result['description'] = $this->description;
+        }
+        if ($this->name !== null) {
+            $result['name'] = $this->name;
+        }
+
+        return $result;
+    }
+}

--- a/src/Schema/ArraySchema.php
+++ b/src/Schema/ArraySchema.php
@@ -16,6 +16,8 @@ class ArraySchema implements Schema
         public readonly string $description,
         public readonly Schema $items,
         public readonly bool $nullable = false,
+        public readonly ?int $minItems = null,
+        public readonly ?int $maxItems = null,
     ) {}
 
     #[\Override]
@@ -27,12 +29,21 @@ class ArraySchema implements Schema
     #[\Override]
     public function toArray(): array
     {
-        return [
+        $schema = [
             'description' => $this->description,
             'type' => $this->nullable
                 ? $this->castToNullable('array')
                 : 'array',
             'items' => $this->items->toArray(),
         ];
+
+        if ($this->minItems !== null) {
+            $schema['minItems'] = $this->minItems;
+        }
+        if ($this->maxItems !== null) {
+            $schema['maxItems'] = $this->maxItems;
+        }
+
+        return $schema;
     }
 }

--- a/src/Schema/NumberSchema.php
+++ b/src/Schema/NumberSchema.php
@@ -15,6 +15,11 @@ class NumberSchema implements Schema
         public readonly string $name,
         public readonly string $description,
         public readonly bool $nullable = false,
+        public readonly ?float $multipleOf = null,
+        public readonly ?float $maximum = null,
+        public readonly ?float $exclusiveMaximum = null,
+        public readonly ?float $minimum = null,
+        public readonly ?float $exclusiveMinimum = null,
     ) {}
 
     #[\Override]
@@ -26,11 +31,29 @@ class NumberSchema implements Schema
     #[\Override]
     public function toArray(): array
     {
-        return [
+        $schema = [
             'description' => $this->description,
             'type' => $this->nullable
                 ? $this->castToNullable('number')
                 : 'number',
         ];
+
+        if ($this->multipleOf !== null) {
+            $schema['multipleOf'] = $this->multipleOf;
+        }
+        if ($this->maximum !== null) {
+            $schema['maximum'] = $this->maximum;
+        }
+        if ($this->exclusiveMaximum !== null) {
+            $schema['exclusiveMaximum'] = $this->exclusiveMaximum;
+        }
+        if ($this->minimum !== null) {
+            $schema['minimum'] = $this->minimum;
+        }
+        if ($this->exclusiveMinimum !== null) {
+            $schema['exclusiveMinimum'] = $this->exclusiveMinimum;
+        }
+
+        return $schema;
     }
 }

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -15,6 +15,8 @@ class StringSchema implements Schema
         public readonly string $name,
         public readonly string $description,
         public readonly bool $nullable = false,
+        public readonly ?string $pattern = null,
+        public readonly ?string $format = null,
     ) {}
 
     #[\Override]
@@ -26,11 +28,20 @@ class StringSchema implements Schema
     #[\Override]
     public function toArray(): array
     {
-        return [
+        $schema = [
             'description' => $this->description,
             'type' => $this->nullable
                 ? $this->castToNullable('string')
                 : 'string',
         ];
+
+        if ($this->pattern !== null) {
+            $schema['pattern'] = $this->pattern;
+        }
+        if ($this->format !== null) {
+            $schema['format'] = $this->format;
+        }
+
+        return $schema;
     }
 }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -239,3 +239,23 @@ it('non-nullable enum with single type returns single type', function (): void {
         'type' => 'string',
     ]);
 });
+it('supports ArraySchema minItems and maxItems', function (): void {
+    $schema = new ArraySchema(
+        name: 'tags',
+        description: 'User tags',
+        items: new StringSchema('tag', 'A tag'),
+        minItems: 1,
+        maxItems: 5
+    );
+    $expected = [
+        'description' => 'User tags',
+        'type' => 'array',
+        'items' => [
+            'description' => 'A tag',
+            'type' => 'string',
+        ],
+        'minItems' => 1,
+        'maxItems' => 5,
+    ];
+    expect($schema->toArray())->toBe($expected);
+});

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -239,6 +239,22 @@ it('non-nullable enum with single type returns single type', function (): void {
         'type' => 'string',
     ]);
 });
+it('supports StringSchema format and pattern', function (): void {
+    $schema = new StringSchema(
+        name: 'email',
+        description: 'User email',
+        pattern: '^[^@\s]+@[^@\s]+\.[^@\s]+$',
+        format: 'email'
+    );
+    $expected = [
+        'description' => 'User email',
+        'type' => 'string',
+        'pattern' => '^[^@\s]+@[^@\s]+\.[^@\s]+$',
+        'format' => 'email',
+    ];
+
+    expect($schema->toArray())->toBe($expected);
+});
 it('supports ArraySchema minItems and maxItems', function (): void {
     $schema = new ArraySchema(
         name: 'tags',

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -255,6 +255,29 @@ it('supports StringSchema format and pattern', function (): void {
 
     expect($schema->toArray())->toBe($expected);
 });
+
+it('supports NumberSchema restrictions', function (): void {
+    $schema = new NumberSchema(
+        name: 'score',
+        description: 'User score',
+        multipleOf: 0.5,
+        maximum: 10,
+        exclusiveMaximum: 10,
+        minimum: 0,
+        exclusiveMinimum: 0
+    );
+    $expected = [
+        'description' => 'User score',
+        'type' => 'number',
+        'multipleOf' => 0.5,
+        'maximum' => 10.0,
+        'exclusiveMaximum' => 10.0,
+        'minimum' => 0.0,
+        'exclusiveMinimum' => 0.0,
+    ];
+    expect($schema->toArray())->toBe($expected);
+});
+
 it('supports ArraySchema minItems and maxItems', function (): void {
     $schema = new ArraySchema(
         name: 'tags',


### PR DESCRIPTION
## Description
Extended Schema Property Support, the goal of this was to stay within the same format of how we currently utilize the schema objects. 

> Note: This PR is still a draft, as I have not performed a real world test. 

Attempts to resolve #533 

If this doesn't work as a solution that the community would like, I was thinking of adding an ``options`` key to the objects and utilizing that to merge any additional keys that X provider may support. So if this is a more desired approach, just let me know and I will add/convert it over.

#### StringSchema
- Added support for the `pattern` property, allowing regular expression validation for string values.
- Added support for the `format` property, supporting OpenAI-compatible formats such as:
  - `date-time`, `time`, `date`, `duration`
  - `email`, `hostname`, `ipv4`, `ipv6`, `uuid`
- These properties are now included in the schema output array, making the schema more expressive and compatible with OpenAI and JSON Schema standards.

```php
<?php
use Prism\Prism\Schema\StringSchema;

// Basic string
$email = new StringSchema('email', 'User email address');

// With pattern and format
$username = new StringSchema(
    name: 'username',
    description: 'Alphanumeric username',
    pattern: '^[a-zA-Z0-9_]{3,16}$',
    format: null
);
```

#### NumberSchema
- Added support for numeric constraints:
  - `multipleOf`: restricts values to multiples of a given number.
  - `maximum` and `exclusiveMaximum`: set upper bounds (inclusive/exclusive).
  - `minimum` and `exclusiveMinimum`: set lower bounds (inclusive/exclusive).
- These constraints are included in the schema output if set.

```php
<?php
use Prism\Prism\Schema\NumberSchema;

// Basic number
$age = new NumberSchema('age', 'User age');

// With restrictions
$score = new NumberSchema(
    name: 'score',
    description: 'Score between 0 and 100',
    minimum: 0,
    maximum: 100,
    multipleOf: 0.5
);
```

#### ArraySchema
- Added support for `minItems` and `maxItems` properties, allowing control over the minimum and maximum number of items in an array.
- These are included in the schema output if set.

```php
<?php
use Prism\Prism\Schema\ArraySchema;
use Prism\Prism\Schema\StringSchema;

$tags = new ArraySchema(
    name: 'tags',
    description: 'User tags',
    items: new StringSchema('tag', 'A tag'),
    minItems: 1,
    maxItems: 10
);
```

### 2. anyOf Schema Composition

- Introduced a new `AnyOfSchema` class to support the `anyOf` keyword, as used in OpenAI and JSON Schema.
- This allows a property to be valid against any one of several provided schemas.
- The class takes an array of schema instances and outputs the correct `anyOf` structure in the schema array.

### 3. Usage Example

You can now construct complex schemas such as:

```php
$itemSchema = new AnyOfSchema([
    $userSchema, // e.g., an ObjectSchema for a user
    $addressSchema // e.g., an ObjectSchema for an address
]);

$parentSchema = new ObjectSchema(
    name: 'root',
    description: 'Root schema',
    properties: [
        $itemSchema // 'item' property supports anyOf
    ],
    requiredFields: ['item'],
    allowAdditionalProperties: false
);
```

### 4. Tests

- Added comprehensive tests for:
  - StringSchema with `pattern` and `format`
  - NumberSchema with all numeric restrictions
  - ArraySchema with `minItems` and `maxItems`
  - AnyOfSchema for OpenAI-style schema composition
- Tests ensure that the schema output matches OpenAI and JSON Schema expectations.

### 5. Compatibility

- All changes are backward compatible with existing schema usage.
- The new features are opt-in and do not affect existing schemas unless the new properties are used.