### PR TITLE
fix: convert backed enum tool arguments

### DIFF
--- a/src/Tool.php
+++ b/src/Tool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prism\Prism;
 
 use ArgumentCountError;
+use BackedEnum;
 use Closure;
 use Error;
 use Illuminate\Container\Container;
@@ -22,6 +23,8 @@ use Prism\Prism\Schema\StringSchema;
 use Prism\Prism\Tools\LaravelMcpTool;
 use Prism\Prism\ValueObjects\ToolError;
 use Prism\Prism\ValueObjects\ToolOutput;
+use ReflectionFunction;
+use ReflectionNamedType;
 use Throwable;
 use TypeError;
 
@@ -262,6 +265,7 @@ class Tool
     public function handle(...$args): string|ToolOutput|ToolError
     {
         try {
+            $args = $this->normalizeBackedEnumArguments($args);
             $value = call_user_func($this->fn, ...$args);
 
             if (is_string($value)) {
@@ -279,6 +283,46 @@ class Tool
         } catch (Throwable $e) {
             return $this->handleToolException($e, $args);
         }
+    }
+
+    /**
+     * Convert scalar values returned by a model into backed enum instances
+     * expected by the tool callable.
+     *
+     * @param  array<int|string,mixed>  $args
+     * @return array<int|string,mixed>
+     */
+    protected function normalizeBackedEnumArguments(array $args): array
+    {
+        $reflection = new ReflectionFunction(Closure::fromCallable($this->fn));
+
+        foreach ($reflection->getParameters() as $index => $parameter) {
+            $type = $parameter->getType();
+
+            if (! $type instanceof ReflectionNamedType
+                || ! is_subclass_of($type->getName(), BackedEnum::class)
+                || $parameter->isVariadic()
+            ) {
+                continue;
+            }
+
+            $key = array_key_exists($parameter->getName(), $args)
+                ? $parameter->getName()
+                : $index;
+
+            if (! array_key_exists($key, $args)
+                || (! is_string($args[$key]) && ! is_int($args[$key]))) {
+                continue;
+            }
+
+            try {
+                $args[$key] = $type->getName()::from($args[$key]);
+            } catch (\ValueError $e) {
+                throw new TypeError($e->getMessage(), previous: $e);
+            }
+        }
+
+        return $args;
     }
 
     protected function shouldHandleErrors(): bool

--- a/tests/ToolTest.php
+++ b/tests/ToolTest.php
@@ -9,6 +9,13 @@ use Prism\Prism\Facades\Tool as ToolFacade;
 use Prism\Prism\Schema\BooleanSchema;
 use Prism\Prism\Schema\StringSchema;
 use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\ToolError;
+
+enum ToolTestStatus: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}
 
 it('can return tool details', function (): void {
     $searchTool = (new Tool)
@@ -47,6 +54,32 @@ it('can use a closure', function (): void {
 
     expect($searchTool->handle('What time is the event?'))
         ->toBe('The event is at 3pm eastern');
+});
+
+it('converts backed enum arguments before invoking the tool', function (): void {
+    $tool = (new Tool)
+        ->as('set_status')
+        ->for('Set a status')
+        ->withEnumParameter('status', 'The status', ['active', 'inactive'])
+        ->using(function (ToolTestStatus $status): string {
+            return $status->name;
+        });
+
+    expect($tool->handle('active'))->toBe('Active')
+        ->and($tool->handle(status: 'inactive'))->toBe('Inactive');
+});
+
+it('returns a validation error when a backed enum value is invalid', function (): void {
+    $tool = (new Tool)
+        ->as('set_status')
+        ->for('Set a status')
+        ->withEnumParameter('status', 'The status', ['active', 'inactive'])
+        ->using(fn (ToolTestStatus $status): string => $status->name);
+
+    $result = $tool->handle('unknown');
+
+    expect($result)->toBeInstanceOf(ToolError::class)
+        ->and($result->message)->toContain('Parameter validation error');
 });
 
 it('can be used via facade', function (): void {


### PR DESCRIPTION
## Summary

- Convert string/integer values returned for tool arguments into backed enum instances expected by the callable.
- Support both positional and named arguments.
- Surface invalid enum values as parameter validation errors.
- Add regression coverage for positional, named, and invalid values.

Closes #1016

## Validation

- `git diff --check` passed.
- Local Pest/PHPStan could not be run because this environment has no PHP/Composer installation and no `vendor` directory.
- GitHub Actions should run the repository's full Pest matrix and PHPStan checks.