### PR TITLE
docs: show OpenAI-compatible gateway setup

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -9,6 +9,33 @@
 ]
 ```
 
+### OpenAI-compatible gateways
+
+The OpenAI provider can also point at an OpenAI-compatible gateway by changing
+the configured URL and API key. This is useful for teams that want to keep their
+Prism application code unchanged while centralizing model access, policy
+enforcement, audit logs, traces, and usage/cost reporting in a control plane.
+
+For example, to route Prism calls through Tuning Engines:
+
+```php
+'openai' => [
+    'url' => env('OPENAI_URL', 'https://api.tuningengines.com/v1'),
+    'api_key' => env('TUNING_ENGINES_API_KEY', ''),
+    'organization' => null,
+]
+```
+
+Then use the model alias that your Tuning Engines inference key is allowed to
+access:
+
+```php
+$response = Prism::text()
+    ->using('openai', 'gpt-4o')
+    ->withPrompt('Summarize the release risk for this change.')
+    ->asText();
+```
+
 ## Provider-specific options
 ### Strict Tool Schemas
 


### PR DESCRIPTION
## Summary
- add an OpenAI-compatible gateway example to the OpenAI provider page
- show how to route Prism through Tuning Engines by changing the provider URL and API key
- keep Prism application calls unchanged with ->using('openai', 'gpt-4o')

## Why
We are a Rails and AI infrastructure team using Prism with Tuning Engines. Since Prism already supports configurable provider URLs, this gives Laravel/PHP teams a simple setup path for governed model access, policy checks, traces, audit logs, and usage/cost reporting without changing their Prism application logic. It would mean a lot to us if you are open to including it, and I am happy to revise the copy to fit the docs style.

## Validation
- git diff --check