### PR TITLE
Forward provider options in the DeepSeek handlers. Fixes #1031

### DIFF
--- a/src/Providers/DeepSeek/Handlers/Stream.php
+++ b/src/Providers/DeepSeek/Handlers/Stream.php
@@ -436,6 +436,13 @@ class Stream
                 'top_p' => $request->topP(),
                 'tools' => ToolMap::map($request->tools()) ?: null,
                 'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                // DeepSeek-specific knobs, e.g. ['thinking' => ['type' => 'disabled']]
+                // to skip reasoning on models that would otherwise think first.
+                'thinking' => $request->providerOptions('thinking'),
+                'reasoning_effort' => $request->providerOptions('reasoning_effort'),
+                'frequency_penalty' => $request->providerOptions('frequency_penalty'),
+                'presence_penalty' => $request->providerOptions('presence_penalty'),
+                'stop' => $request->providerOptions('stop'),
             ]))
         );
 

--- a/src/Providers/DeepSeek/Handlers/Structured.php
+++ b/src/Providers/DeepSeek/Handlers/Structured.php
@@ -58,6 +58,13 @@ class Structured
                 'temperature' => $request->temperature(),
                 'top_p' => $request->topP(),
                 'response_format' => ['type' => 'json_object'],
+                // DeepSeek-specific knobs, e.g. ['thinking' => ['type' => 'disabled']]
+                // to skip reasoning on models that would otherwise think first.
+                'thinking' => $request->providerOptions('thinking'),
+                'reasoning_effort' => $request->providerOptions('reasoning_effort'),
+                'frequency_penalty' => $request->providerOptions('frequency_penalty'),
+                'presence_penalty' => $request->providerOptions('presence_penalty'),
+                'stop' => $request->providerOptions('stop'),
             ]))
         );
 

--- a/src/Providers/DeepSeek/Handlers/Text.php
+++ b/src/Providers/DeepSeek/Handlers/Text.php
@@ -110,6 +110,13 @@ class Text
                 'top_p' => $request->topP(),
                 'tools' => ToolMap::map($request->tools()) ?: null,
                 'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                // DeepSeek-specific knobs, e.g. ['thinking' => ['type' => 'disabled']]
+                // to skip reasoning on models that would otherwise think first.
+                'thinking' => $request->providerOptions('thinking'),
+                'reasoning_effort' => $request->providerOptions('reasoning_effort'),
+                'frequency_penalty' => $request->providerOptions('frequency_penalty'),
+                'presence_penalty' => $request->providerOptions('presence_penalty'),
+                'stop' => $request->providerOptions('stop'),
             ]))
         );
 

--- a/tests/Providers/DeepSeek/TextTest.php
+++ b/tests/Providers/DeepSeek/TextTest.php
@@ -145,3 +145,38 @@ it('can generate text using multiple tools and multiple steps', function (): voi
     // Assert finish reason
     expect($response->finishReason)->toBe(FinishReason::Stop);
 });
+
+it('forwards deepseek provider options into the request body', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/chat/completions', 'deepseek/generate-text-with-a-prompt');
+
+    Prism::text()
+        ->using(Provider::DeepSeek, 'deepseek-chat')
+        ->withProviderOptions([
+            'thinking' => ['type' => 'disabled'],
+            'reasoning_effort' => 'low',
+        ])
+        ->withPrompt('Who are you?')
+        ->generate();
+
+    Http::assertSent(function (Request $request): true {
+        expect($request->data()['thinking'])->toBe(['type' => 'disabled']);
+        expect($request->data()['reasoning_effort'])->toBe('low');
+
+        return true;
+    });
+});
+
+it('omits deepseek provider options that were not set', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/chat/completions', 'deepseek/generate-text-with-a-prompt');
+
+    Prism::text()
+        ->using(Provider::DeepSeek, 'deepseek-chat')
+        ->withPrompt('Who are you?')
+        ->generate();
+
+    Http::assertSent(function (Request $request): true {
+        expect($request->data())->not->toHaveKeys(['thinking', 'reasoning_effort', 'stop']);
+
+        return true;
+    });
+});


### PR DESCRIPTION
## Description
DeepSeek thinking mode option and others were simply being discarded. This PR adds support for them. 
FIxes #1031