### PR TITLE
fix(deepseek): don't drop streamed content deltas equal to "0"

### DIFF
--- a/src/Providers/DeepSeek/Handlers/Stream.php
+++ b/src/Providers/DeepSeek/Handlers/Stream.php
@@ -137,7 +137,7 @@ class Stream
             }
 
             $reasoningDelta = $this->extractReasoningDelta($data);
-            if ($reasoningDelta !== '' && $reasoningDelta !== '0') {
+            if ($reasoningDelta !== '') {
                 if ($this->state->shouldEmitThinkingStart()) {
                     $this->state->withReasoningId(EventID::generate())->markThinkingStarted();
 
@@ -167,7 +167,7 @@ class Stream
             }
 
             $content = $this->extractContentDelta($data);
-            if ($content !== '' && $content !== '0') {
+            if ($content !== '') {
                 if ($this->state->shouldEmitTextStart()) {
                     $this->state->markTextStarted();
 

--- a/src/Providers/XAI/Handlers/Stream.php
+++ b/src/Providers/XAI/Handlers/Stream.php
@@ -111,7 +111,7 @@ class Stream
 
             $thinkingContent = $this->extractThinking($data, $request);
 
-            if ($thinkingContent !== '' && $thinkingContent !== '0') {
+            if ($thinkingContent !== '') {
                 if ($this->state->shouldEmitThinkingStart()) {
                     $this->state
                         ->withReasoningId(EventID::generate())

--- a/tests/Fixtures/deepseek/stream-zero-delta-1.sse
+++ b/tests/Fixtures/deepseek/stream-zero-delta-1.sse
@@ -1,0 +1,11 @@
+data: {"id":"chatcmpl-zero-delta","object":"chat.completion.chunk","created":1752800000,"model":"deepseek-chat","system_fingerprint":"fp_repro","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-zero-delta","object":"chat.completion.chunk","created":1752800000,"model":"deepseek-chat","system_fingerprint":"fp_repro","choices":[{"index":0,"delta":{"content":"410"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-zero-delta","object":"chat.completion.chunk","created":1752800000,"model":"deepseek-chat","system_fingerprint":"fp_repro","choices":[{"index":0,"delta":{"content":"0"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-zero-delta","object":"chat.completion.chunk","created":1752800000,"model":"deepseek-chat","system_fingerprint":"fp_repro","choices":[{"index":0,"delta":{"content":"50"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-zero-delta","object":"chat.completion.chunk","created":1752800000,"model":"deepseek-chat","system_fingerprint":"fp_repro","choices":[{"index":0,"delta":{"content":""},"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":8,"total_tokens":15}}
+
+data: [DONE]

--- a/tests/Fixtures/deepseek/stream-zero-reasoning-1.sse
+++ b/tests/Fixtures/deepseek/stream-zero-reasoning-1.sse
@@ -1,0 +1,11 @@
+data: {"id":"chatcmpl-zero-reasoning","object":"chat.completion.chunk","created":1752800000,"model":"deepseek-reasoner","system_fingerprint":"fp_repro","choices":[{"index":0,"delta":{"role":"assistant","content":null,"reasoning_content":""},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-zero-reasoning","object":"chat.completion.chunk","created":1752800000,"model":"deepseek-reasoner","system_fingerprint":"fp_repro","choices":[{"index":0,"delta":{"content":null,"reasoning_content":"result is "},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-zero-reasoning","object":"chat.completion.chunk","created":1752800000,"model":"deepseek-reasoner","system_fingerprint":"fp_repro","choices":[{"index":0,"delta":{"content":null,"reasoning_content":"0"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-zero-reasoning","object":"chat.completion.chunk","created":1752800000,"model":"deepseek-reasoner","system_fingerprint":"fp_repro","choices":[{"index":0,"delta":{"content":null,"reasoning_content":" not found"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-zero-reasoning","object":"chat.completion.chunk","created":1752800000,"model":"deepseek-reasoner","system_fingerprint":"fp_repro","choices":[{"index":0,"delta":{"content":"Done","reasoning_content":null},"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":8,"total_tokens":15}}
+
+data: [DONE]

--- a/tests/Fixtures/xai/stream-with-thinking-zero-responses-1.json
+++ b/tests/Fixtures/xai/stream-with-thinking-zero-responses-1.json
@@ -1,0 +1,11 @@
+data: {"id":"chatcmpl-zero-thinking","object":"chat.completion.chunk","created":1752800000,"model":"grok-4","choices":[{"index":0,"delta":{"reasoning_content":"result is ","role":"assistant"}}],"system_fingerprint":"fp_repro"}
+
+data: {"id":"chatcmpl-zero-thinking","object":"chat.completion.chunk","created":1752800000,"model":"grok-4","choices":[{"index":0,"delta":{"reasoning_content":"0"}}],"system_fingerprint":"fp_repro"}
+
+data: {"id":"chatcmpl-zero-thinking","object":"chat.completion.chunk","created":1752800000,"model":"grok-4","choices":[{"index":0,"delta":{"reasoning_content":" not found"}}],"system_fingerprint":"fp_repro"}
+
+data: {"id":"chatcmpl-zero-thinking","object":"chat.completion.chunk","created":1752800000,"model":"grok-4","choices":[{"index":0,"delta":{"content":"Done","role":"assistant"}}],"system_fingerprint":"fp_repro"}
+
+data: {"id":"chatcmpl-zero-thinking","object":"chat.completion.chunk","created":1752800000,"model":"grok-4","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":8,"total_tokens":15}}
+
+data: [DONE]

--- a/tests/Providers/DeepSeek/StreamTest.php
+++ b/tests/Providers/DeepSeek/StreamTest.php
@@ -214,6 +214,44 @@ it('can handle reasoning/thinking tokens in streaming', function (): void {
         ->and($regularContent)->toContain('32');
 });
 
+it('does not drop content deltas equal to "0" mid stream', function (): void {
+    FixtureResponse::fakeStreamResponses('chat/completions', 'deepseek/stream-zero-delta');
+
+    $response = Prism::text()
+        ->using(Provider::DeepSeek, 'deepseek-chat')
+        ->withPrompt('Who are you?')
+        ->asStream();
+
+    $text = '';
+
+    foreach ($response as $event) {
+        if ($event instanceof TextDeltaEvent) {
+            $text .= $event->delta;
+        }
+    }
+
+    expect($text)->toBe('410050');
+});
+
+it('does not drop reasoning deltas equal to "0" mid stream', function (): void {
+    FixtureResponse::fakeStreamResponses('chat/completions', 'deepseek/stream-zero-reasoning');
+
+    $response = Prism::text()
+        ->using(Provider::DeepSeek, 'deepseek-reasoner')
+        ->withPrompt('What is 410 - 410?')
+        ->asStream();
+
+    $thinkingContent = '';
+
+    foreach ($response as $event) {
+        if ($event instanceof ThinkingEvent) {
+            $thinkingContent .= $event->delta;
+        }
+    }
+
+    expect($thinkingContent)->toBe('result is 0 not found');
+});
+
 it('emits step start and step finish events', function (): void {
     FixtureResponse::fakeStreamResponses('chat/completions', 'deepseek/stream-basic-text');
 

--- a/tests/Providers/XAI/StreamTest.php
+++ b/tests/Providers/XAI/StreamTest.php
@@ -461,6 +461,25 @@ it('does not truncate 0 mid stream', function (): void {
     });
 });
 
+it('does not drop thinking deltas equal to "0" mid stream', function (): void {
+    FixtureResponse::fakeResponseSequence('v1/chat/completions', 'xai/stream-with-thinking-zero-responses');
+
+    $response = Prism::text()
+        ->using('xai', 'grok-4')
+        ->withPrompt('What is 410 - 410?')
+        ->asStream();
+
+    $thinkingContent = '';
+
+    foreach ($response as $event) {
+        if ($event instanceof ThinkingEvent) {
+            $thinkingContent .= $event->delta;
+        }
+    }
+
+    expect($thinkingContent)->toBe('result is 0 not found');
+});
+
 it('emits step start and step finish events', function (): void {
     FixtureResponse::fakeResponseSequence('v1/chat/completions', 'xai/stream-basic-text-responses');
 


### PR DESCRIPTION
## Problem

Numbers ending in `0` are corrupted when streamed through the DeepSeek provider.
The provider emits `3800` as two content deltas — `"380"` then `"0"` — and the
stream handler skips any delta that is exactly the string `"0"`, so the assembled
text is `380`. Same for `2200` → `220`.

A raw API call (and Prism's non-streaming `asText()`) return the value correctly.
The corruption is introduced by Prism's stream parsing, not by the model.

## Root cause

`src/Providers/DeepSeek/Handlers/Stream.php`:

```php
$content = $this->extractContentDelta($data);
if ($content !== '' && $content !== '0') {
    // yield TextDeltaEvent ...
    continue;
}
// a "0" delta falls through and is treated as "no content"
```

A `"0"` delta is legitimate content and must be yielded. The same guard exists
for reasoning deltas in the DeepSeek handler and for thinking deltas in the XAI
handler.

## Changes

- `src/Providers/DeepSeek/Handlers/Stream.php` — yield `"0"` content and reasoning deltas.
- `src/Providers/XAI/Handlers/Stream.php` — yield `"0"` thinking deltas.
- `tests/Providers/DeepSeek/StreamTest.php`, `tests/Providers/XAI/StreamTest.php` — regression tests
  (fail without the fix, pass with it), plus SSE fixtures.

## Notes

- The existing XAI test `does not truncate 0 mid stream` covers the same bug for
  XAI content deltas (already fixed in that path); this PR completes the same fix
  for DeepSeek content + reasoning and XAI thinking deltas.
- The `!== '0'` guard also appears in several `MessageMap` classes (Anthropic,
  OpenAI, Gemini, OpenRouter) — that is outgoing message serialization, a
  different code path, and is left out of this PR.

Fixes #1034
