### PR TITLE
bug(gemini) Set default values for groundingSupport indices

### DIFF
--- a/src/Providers/Gemini/Maps/CitationMapper.php
+++ b/src/Providers/Gemini/Maps/CitationMapper.php
@@ -26,8 +26,8 @@ class CitationMapper
         $groundingChunks = data_get($candidate, 'groundingMetadata.groundingChunks', []);
 
         foreach ($groundingSupports as $groundingSupport) {
-            $startIndex = data_get($groundingSupport, 'segment.startIndex');
-            $endIndex = data_get($groundingSupport, 'segment.endIndex');
+            $startIndex = data_get($groundingSupport, 'segment.startIndex') ?? 0;
+            $endIndex = data_get($groundingSupport, 'segment.endIndex') ?? strlen($originalOutput);
 
             if ($startIndex - 1 > $lastWrittenCharacter) {
                 $messageParts[] = new MessagePartWithCitations(


### PR DESCRIPTION
## Description

Add default values for startIndex and endIndex in CitationMapper as they are not passed if startIndex is zero and endIndex is at the end of the string.

## Breaking Changes

No breaking changes, bugfix only