### PR TITLE
fix(openai): support GPT-5.6 Luna structured mode

### DIFF
--- a/src/Providers/OpenAI/Support/StructuredModeResolver.php
+++ b/src/Providers/OpenAI/Support/StructuredModeResolver.php
@@ -43,6 +43,7 @@ class StructuredModeResolver
             'gpt-5.1',
             'gpt-5.2',
             'gpt-5.4',
+            'gpt-5.6-luna',
         ]);
     }
 

--- a/tests/Providers/OpenAI/StructuredModeResolverTest.php
+++ b/tests/Providers/OpenAI/StructuredModeResolverTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Providers\OpenAI;
+
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Providers\OpenAI\Support\StructuredModeResolver;
+
+it('resolves GPT-5.6 Luna to strict structured mode', function (): void {
+    expect(StructuredModeResolver::forModel('gpt-5.6-luna'))
+        ->toBe(StructuredMode::Structured);
+});


### PR DESCRIPTION
Adds `gpt-5.6-luna` to OpenAI’s strict structured-output resolver.

Focused verification: `php vendor/bin/pest tests/Providers/OpenAI/StructuredModeResolverTest.php` (1 test, 1 assertion).