### PR TITLE
Add tool call support to Mistral structured handler

### DIFF
--- a/src/Providers/Mistral/Handlers/Structured.php
+++ b/src/Providers/Mistral/Handlers/Structured.php
@@ -7,22 +7,32 @@ namespace Prism\Prism\Providers\Mistral\Handlers;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
 use Illuminate\Support\Arr;
+use Prism\Prism\Concerns\CallsTools;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Providers\Mistral\Concerns\ExtractsText;
+use Prism\Prism\Providers\Mistral\Concerns\ExtractsThinking;
 use Prism\Prism\Providers\Mistral\Concerns\MapsFinishReason;
 use Prism\Prism\Providers\Mistral\Concerns\ProcessRateLimits;
 use Prism\Prism\Providers\Mistral\Concerns\ValidatesResponse;
-use Prism\Prism\Providers\Mistral\Maps\FinishReasonMap;
 use Prism\Prism\Providers\Mistral\Maps\MessageMap;
+use Prism\Prism\Providers\Mistral\Maps\ToolChoiceMap;
+use Prism\Prism\Providers\Mistral\Maps\ToolMap;
 use Prism\Prism\Structured\Request;
 use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Structured\ResponseBuilder;
 use Prism\Prism\Structured\Step;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
-use Prism\Prism\ValueObjects\Messages\SystemMessage;
+use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
 use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolCall;
