### PR TITLE
Fix: Nullable Enum Schema

### DIFF
--- a/src/Schema/EnumSchema.php
+++ b/src/Schema/EnumSchema.php
@@ -29,9 +29,23 @@ readonly class EnumSchema implements Schema
     {
         return [
             'description' => $this->description,
-            'enum' => $this->options,
+            'enum' => $this->options(),
             'type' => $this->types(),
         ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function options(): array
+    {
+        $options = $this->options;
+
+        if ($this->nullable) {
+            $options[] = null;
+        }
+
+        return $options;
     }
 
     /**


### PR DESCRIPTION
## Description
Append `null` to the enum array when nullable is true.

When `nullable: true` is set on `EnumSchema`, `null` is added to the `type` field but not to the `enum` array. Without `null` as an explicit enum option, the LLM does not treat it as a valid choice, so instead of returning `null` for unrecognised values, it picks the closest match from the list.

Reference:
https://community.openai.com/t/assign-null-when-information-not-available-in-structured-outputs/907624