### PR TITLE
fix(deepseek): extract prompt_cache_hit_tokens and reasoning_tokens from usage

### DIFF
--- a/src/Providers/DeepSeek/Handlers/Stream.php
+++ b/src/Providers/DeepSeek/Handlers/Stream.php
@@ -357,9 +357,15 @@ class Stream
             return null;
         }
 
+        $totalPrompt = (int) data_get($usage, 'prompt_tokens', 0);
+        $cacheHit = (int) data_get($usage, 'prompt_cache_hit_tokens', 0);
+        $reasoning = (int) data_get($usage, 'completion_tokens_details.reasoning_tokens', 0);
+
         return new Usage(
-            promptTokens: (int) data_get($usage, 'prompt_tokens', 0),
-            completionTokens: (int) data_get($usage, 'completion_tokens', 0)
+            promptTokens: max(0, $totalPrompt - $cacheHit),
+            completionTokens: (int) data_get($usage, 'completion_tokens', 0),
+            cacheReadInputTokens: $cacheHit > 0 ? $cacheHit : null,
+            thoughtTokens: $reasoning > 0 ? $reasoning : null,
         );
     }
 

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -122,6 +122,10 @@ class Text
      */
     protected function addStep(array $data, Request $request, array $toolResults = []): void
     {
+        $totalPrompt = (int) (data_get($data, 'usage.prompt_tokens') ?? 0);
+        $cacheHit = (int) (data_get($data, 'usage.prompt_cache_hit_tokens') ?? 0);
+        $reasoning = (int) (data_get($data, 'usage.completion_tokens_details.reasoning_tokens') ?? 0);
+
         $this->responseBuilder->addStep(new Step(
             text: data_get($data, 'choices.0.message.content') ?? '',
             finishReason: $this->mapFinishReason($data),
@@ -129,8 +133,10 @@ class Text
             toolResults: $toolResults,
             providerToolCalls: [],
             usage: new Usage(
-                data_get($data, 'usage.prompt_tokens'),
-                data_get($data, 'usage.completion_tokens'),
+                promptTokens: max(0, $totalPrompt - $cacheHit),
+                completionTokens: (int) (data_get($data, 'usage.completion_tokens') ?? 0),
+                cacheReadInputTokens: $cacheHit > 0 ? $cacheHit : null,
+                thoughtTokens: $reasoning > 0 ? $reasoning : null,
             ),
             meta: new Meta(
                 id: data_get($data, 'id'),

--- a/tests/Providers/DeepSeek/TextTest.php
+++ b/tests/Providers/DeepSeek/TextTest.php
@@ -129,8 +129,13 @@ it('can generate text using multiple tools and multiple steps', function (): voi
     expect($secondStep->messages[1]->toolCalls[1]->name)->toBe('weather');
     expect($secondStep->messages[2])->toBeInstanceOf(ToolResultMessage::class);
 
-    // Assert usage
-    expect($response->usage->promptTokens)->toBe(507);
+    // Assert usage. promptTokens is now the FRESH portion (prompt_tokens minus
+    // prompt_cache_hit_tokens) so cost trackers can apply the cached rate to the
+    // hit portion separately. Aggregated across both steps:
+    //   step 1 fixture: prompt_tokens=220, prompt_cache_hit_tokens=192 → fresh 28, cached 192
+    //   step 2 fixture: prompt_tokens=287, prompt_cache_hit_tokens=256 → fresh 31, cached 256
+    expect($response->usage->promptTokens)->toBe(59);
+    expect($response->usage->cacheReadInputTokens)->toBe(448);
     expect($response->usage->completionTokens)->toBe(76);
 
     // Assert response


### PR DESCRIPTION
## Description

`DeepSeek\Handlers\Text::addStep()` and `Stream::extractUsage()` hardcode `Usage` to only `prompt_tokens` and `completion_tokens` from the API response, silently dropping two DeepSeek-specific fields:

- `usage.prompt_cache_hit_tokens` — cached input portion of the prompt. DeepSeek offers a 98% discount on cache hits (their headline feature) and exposes this as a separate counter.
- `usage.completion_tokens_details.reasoning_tokens` — internal thinking tokens emitted by reasoning models (\`deepseek-reasoner\`, \`deepseek-v4-flash\` thinking mode).

### Impact

- Apps that compute cost from Prism's \`Usage\` charge the full \`prompt_tokens\` at fresh rate — overstating real spend ~3-5x once the prompt cache warms up.
- No signal to derive a \`cacheHitRatio\` for monitoring prompt-prefix stability.
- Reasoning-mode token consumption is invisible to observability tooling (Langfuse, custom dashboards, etc.).

### Changes

- **\`src/Providers/DeepSeek/Handlers/Text.php\`::addStep()** — read both fields from \`usage\`, subtract cache hit from \`prompt_tokens\` to derive the fresh-prompt count, populate \`Usage\` with \`cacheReadInputTokens\` and \`thoughtTokens\`. Mirrors what the Gemini and OpenAI handlers already do for their analogous fields.
- **\`src/Providers/DeepSeek/Handlers/Stream.php\`::extractUsage()** — same fix in the streaming path.
- **\`tests/Providers/DeepSeek/TextTest.php\`** — multi-step tools test updated to assert the new semantics (fresh-only \`promptTokens\` aggregated across steps, plus the previously-invisible \`cacheReadInputTokens\`).

All 28 DeepSeek tests pass. Pint clean.

### Testing

Verified against \`deepseek-v4-flash\` direct API in production:
- Cold cache request → \`cacheReadInputTokens=0\`, \`promptTokens=<full>\`
- Warm cache (same prefix within ~hour TTL) → \`cacheReadInputTokens=<bulk>\`, \`promptTokens=<delta>\`
- Reasoning model → \`thoughtTokens\` populated and matches the DeepSeek platform dashboard

### References

- [DeepSeek pricing — cache hit / miss tokens](https://api-docs.deepseek.com/quick_start/pricing)
- [DeepSeek context caching docs](https://api-docs.deepseek.com/guides/kv_cache)

Non-overlapping with #1020 (which fixes \`reasoning_content\` round-trip) — both fixes are complementary; this one is purely about exposing usage detail that's already in the response.