### PR TITLE
fix(deepseek): preserve reasoning_content in thinking mode for tool calls

### DIFF
--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -63,10 +63,13 @@ class Text
 
         $this->addStep($data, $request, $toolResults);
 
+        $reasoningContent = data_get($data, 'choices.0.message.reasoning_content');
+        $additionalContent = $reasoningContent ? ['reasoning_content' => $reasoningContent] : [];
+
         $request = $request->addMessage(new AssistantMessage(
             data_get($data, 'choices.0.message.content') ?? '',
             $toolCalls,
-            []
+            $additionalContent
         ));
         $request = $request->addMessage(new ToolResultMessage($toolResults));
         $request->resetToolChoice();
@@ -122,6 +125,8 @@ class Text
      */
     protected function addStep(array $data, Request $request, array $toolResults = []): void
     {
+        $reasoningContent = data_get($data, 'choices.0.message.reasoning_content');
+
         $this->responseBuilder->addStep(new Step(
             text: data_get($data, 'choices.0.message.content') ?? '',
             finishReason: $this->mapFinishReason($data),
@@ -138,7 +143,7 @@ class Text
             ),
             messages: $request->messages(),
             systemPrompts: $request->systemPrompts(),
-            additionalContent: [],
+            additionalContent: $reasoningContent ? ['reasoning_content' => $reasoningContent] : [],
             raw: $data,
         ));
     }

--- a/src/Providers/DeepSeek/Maps/MessageMap.php
+++ b/src/Providers/DeepSeek/Maps/MessageMap.php
@@ -99,10 +99,10 @@ class MessageMap
             ],
         ], $message->toolCalls);
 
-        $this->mappedMessages[] = array_filter([
+        $this->mappedMessages[] = array_filter(array_merge([
             'role' => 'assistant',
             'content' => $message->content,
             'tool_calls' => $toolCalls,
-        ]);
+        ], $message->additionalContent));
     }
 }


### PR DESCRIPTION
## Summary

- **DeepSeek's thinking mode** requires `reasoning_content` to be passed back in all subsequent requests when tool calls are involved. Without this, the API returns `400: The reasoning_content in the thinking mode must be passed back to the API.`
- This PR fixes multi-turn conversations with tools in `deepseek-v4-flash` (and other DeepSeek thinking-mode models).

## Problem

When using DeepSeek models in thinking mode with tools, Prism discards the `reasoning_content` from the API response:

1. **`Text.php` handler** creates `AssistantMessage` with empty `additionalContent` — the `reasoning_content` from the raw response is lost
2. **`MessageMap.php`** does not merge `additionalContent` into the API payload — even if `reasoning_content` was in the message object, it was never sent back to the API

When Prism recursively calls `handle()` for tool-use continuation, the request includes an `AssistantMessage` without `reasoning_content` → DeepSeek returns 400.

## Changes

### `src/Providers/DeepSeek/Handlers/Text.php`
- Extract `reasoning_content` from raw response (`choices.0.message.reasoning_content`)
- Include it in `AssistantMessage.additionalContent` for both:
  - Tool call intermediate steps (line 66-73)
  - Final response step via `addStep()` (line 128)

### `src/Providers/DeepSeek/Maps/MessageMap.php`
- Merge `$message->additionalContent` into the API payload via `array_merge()` (line 102-106)
- This ensures `reasoning_content` is sent back to the API in multi-turn conversations

## Testing

Verified with 4-turn conversation using tools:
- Turn 1 (no history) ✅
- Turn 2 (with history) ✅
- Turn 3 (deeper history) ✅
- Turn 4 (4-turn conversation) ✅

## References

- [DeepSeek Thinking Mode Docs](https://api-docs.deepseek.com/guides/thinking_mode) — *"Between two user messages, if the model performed a tool call, the intermediate assistant's reasoning_content must participate in the context concatenation and must be passed back to the API in all subsequent user interaction turns."*