### PR TITLE
fix(audio): map webm and mp4 container mime types to audio extensions

### DIFF
--- a/src/Concerns/GeneratesAudioFilename.php
+++ b/src/Concerns/GeneratesAudioFilename.php
@@ -11,13 +11,13 @@ trait GeneratesAudioFilename
         $extension = match ($mimeType) {
             'audio/flac' => 'flac',
             'audio/mpeg', 'audio/mp3' => 'mp3',
-            'audio/mp4' => 'mp4',
+            'audio/mp4', 'video/mp4' => 'mp4',
             'audio/mpga' => 'mpga',
             'audio/m4a', 'audio/x-m4a' => 'm4a',
-            'audio/ogg' => 'ogg',
+            'audio/ogg', 'video/ogg' => 'ogg',
             'audio/opus' => 'opus',
             'audio/wav', 'audio/wave' => 'wav',
-            'audio/webm' => 'webm',
+            'audio/webm', 'video/webm' => 'webm',
             default => 'mp3',
         };
 

--- a/tests/Concerns/GeneratesAudioFilenameTest.php
+++ b/tests/Concerns/GeneratesAudioFilenameTest.php
@@ -30,6 +30,10 @@ it('generates correct filename for mp4 audio', function (): void {
     expect($this->instance->generate('audio/mp4'))->toBe('audio.mp4');
 });
 
+it('generates correct filename for mp4 video container', function (): void {
+    expect($this->instance->generate('video/mp4'))->toBe('audio.mp4');
+});
+
 it('generates correct filename for mpga audio', function (): void {
     expect($this->instance->generate('audio/mpga'))->toBe('audio.mpga');
 });
@@ -46,6 +50,10 @@ it('generates correct filename for ogg audio', function (): void {
     expect($this->instance->generate('audio/ogg'))->toBe('audio.ogg');
 });
 
+it('generates correct filename for ogg video container', function (): void {
+    expect($this->instance->generate('video/ogg'))->toBe('audio.ogg');
+});
+
 it('generates correct filename for opus audio', function (): void {
     expect($this->instance->generate('audio/opus'))->toBe('audio.opus');
 });
@@ -60,6 +68,10 @@ it('generates correct filename for wave audio', function (): void {
 
 it('generates correct filename for webm audio', function (): void {
     expect($this->instance->generate('audio/webm'))->toBe('audio.webm');
+});
+
+it('generates correct filename for webm video container', function (): void {
+    expect($this->instance->generate('video/webm'))->toBe('audio.webm');
 });
 
 it('defaults to mp3 for null mime type', function (): void {


### PR DESCRIPTION
## Description

`finfo` reports browser `MediaRecorder` output as `video/webm`, since WebM is a container format. That isn't in `GeneratesAudioFilename`'s match list, so it falls through to `default => 'mp3'` and the file gets uploaded as `audio.mp3` with WebM bytes inside it. OpenAI fails to parse it with:

```
OpenAI Error [400]: invalid_request_error - Audio file might be corrupted or unsupported
```

Same thing happens with `video/mp4`, which is what Safari's `MediaRecorder` produces.

This adds the container types to the existing match list. The `default => 'mp3'` fallback is unchanged, along with the three tests covering it.

Related to #981. That issue covers the `audio/x-wav` alias, and #1001 handles it at the `Media` layer, which makes sense for aliases that are for sure audio. `video/webm` is different because it's a truthful mime type, and normalizing it in `Media` would break genuine video input such as Gemini's. So this only touches the audio filename helper, and the two changes shouldn't conflict.
