### PR TITLE
fix(gemini,groq): include finish reason in unhandled finish reason exceptions

### DIFF
--- a/src/Providers/Gemini/Handlers/Structured.php
+++ b/src/Providers/Gemini/Handlers/Structured.php
@@ -68,7 +68,11 @@ class Structured
         return match ($finishReason) {
             FinishReason::ToolCalls => $this->handleToolCalls($data, $request),
             FinishReason::Stop, FinishReason::Length => $this->handleStop($data, $request, $finishReason),
-            default => throw new PrismException('Gemini: unhandled finish reason'),
+            default => throw new PrismException(sprintf(
+                'Gemini: unhandled finish reason "%s" (raw: %s)',
+                $finishReason->value,
+                data_get($data, 'candidates.0.finishReason', 'unknown'),
+            )),
         };
     }
 

--- a/src/Providers/Gemini/Handlers/Text.php
+++ b/src/Providers/Gemini/Handlers/Text.php
@@ -59,7 +59,11 @@ class Text
         return match ($finishReason) {
             FinishReason::ToolCalls => $this->handleToolCalls($data, $request),
             FinishReason::Stop, FinishReason::Length => $this->handleStop($data, $request, $finishReason),
-            default => throw new PrismException('Gemini: unhandled finish reason'),
+            default => throw new PrismException(sprintf(
+                'Gemini: unhandled finish reason "%s" (raw: %s)',
+                $finishReason->value,
+                data_get($data, 'candidates.0.finishReason', 'unknown'),
+            )),
         };
     }
 

--- a/src/Providers/Groq/Handlers/Text.php
+++ b/src/Providers/Groq/Handlers/Text.php
@@ -51,7 +51,11 @@ class Text
         return match ($finishReason) {
             FinishReason::ToolCalls => $this->handleToolCalls($data, $request, $response),
             FinishReason::Stop, FinishReason::Length => $this->handleStop($data, $request, $response, $finishReason),
-            default => throw new PrismException('Groq: unhandled finish reason'),
+            default => throw new PrismException(sprintf(
+                'Groq: unhandled finish reason "%s" (raw: %s)',
+                $finishReason->value,
+                data_get($data, 'choices.0.finish_reason', 'unknown'),
+            )),
         };
     }
 

--- a/tests/Fixtures/gemini/generate-structured-content-filter-1.json
+++ b/tests/Fixtures/gemini/generate-structured-content-filter-1.json
@@ -1,0 +1,27 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": ""
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "SAFETY",
+      "safetyRatings": [
+        {
+          "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+          "probability": "HIGH"
+        }
+      ]
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 10,
+    "candidatesTokenCount": 0,
+    "totalTokenCount": 10
+  },
+  "modelVersion": "gemini-1.5-flash"
+}

--- a/tests/Fixtures/gemini/generate-text-content-filter-1.json
+++ b/tests/Fixtures/gemini/generate-text-content-filter-1.json
@@ -1,0 +1,27 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": ""
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "SAFETY",
+      "safetyRatings": [
+        {
+          "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+          "probability": "HIGH"
+        }
+      ]
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 10,
+    "candidatesTokenCount": 0,
+    "totalTokenCount": 10
+  },
+  "modelVersion": "gemini-1.5-flash"
+}

--- a/tests/Providers/Gemini/GeminiStructuredTest.php
+++ b/tests/Providers/Gemini/GeminiStructuredTest.php
@@ -7,6 +7,7 @@ namespace Tests\Providers\Gemini;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Prism\Prism\Enums\Provider;
+use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\Schema\AnyOfSchema;
 use Prism\Prism\Schema\ArraySchema;
@@ -403,4 +404,22 @@ it('filters out thought parts when includeThoughts is true', function (): void {
     expect($response->steps[0]->additionalContent)->toHaveKey('thoughtSummaries');
     expect($response->steps[0]->additionalContent['thoughtSummaries'])->toBeArray();
     expect($response->steps[0]->additionalContent['thoughtSummaries'][0])->toContain('Let me think about');
+});
+
+it('includes finish reason details in exception for content filter on structured output', function (): void {
+    FixtureResponse::fakeResponseSequence('*', 'gemini/generate-structured-content-filter');
+
+    expect(fn () => Prism::structured()
+        ->using(Provider::Gemini, 'gemini-1.5-flash')
+        ->withSchema(new ObjectSchema(
+            'output',
+            'the output object',
+            [
+                new StringSchema('answer', 'The answer', true),
+            ],
+            requiredFields: ['answer'],
+        ))
+        ->withPrompt('Test prompt')
+        ->asStructured()
+    )->toThrow(PrismException::class, 'Gemini: unhandled finish reason "content-filter" (raw: SAFETY)');
 });

--- a/tests/Providers/Gemini/GeminiTextTest.php
+++ b/tests/Providers/Gemini/GeminiTextTest.php
@@ -482,6 +482,18 @@ describe('provider tools', function (): void {
     });
 });
 
+describe('Error handling for Gemini', function (): void {
+    it('includes finish reason details in exception for content filter', function (): void {
+        FixtureResponse::fakeResponseSequence('*', 'gemini/generate-text-content-filter');
+
+        expect(fn () => Prism::text()
+            ->using(Provider::Gemini, 'gemini-1.5-flash')
+            ->withPrompt('Test prompt')
+            ->asText()
+        )->toThrow(PrismException::class, 'Gemini: unhandled finish reason "content-filter" (raw: SAFETY)');
+    });
+});
+
 describe('Cache support for Gemini', function (): void {
     it('can use a cache object with a text request', function (): void {
         FixtureResponse::fakeResponseSequence('*', 'gemini/use-cache-with-text');


### PR DESCRIPTION
## Description

Enriches the default `PrismException` in `Gemini\Handlers\Text`, `Gemini\Handlers\Structured`, and `Groq\Handlers\Text` to include both the mapped `FinishReason` enum value and the raw provider finish reason string — matching the approach already used in OpenAI handlers (PR #941).

Previously threw a generic `"Gemini: unhandled finish reason"` with no indication of what the actual reason was (e.g. `SAFETY`, `LANGUAGE`, etc.). Now throws `'Gemini: unhandled finish reason "content-filter" (raw: SAFETY)'`.

Relates to #205.

**Changes:**
- `src/Providers/Gemini/Handlers/Text.php` — enriched default exception with sprintf
- `src/Providers/Gemini/Handlers/Structured.php` — same
- `src/Providers/Groq/Handlers/Text.php` — same
- Added Pest tests for Gemini Text and Structured content filter exceptions
- Added test fixtures simulating SAFETY finish reason responses

## Breaking Changes

None — only changes exception message strings in error paths.