+use Prism\Prism\ValueObjects\ToolResult;
 use Prism\Prism\ValueObjects\Usage;
 
 class Structured
 {
+    use CallsTools;
+    use ExtractsText;
+    use ExtractsThinking;
     use MapsFinishReason;
     use ProcessRateLimits;
     use ValidatesResponse;
@@ -36,18 +46,145 @@ class Structured
 
     public function handle(Request $request): StructuredResponse
     {
-        $request = $this->appendMessageForJsonMode($request);
+        return $this->sendAndRespond($request);
+    }
 
-        $response = $this->sendRequest($request);
+    /**
+     * Send the request and handle the response, looping on tool calls.
+     *
+     * Mistral does not allow response_format and tools in the same request.
+     * When tools are present, we omit response_format and let the model call
+     * tools freely. Once tool calling is done, we re-send without tools but
+     * with response_format to get the final structured JSON response.
+     */
+    protected function sendAndRespond(Request $request): StructuredResponse
+    {
+        $hasTools = count($request->tools()) > 0;
+
+        $response = $this->sendRequest($request, useTools: $hasTools);
 
         $this->validateResponse($response);
 
         $data = $response->json();
 
-        return $this->createResponse($request, $data);
+        if ($this->mapFinishReason($data) === FinishReason::ToolCalls) {
+            return $this->handleToolCalls($data, $request, $response);
+        }
+
+        // If tools were sent but the model chose to stop without calling them,
+        // the response is unconstrained text (no response_format was set).
+        // Discard it and re-send without tools to get proper structured output.
+        if ($hasTools) {
+            return $this->sendStructuredResponse($request);
+        }
+
+        return $this->handleStop($data, $request, $response);
     }
 
-    protected function sendRequest(Request $request): ClientResponse
+    /**
+     * Send a final request without tools but with json_schema response format
+     * to get the structured JSON output.
+     */
+    protected function sendStructuredResponse(Request $request): StructuredResponse
+    {
+        $response = $this->sendRequest($request, useTools: false);
+
+        $this->validateResponse($response);
+
+        return $this->handleStop($response->json(), $request, $response);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function handleToolCalls(array $data, Request $request, ClientResponse $clientResponse): StructuredResponse
+    {
+        $toolCalls = $this->mapToolCalls(data_get($data, 'choices.0.message.tool_calls', []));
+
+        $toolResults = $this->callTools($request->tools(), $toolCalls);
+
+        $this->addStep($data, $request, $clientResponse, toolCalls: $toolCalls, toolResults: $toolResults);
+
+        $request->addMessage(new AssistantMessage(
+            $this->extractText(data_get($data, 'choices.0.message', [])),
+            $toolCalls,
+        ));
+        $request->addMessage(new ToolResultMessage($toolResults));
+        $request->resetToolChoice();
+
+        if ($this->shouldContinue($request)) {
+            return $this->sendAndRespond($request);
+        }
+
+        // Max steps exhausted during tool calling. Send one final request
+        // without tools to get structured output.
+        return $this->sendStructuredResponse($request);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function handleStop(array $data, Request $request, ClientResponse $clientResponse): StructuredResponse
+    {
+        $text = data_get($data, 'choices.0.message.content') ?? '';
+
+        $request->addMessage(new AssistantMessage($text));
+
+        $this->addStep($data, $request, $clientResponse);
+
+        return $this->responseBuilder->toResponse();
+    }
+
+    protected function shouldContinue(Request $request): bool
+    {
+        if ($request->maxSteps() === 0) {
+            return true;
+        }
+
+        return $this->responseBuilder->steps->count() < $request->maxSteps();
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  ToolCall[]  $toolCalls
+     * @param  ToolResult[]  $toolResults
+     */
+    protected function addStep(
+        array $data,
+        Request $request,
+        ClientResponse $clientResponse,
+        array $toolCalls = [],
+        array $toolResults = [],
+    ): void {
+        $this->responseBuilder->addStep(new Step(
+            text: $this->extractText(data_get($data, 'choices.0.message', [])),
+            finishReason: $this->mapFinishReason($data),
+            usage: new Usage(
+                data_get($data, 'usage.prompt_tokens'),
+                data_get($data, 'usage.completion_tokens'),
+            ),
+            meta: new Meta(
+                id: data_get($data, 'id'),
+                model: data_get($data, 'model'),
+                rateLimits: $this->processRateLimits($clientResponse),
+            ),
+            messages: $request->messages(),
+            systemPrompts: $request->systemPrompts(),
+            additionalContent: $this->extractThinking(data_get($data, 'choices.0.message', [])),
+            toolCalls: $toolCalls,
+            toolResults: $toolResults,
+            raw: $data,
+        ));
+    }
+
+    /**
+     * Send the request to Mistral, using either tools or json_schema response format.
+     *
+     * Uses json_schema mode (strict server-side schema enforcement) instead of
+     * json_object mode, so Mistral enforces the output schema directly rather
+     * than relying on a system prompt instruction.
+     */
+    protected function sendRequest(Request $request, bool $useTools = false): ClientResponse
     {
         /** @var ClientResponse $response */
         $response = $this->client->post(
@@ -59,7 +196,16 @@ class Structured
             ], Arr::whereNotNull([
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
-                'response_format' => ['type' => 'json_object'],
+                'tools' => $useTools ? ToolMap::map($request->tools()) : null,
+                'tool_choice' => $useTools ? ToolChoiceMap::map($request->toolChoice()) : null,
+                'response_format' => $useTools ? null : [
+                    'type' => 'json_schema',
+                    'json_schema' => [
+                        'schema' => $request->schema()->toArray(),
+                        'name' => $request->schema()->name(),
+                        'strict' => true,
+                    ],
+                ],
             ]))
         );
 
@@ -67,42 +213,19 @@ class Structured
     }
 
     /**
-     * @param  array<string, mixed>  $data
+     * @param  array<mixed>|null  $toolCalls
+     * @return ToolCall[]
      */
-    protected function createResponse(Request $request, array $data): StructuredResponse
+    protected function mapToolCalls(?array $toolCalls): array
     {
-        $text = data_get($data, 'choices.0.message.content') ?? '';
+        if (! $toolCalls) {
+            return [];
+        }
 
-        $responseMessage = new AssistantMessage($text);
-        $request->addMessage($responseMessage);
-
-        $step = new Step(
-            text: $text,
-            finishReason: FinishReasonMap::map(data_get($data, 'choices.0.finish_reason', '')),
-            usage: new Usage(
-                data_get($data, 'usage.prompt_tokens'),
-                data_get($data, 'usage.completion_tokens'),
-            ),
-            meta: new Meta(
-                id: data_get($data, 'id'),
-                model: data_get($data, 'model'),
-            ),
-            messages: $request->messages(),
-            systemPrompts: $request->systemPrompts(),
-            additionalContent: [],
-            raw: $data
-        );
-
-        $this->responseBuilder->addStep($step);
-
-        return $this->responseBuilder->toResponse();
-    }
-
-    protected function appendMessageForJsonMode(Request $request): Request
-    {
-        return $request->addMessage(new SystemMessage(sprintf(
-            "Respond with JSON that matches the following schema: \n %s",
-            json_encode($request->schema()->toArray(), JSON_PRETTY_PRINT)
-        )));
+        return array_map(fn ($toolCall): ToolCall => new ToolCall(
+            id: data_get($toolCall, 'id'),
+            name: data_get($toolCall, 'function.name'),
+            arguments: data_get($toolCall, 'function.arguments'),
+        ), $toolCalls);
     }
 }


### PR DESCRIPTION
The Mistral structured handler currently has no tool call support and uses the legacy `json_object` response format with a system prompt instruction for schema enforcement. This PR adds full tool calling with a two-phase approach and upgrades to `json_schema` mode.

### The problem

Mistral does not allow `response_format` and `tools` in the same API request. The current structured handler has no tool support at all, it simply appends a system message with the JSON schema and uses `json_object` mode.

### The solution

A two-phase approach:

1. **Phase 1 (tool calling):** When tools are present, send requests with `tools`/`tool_choice` but without `response_format`. Handle tool calls in a loop until the model stops or max steps is exhausted.

2. **Phase 2 (structured output):** Send a final request without tools but with `json_schema` response format for strict server-side schema enforcement.

Edge cases handled:
- **No tools** - sends a single request with `json_schema` response format directly
- **Tools present but model doesn't call them** - the response has no schema enforcement (since `response_format` was omitted), so it's discarded and a follow-up request is sent without tools to get proper structured output
- **Max steps exhausted** - forces a final structured response request

### Changes

- Added `CallsTools`, `ExtractsText`, `ExtractsThinking` traits (matching the Text handler)
- Replaced `appendMessageForJsonMode()` (system prompt hack) with `json_schema` response format (strict server-side enforcement)
- Added `sendAndRespond()` orchestration with `handleToolCalls()` / `handleStop()` / `sendStructuredResponse()`
- Extracted `addStep()` for reuse across tool call and stop flows (matching Text handler pattern)
- Included `rateLimits` in Meta via `processRateLimits()` (was missing)
- Included `additionalContent` from `extractThinking()` (was missing)

### How it follows the existing patterns

This implementation mirrors the Mistral Text handler's structure:
- Same trait usage (`CallsTools`, `ExtractsText`, `ExtractsThinking`, `MapsFinishReason`, `ProcessRateLimits`, `ValidatesResponse`)
- Same `addStep()` reusable method pattern
- Same `shouldContinue()` logic (including `maxSteps === 0` as infinite)
- Same `mapToolCalls()` implementation
- Same message sequencing (`AssistantMessage` → `ToolResultMessage` → `resetToolChoice`)