### PR TITLE
fix(prism): avoid requiring full laravel framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,16 @@
   "require": {
     "php": "^8.2",
     "ext-fileinfo": "*",
-    "laravel/framework": "^11.0|^12.0|^13.0"
+    "illuminate/broadcasting": "^11.0|^12.0|^13.0",
+    "illuminate/bus": "^11.0|^12.0|^13.0",
+    "illuminate/container": "^11.0|^12.0|^13.0",
+    "illuminate/contracts": "^11.0|^12.0|^13.0",
+    "illuminate/events": "^11.0|^12.0|^13.0",
+    "illuminate/filesystem": "^11.0|^12.0|^13.0",
+    "illuminate/http": "^11.0|^12.0|^13.0",
+    "illuminate/routing": "^11.0|^12.0|^13.0",
+    "illuminate/support": "^11.0|^12.0|^13.0",
+    "illuminate/validation": "^11.0|^12.0|^13.0"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
## Problem

`prism-php/prism` currently requires the full `laravel/framework` package at runtime. Packages that only need Prism through `laravel/ai` then install the complete Laravel framework even when the host application already provides the required Illuminate components.

## Change Summary

- Replace the broad `laravel/framework` runtime requirement with the concrete Illuminate components used by `src/`.
- Keep Laravel 11, 12, and 13 compatibility ranges aligned with the previous framework constraint.
- Leave dev/test dependencies unchanged.

## Validation

- Parsed `composer.json` successfully with PowerShell `ConvertFrom-Json`.
- Ran `git diff --check` successfully.
- Reviewed `src/` Illuminate namespace usage against the listed component packages.

## Risk

Low-to-medium. This changes dependency metadata only, but consumers relying on Prism to implicitly install unrelated Laravel framework classes may need to require those packages directly.