### PR TITLE
feat(openai): support GPT-5.6 structured output

### DIFF
--- a/src/Providers/OpenAI/Support/StructuredModeResolver.php
+++ b/src/Providers/OpenAI/Support/StructuredModeResolver.php
@@ -43,6 +43,10 @@ class StructuredModeResolver
             'gpt-5.1',
             'gpt-5.2',
             'gpt-5.4',
+            'gpt-5.6',
+            'gpt-5.6-sol',
+            'gpt-5.6-terra',
+            'gpt-5.6-luna',
         ]);
     }
 

--- a/tests/Providers/OpenAI/StructuredTest.php
+++ b/tests/Providers/OpenAI/StructuredTest.php
@@ -144,6 +144,48 @@ it('uses meta to define strict mode', function (): void {
     });
 });
 
+it('uses structured mode for GPT-5.6 models', function (string $model): void {
+    FixtureResponse::fakeResponseSequence(
+        'v1/responses',
+        'openai/strict-schema-setting-set'
+    );
+
+    $schema = new ObjectSchema(
+        'output',
+        'the output object',
+        [
+            new StringSchema('weather', 'The weather forecast'),
+            new StringSchema('game_time', 'The tigers game time'),
+            new BooleanSchema('coat_required', 'whether a coat is required'),
+        ],
+        ['weather', 'game_time', 'coat_required']
+    );
+
+    Prism::structured()
+        ->using(Provider::OpenAI, $model)
+        ->withSchema($schema)
+        ->withPrompt('What time is the tigers game today and should I wear a coat?')
+        ->withProviderOptions([
+            'schema' => ['strict' => true],
+        ])
+        ->asStructured();
+
+    Http::assertSent(function (Request $request) use ($model): true {
+        $body = json_decode($request->body(), true);
+
+        expect(data_get($body, 'model'))->toBe($model)
+            ->and(data_get($body, 'text.format.type'))->toBe('json_schema')
+            ->and(data_get($body, 'text.format.strict'))->toBeTrue();
+
+        return true;
+    });
+})->with([
+    'GPT-5.6 alias' => 'gpt-5.6',
+    'GPT-5.6 Sol' => 'gpt-5.6-sol',
+    'GPT-5.6 Terra' => 'gpt-5.6-terra',
+    'GPT-5.6 Luna' => 'gpt-5.6-luna',
+]);
+
 it('throws an exception when there is a refusal', function (): void {
     $this->expectException(PrismException::class);
     $this->expectExceptionMessage('OpenAI Refusal: Could not process your request');


### PR DESCRIPTION
## Description

Adds native structured-output recognition for the official GPT-5.6 API model family:

- `gpt-5.6` (Sol alias)
- `gpt-5.6-sol`
- `gpt-5.6-terra`
- `gpt-5.6-luna`

Without these entries, `StructuredModeResolver` silently falls back to JSON mode, so Prism sends `json_object` instead of `json_schema` and ignores `schema.strict`.

OpenAI documents Structured Outputs support for each GPT-5.6 model:

- https://developers.openai.com/api/docs/models/gpt-5.6-sol
- https://developers.openai.com/api/docs/models/gpt-5.6-terra
- https://developers.openai.com/api/docs/models/gpt-5.6-luna

The regression test covers all four identifiers and asserts Prism sends `json_schema` with `strict: true`.

This is intentionally narrower than #991, which proposes broader prefix matching for versioned model names.

## Breaking Changes

None.

## Test plan

- `vendor/bin/pest tests/Providers/OpenAI/StructuredTest.php`
- `vendor/bin/pest` (1467 passed, 8 skipped)
- `vendor/bin/phpstan analyse --memory-limit=512M`
- Pint and Rector on changed files